### PR TITLE
Add option to disable loading models at startup

### DIFF
--- a/mlserver/cli/serve.py
+++ b/mlserver/cli/serve.py
@@ -31,9 +31,11 @@ async def load_settings(folder: str = None) -> Tuple[Settings, List[MLModel]]:
     if folder is not None:
         settings.model_repository_root = folder
 
-    repository = ModelRepository(settings.model_repository_root)
-    available_models = await repository.list()
-    models = [_init_model(model) for model in available_models]
+    models = []
+    if settings.load_models_at_startup:
+        repository = ModelRepository(settings.model_repository_root)
+        available_models = await repository.list()
+        models = [_init_model(model) for model in available_models]
 
     return settings, models
 

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
 
     # Model repository folder
     model_repository_root: str = "."
+    load_models_at_startup: bool = True
 
     # Server metadata
     server_name: str = "mlserver"

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1,9 +1,7 @@
-from mlserver.cli.serve import (
-    load_settings,
-)
-from mlserver.settings import (
-    ModelSettings,
-)
+import os
+
+from mlserver.cli.serve import DEFAULT_SETTINGS_FILENAME, load_settings
+from mlserver.settings import Settings, ModelSettings
 
 
 async def test_load_models(sum_model_settings: ModelSettings, model_folder: str):
@@ -12,3 +10,15 @@ async def test_load_models(sum_model_settings: ModelSettings, model_folder: str)
     assert len(models) == 1
     assert models[0].name == sum_model_settings.name
     assert models[0].version == sum_model_settings.parameters.version  # type: ignore
+
+
+async def test_disable_load_models(settings: Settings, model_folder: str):
+    settings.load_models_at_startup = False
+
+    settings_path = os.path.join(model_folder, DEFAULT_SETTINGS_FILENAME)
+    with open(settings_path, "w") as settings_file:
+        settings_file.write(settings.json())
+
+    _, models = await load_settings(model_folder)
+
+    assert len(models) == 0


### PR DESCRIPTION
## Changelog

On some scenarios (i.e. MMS servers), it makes sense to disable loading models at startup time. This PR adds an option to the server settings to do that. 