### PR TITLE
Add initial support for custom protocols

### DIFF
--- a/mlserver/handlers/__init__.py
+++ b/mlserver/handlers/__init__.py
@@ -1,4 +1,10 @@
 from .dataplane import DataPlane
 from .model_repository import ModelRepositoryHandlers
+from .custom import get_custom_handlers, custom_handler
 
-__all__ = ["DataPlane", "ModelRepositoryHandlers"]
+__all__ = [
+    "DataPlane",
+    "ModelRepositoryHandlers",
+    "get_custom_handlers",
+    "custom_handler",
+]

--- a/mlserver/handlers/custom.py
+++ b/mlserver/handlers/custom.py
@@ -11,6 +11,7 @@ _HandlerMethod = Callable[..., Any]
 
 class CustomHandler(BaseModel):
     rest_path: str
+    rest_method: str = "POST"
 
 
 def custom_handler(rest_path: str):

--- a/mlserver/handlers/custom.py
+++ b/mlserver/handlers/custom.py
@@ -24,9 +24,7 @@ class CustomHandlerRegistry:
         # TODO: Do we need to check for duplicates?
         self._handlers[custom_handler.runtime].append(custom_handler)
 
-    def find_handlers(self, model: MLModel) -> List[CustomHandler]:
-        runtime = model.__class__
-
+    def find_handlers(self, runtime: Type[MLModel]) -> List[CustomHandler]:
         if runtime not in self._handlers:
             return []
 

--- a/mlserver/handlers/custom.py
+++ b/mlserver/handlers/custom.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from ..model import MLModel
 
 _CustomHandlerAttr = "__custom_handler__"
-_Handler = Callable[..., Any]
+_HandlerMethod = Callable[..., Any]
 
 
 class CustomHandler(BaseModel):
@@ -22,7 +22,7 @@ def custom_handler(rest_path: str):
     return _wraps
 
 
-def get_custom_handlers(model: MLModel) -> List[Tuple[CustomHandler, _Handler]]:
+def get_custom_handlers(model: MLModel) -> List[Tuple[CustomHandler, _HandlerMethod]]:
     handlers = []
     members = inspect.getmembers(model)
 

--- a/mlserver/handlers/custom.py
+++ b/mlserver/handlers/custom.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable, Dict, List, Type
+from pydantic import BaseModel
+
+from ..model import MLModel
+
+_Handler = Callable[..., Any]
+_HandlerDict = Dict[Type[MLModel], List["CustomHandler"]]
+
+
+class CustomHandler(BaseModel):
+    rest_path: str
+    runtime: Type[MLModel]
+    handler: _Handler
+
+
+class CustomHandlerRegistry:
+    def __init__(self):
+        self._handlers: _HandlerDict = {}
+
+    def register_handler(self, custom_handler: CustomHandler):
+        if custom_handler.runtime not in self._handlers:
+            self._handlers[custom_handler.runtime] = []
+
+        # TODO: Do we need to check for duplicates?
+        self._handlers[custom_handler.runtime].append(custom_handler)
+
+    def find_handlers(self, model: MLModel) -> List[CustomHandler]:
+        runtime = model.__class__
+
+        if runtime not in self._handlers:
+            return []
+
+        return self._handlers[runtime]

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -1,13 +1,13 @@
 import asyncio
 
-from typing import Coroutine, List, Dict
+from typing import Callable, Coroutine, List, Dict
 from itertools import chain
 
 from .model import MLModel
 from .errors import ModelNotFound
 from .types import RepositoryIndexResponse
 
-ModelRegistryHook = Coroutine[None, MLModel, None]
+ModelRegistryHook = Callable[[MLModel], Coroutine[None, None, None]]
 
 
 class SingleModelRegistry:

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -33,7 +33,9 @@ class RESTServer:
         handlers = get_custom_handlers(model)
         for custom_handler, handler_method in handlers:
             self._app.add_api_route(
-                custom_handler.rest_path, handler_method, methods=["POST"]
+                custom_handler.rest_path,
+                handler_method,
+                methods=[custom_handler.rest_method],
             )
 
     async def delete_custom_handlers(self, model: MLModel):

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -1,7 +1,8 @@
 import uvicorn
 
 from ..settings import Settings
-from ..handlers import DataPlane, ModelRepositoryHandlers
+from ..handlers import DataPlane, ModelRepositoryHandlers, get_custom_handlers
+from ..model import MLModel
 
 from .app import create_app
 
@@ -26,6 +27,16 @@ class RESTServer:
             data_plane=self._data_plane,
             model_repository_handlers=self._model_repository_handlers,
         )
+
+    async def add_custom_handlers(self, model: MLModel):
+        handlers = get_custom_handlers(model)
+        for custom_handler, handler_method in handlers:
+            self._app.add_api_route(
+                custom_handler.rest_path, handler_method, methods=["POST"]
+            )
+
+    async def delete_custom_handlers(self, model: MLModel):
+        pass
 
     async def start(self):
         cfg = uvicorn.Config(

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -4,6 +4,7 @@ from ..settings import Settings
 from ..handlers import DataPlane, ModelRepositoryHandlers, get_custom_handlers
 from ..model import MLModel
 
+from .utils import to_scope
 from .app import create_app
 
 
@@ -36,7 +37,23 @@ class RESTServer:
             )
 
     async def delete_custom_handlers(self, model: MLModel):
-        pass
+        handlers = get_custom_handlers(model)
+        scopes = [to_scope(custom_handler) for custom_handler, _ in handlers]
+
+        # NOTE: Loop in reverse, so that it's quicker to find all the recently
+        # added routes and we can remove routes on-the-fly
+        for i, route in reversed(list(enumerate(self._app.routes))):
+            if len(scopes) == 0:
+                return
+
+            for j, scope in enumerate(scopes):
+                match, _ = route.matches(scope)
+                if match == match.NONE:
+                    continue
+
+                # Remove route and scope
+                self._app.routes.pop(i)
+                scopes.pop(j)
 
     async def start(self):
         cfg = uvicorn.Config(

--- a/mlserver/rest/utils.py
+++ b/mlserver/rest/utils.py
@@ -15,4 +15,8 @@ def to_status_code(flag: bool, error_code: int = status.HTTP_400_BAD_REQUEST) ->
 
 
 def to_scope(custom_handler: CustomHandler) -> Scope:
-    return {"type": "http", "method": "POST", "path": custom_handler.rest_path}
+    return {
+        "type": "http",
+        "method": custom_handler.rest_method,
+        "path": custom_handler.rest_path,
+    }

--- a/mlserver/rest/utils.py
+++ b/mlserver/rest/utils.py
@@ -1,4 +1,7 @@
 from fastapi import status
+from starlette.types import Scope
+
+from ..handlers.custom import CustomHandler
 
 
 def to_status_code(flag: bool, error_code: int = status.HTTP_400_BAD_REQUEST) -> int:
@@ -9,3 +12,7 @@ def to_status_code(flag: bool, error_code: int = status.HTTP_400_BAD_REQUEST) ->
         return status.HTTP_200_OK
 
     return error_code
+
+
+def to_scope(custom_handler: CustomHandler) -> Scope:
+    return {"type": "http", "method": "POST", "path": custom_handler.rest_path}

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -17,7 +17,10 @@ HANDLED_SIGNALS = [signal.SIGINT, signal.SIGTERM]
 class MLServer:
     def __init__(self, settings: Settings):
         self._settings = settings
-        self._model_registry = MultiModelRegistry()
+        self._model_registry = MultiModelRegistry(
+            on_model_load=self.add_custom_handlers,
+            on_model_unload=self.remove_custom_handlers,
+        )
         self._model_repository = ModelRepository(self._settings.model_repository_root)
         self._data_plane = DataPlane(
             settings=self._settings, model_registry=self._model_registry
@@ -29,18 +32,31 @@ class MLServer:
     async def start(self, models: List[MLModel] = []):
         self._add_signal_handlers()
 
-        # TODO: Discover models from ModelRepository
-        # TODO: Add flag to disable autoload of models
-        load_tasks = [self._model_registry.load(model) for model in models]
-        await asyncio.gather(*load_tasks)
-
         self._rest_server = RESTServer(
             self._settings, self._data_plane, self._model_repository_handlers
         )
         self._grpc_server = GRPCServer(
             self._settings, self._data_plane, self._model_repository_handlers
         )
+
+        # TODO: Discover models from ModelRepository
+        # TODO: Add flag to disable autoload of models
+        load_tasks = [self._model_registry.load(model) for model in models]
+        await asyncio.gather(*load_tasks)
+
         await asyncio.gather(self._rest_server.start(), self._grpc_server.start())
+
+    async def add_custom_handlers(self, model: MLModel):
+        await self._rest_server.add_custom_handlers(model)
+
+        # TODO: Add support for custom gRPC endpoints
+        # self._grpc_server.add_custom_handlers(handlers)
+
+    async def remove_custom_handlers(self, model: MLModel):
+        await self._rest_server.delete_custom_handlers(model)
+
+        # TODO: Add support for custom gRPC endpoints
+        # self._grpc_server.delete_custom_handlers(handlers)
 
     def _add_signal_handlers(self):
         loop = asyncio.get_event_loop()

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ datamodel-code-generator==0.11.8
 # Testing
 pytest==6.2.2
 pytest-asyncio==0.15.1
+pytest-mock==3.6.1
 tox==3.23.1
 
 # Linting and formatting

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,12 @@
 from mlserver import types, MLModel
+from mlserver.handlers.custom import custom_handler
 
 
 class SumModel(MLModel):
+    @custom_handler(rest_path="/my-custom-endpoint")
+    def my_payload(self, payload: dict) -> int:
+        return sum(payload)
+
     async def predict(self, payload: types.InferenceRequest) -> types.InferenceResponse:
         total = 0
         for inp in payload.inputs:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,7 +4,7 @@ from mlserver.handlers.custom import custom_handler
 
 class SumModel(MLModel):
     @custom_handler(rest_path="/my-custom-endpoint")
-    def my_payload(self, payload: dict) -> int:
+    def my_payload(self, payload: list) -> int:
         return sum(payload)
 
     async def predict(self, payload: types.InferenceRequest) -> types.InferenceResponse:

--- a/tests/handlers/conftest.py
+++ b/tests/handlers/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from mlserver.model import MLModel
+from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
+
+
+@pytest.fixture
+def custom_handler_registry() -> CustomHandlerRegistry:
+    return CustomHandlerRegistry()
+
+
+@pytest.fixture
+def custom_handler(sum_model: MLModel) -> CustomHandler:
+    def my_custom_path(payload: dict) -> dict:
+        return {"foo": "bar"}
+
+    return CustomHandler(
+        rest_path="/my-custom-path", runtime=sum_model.__class__, handler=my_custom_path
+    )

--- a/tests/handlers/conftest.py
+++ b/tests/handlers/conftest.py
@@ -1,22 +1,8 @@
 import pytest
 
-from mlserver.model import MLModel
-from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
+from mlserver.handlers.custom import CustomHandler
 
 
 @pytest.fixture
-def custom_handler(sum_model: MLModel) -> CustomHandler:
-    def my_custom_path(payload: dict) -> dict:
-        return {"foo": "bar"}
-
-    return CustomHandler(
-        rest_path="/my-custom-path", runtime=sum_model.__class__, handler=my_custom_path
-    )
-
-
-@pytest.fixture
-def custom_handler_registry(custom_handler: CustomHandler) -> CustomHandlerRegistry:
-    reg = CustomHandlerRegistry()
-    reg.register_handler(custom_handler)
-
-    return reg
+def custom_handler() -> CustomHandler:
+    return CustomHandler(rest_path="/my-custom-endpoint")

--- a/tests/handlers/conftest.py
+++ b/tests/handlers/conftest.py
@@ -5,11 +5,6 @@ from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
 
 
 @pytest.fixture
-def custom_handler_registry() -> CustomHandlerRegistry:
-    return CustomHandlerRegistry()
-
-
-@pytest.fixture
 def custom_handler(sum_model: MLModel) -> CustomHandler:
     def my_custom_path(payload: dict) -> dict:
         return {"foo": "bar"}
@@ -17,3 +12,11 @@ def custom_handler(sum_model: MLModel) -> CustomHandler:
     return CustomHandler(
         rest_path="/my-custom-path", runtime=sum_model.__class__, handler=my_custom_path
     )
+
+
+@pytest.fixture
+def custom_handler_registry(custom_handler: CustomHandler) -> CustomHandlerRegistry:
+    reg = CustomHandlerRegistry()
+    reg.register_handler(custom_handler)
+
+    return reg

--- a/tests/handlers/test_custom.py
+++ b/tests/handlers/test_custom.py
@@ -1,0 +1,15 @@
+from mlserver.model import MLModel
+from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
+
+
+def test_register_custom_handler(
+    custom_handler_registry: CustomHandlerRegistry,
+    custom_handler: CustomHandler,
+    sum_model: MLModel,
+):
+    custom_handler_registry.register_handler(custom_handler)
+
+    assert len(custom_handler_registry._handlers) == 1
+    assert sum_model.__class__ in custom_handler_registry._handlers
+    assert len(custom_handler_registry._handlers[sum_model.__class__]) == 1
+    assert custom_handler_registry._handlers[sum_model.__class__][0] == custom_handler

--- a/tests/handlers/test_custom.py
+++ b/tests/handlers/test_custom.py
@@ -1,42 +1,19 @@
-from mlserver.model import MLModel
-from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
+from mlserver.handlers.custom import (
+    _CustomHandlerAttr,
+    CustomHandler,
+    get_custom_handlers,
+)
+
+from ..fixtures import SumModel
 
 
-def test_register_handler(
-    custom_handler_registry: CustomHandlerRegistry,
-    custom_handler: CustomHandler,
-    sum_model: MLModel,
-):
-    new_custom_handler = CustomHandler(
-        rest_path="/new-path",
-        runtime=sum_model.__class__,
-        handler=custom_handler.handler,
-    )
-
-    custom_handler_registry.register_handler(new_custom_handler)
-
-    assert len(custom_handler_registry._handlers) == 1
-    assert sum_model.__class__ in custom_handler_registry._handlers
-    assert len(custom_handler_registry._handlers[sum_model.__class__]) == 2
-    assert custom_handler_registry._handlers[sum_model.__class__] == [
-        custom_handler,
-        new_custom_handler,
-    ]
+def test_custom_handler(sum_model: SumModel, custom_handler: CustomHandler):
+    assert hasattr(sum_model.my_payload, _CustomHandlerAttr)
+    assert getattr(sum_model.my_payload, _CustomHandlerAttr) == custom_handler
 
 
-def test_find_handlers(
-    custom_handler_registry: CustomHandlerRegistry,
-    custom_handler: CustomHandler,
-    sum_model: MLModel,
-):
-    handlers = custom_handler_registry.find_handlers(sum_model.__class__)
+def test_get_custom_handlers(sum_model: SumModel, custom_handler: CustomHandler):
+    handlers = get_custom_handlers(sum_model)
 
-    assert handlers == [custom_handler]
-
-
-def test_find_handlers_empty(
-    custom_handler_registry: CustomHandlerRegistry,
-):
-    handlers = custom_handler_registry.find_handlers(MLModel)
-
-    assert len(handlers) == 0
+    assert len(handlers) == 1
+    assert handlers[0] == (custom_handler, sum_model.my_payload)

--- a/tests/handlers/test_custom.py
+++ b/tests/handlers/test_custom.py
@@ -2,14 +2,41 @@ from mlserver.model import MLModel
 from mlserver.handlers.custom import CustomHandlerRegistry, CustomHandler
 
 
-def test_register_custom_handler(
+def test_register_handler(
     custom_handler_registry: CustomHandlerRegistry,
     custom_handler: CustomHandler,
     sum_model: MLModel,
 ):
-    custom_handler_registry.register_handler(custom_handler)
+    new_custom_handler = CustomHandler(
+        rest_path="/new-path",
+        runtime=sum_model.__class__,
+        handler=custom_handler.handler,
+    )
+
+    custom_handler_registry.register_handler(new_custom_handler)
 
     assert len(custom_handler_registry._handlers) == 1
     assert sum_model.__class__ in custom_handler_registry._handlers
-    assert len(custom_handler_registry._handlers[sum_model.__class__]) == 1
-    assert custom_handler_registry._handlers[sum_model.__class__][0] == custom_handler
+    assert len(custom_handler_registry._handlers[sum_model.__class__]) == 2
+    assert custom_handler_registry._handlers[sum_model.__class__] == [
+        custom_handler,
+        new_custom_handler,
+    ]
+
+
+def test_find_handlers(
+    custom_handler_registry: CustomHandlerRegistry,
+    custom_handler: CustomHandler,
+    sum_model: MLModel,
+):
+    handlers = custom_handler_registry.find_handlers(sum_model.__class__)
+
+    assert handlers == [custom_handler]
+
+
+def test_find_handlers_empty(
+    custom_handler_registry: CustomHandlerRegistry,
+):
+    handlers = custom_handler_registry.find_handlers(MLModel)
+
+    assert len(handlers) == 0

--- a/tests/rest/conftest.py
+++ b/tests/rest/conftest.py
@@ -2,23 +2,35 @@ import pytest
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
 from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.rest import RESTServer
 from mlserver import Settings
 
+from ..fixtures import SumModel
+
 
 @pytest.fixture
-def rest_app(
+async def rest_server(
     settings: Settings,
     data_plane: DataPlane,
     model_repository_handlers: ModelRepositoryHandlers,
-) -> FastAPI:
+    sum_model: SumModel,
+) -> RESTServer:
     server = RESTServer(
         settings,
         data_plane=data_plane,
         model_repository_handlers=model_repository_handlers,
     )
-    return server._app
+
+    await server.add_custom_handlers(sum_model)
+
+    return server
+
+
+@pytest.fixture
+def rest_app(rest_server: RESTServer) -> FastAPI:
+    return rest_server._app
 
 
 @pytest.fixture

--- a/tests/rest/test_custom.py
+++ b/tests/rest/test_custom.py
@@ -1,0 +1,8 @@
+from mlserver.types import InferenceRequest
+
+
+def test_custom_handler(rest_client, inference_request: InferenceRequest):
+    response = rest_client.post("/my-custom-endpoint", json=[1, 2, 3, 4])
+
+    assert response.status_code == 200
+    assert response.json() == 10

--- a/tests/rest/test_server.py
+++ b/tests/rest/test_server.py
@@ -1,0 +1,15 @@
+from mlserver.rest.server import RESTServer
+
+from ..fixtures import SumModel
+
+
+def test_add_custom_handlers(rest_server: RESTServer, sum_model: SumModel):
+    scope = {"type": "http", "method": "POST", "path": "/my-custom-endpoint"}
+    found_route = None
+    for route in rest_server._app.routes:
+        match, _ = route.matches(scope)
+        if match == match.FULL:
+            found_route = route
+            break
+
+    assert found_route is not None

--- a/tests/rest/test_server.py
+++ b/tests/rest/test_server.py
@@ -1,10 +1,11 @@
 from mlserver.rest.server import RESTServer
+from mlserver.rest.utils import to_scope
 
 from ..fixtures import SumModel
 
 
 def test_add_custom_handlers(rest_server: RESTServer, sum_model: SumModel):
-    scope = {"type": "http", "method": "POST", "path": "/my-custom-endpoint"}
+    scope = to_scope(sum_model.my_payload.__custom_handler__)
     found_route = None
     for route in rest_server._app.routes:
         match, _ = route.matches(scope)
@@ -13,3 +14,12 @@ def test_add_custom_handlers(rest_server: RESTServer, sum_model: SumModel):
             break
 
     assert found_route is not None
+
+
+async def test_delete_custom_handlers(rest_server: RESTServer, sum_model: SumModel):
+    await rest_server.delete_custom_handlers(sum_model)
+
+    scope = to_scope(sum_model.my_payload.__custom_handler__)
+    for route in rest_server._app.routes:
+        match, _ = route.matches(scope)
+        assert match == match.NONE

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -29,3 +29,22 @@ async def test_get_model_not_found(model_registry, name, version):
 async def test_get_model(model_registry, sum_model, name, version):
     found_model = await model_registry.get_model(name, version)
     assert found_model == sum_model
+
+
+async def test_model_hooks(model_registry, sum_model, mocker):
+    sum_model._settings.name = "sum-model-2"
+
+    async def _async_val():
+        return None
+
+    model_registry._on_model_load = mocker.stub("_on_model_load")
+    model_registry._on_model_load.return_value = _async_val()
+
+    model_registry._on_model_unload = mocker.stub("_on_model_unload")
+    model_registry._on_model_unload.return_value = _async_val()
+
+    await model_registry.load(sum_model)
+    model_registry._on_model_load.assert_called_once_with(sum_model)
+
+    await model_registry.unload(sum_model.name)
+    model_registry._on_model_unload.assert_called_once_with(sum_model)


### PR DESCRIPTION
Fixes #167 

## Changelog
- Added `on_model_loaded` and `on_model_unloaded` hooks to model registry
- Added `@custom_handler` decorator to add custom handlers, mapped to a REST endpoint
- Add / remove REST routes dynamically when models get loaded / unloaded

## Notes
There are a couple things which aren't tackled by this PR. These are left for future issues:

- Support for gRPC custom endpoints (#214).
- Support for "MMS custom routes" (#215). At the moment we just load the route as-is, without namespacing it with the model name. This means that loading multiple models could lead to clashes.