### PR TITLE
Add support for existing MLflow protocol

### DIFF
--- a/docs/examples/mlflow/README.ipynb
+++ b/docs/examples/mlflow/README.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "subsequent-microwave",
+   "id": "daily-denial",
    "metadata": {},
    "source": [
     "# Serving MLflow models\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "gross-poetry",
+   "id": "ongoing-footwear",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "placed-garbage",
+   "id": "oriental-reservoir",
    "metadata": {},
    "source": [
     "## Training\n",
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "endangered-joshua",
+   "id": "frozen-guess",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "legal-hobby",
+   "id": "pediatric-deficit",
    "metadata": {},
    "outputs": [
     {
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "federal-transsexual",
+   "id": "automated-stable",
    "metadata": {},
    "source": [
     "The training script will also serialise our trained model, leveraging the [MLflow Model format](https://www.mlflow.org/docs/latest/models.html).\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "spatial-democracy",
+   "id": "proprietary-talent",
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "incomplete-plaintiff",
+   "id": "unlike-transport",
    "metadata": {},
    "outputs": [
     {
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "limited-absorption",
+   "id": "reported-salem",
    "metadata": {},
    "source": [
     "## Serving\n",
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "exclusive-colony",
+   "id": "static-universe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "viral-cathedral",
+   "id": "aggressive-mission",
    "metadata": {},
    "source": [
     "Now that we have our config in-place, we can start the server by running `mlserver start .`. This needs to either be ran from the same directory where our config files are or pointing to the folder where they are.\n",
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "neural-status",
+   "id": "rapid-commons",
    "metadata": {},
    "source": [
     "### Send test inference request\n",
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "ancient-rugby",
+   "id": "radio-elements",
    "metadata": {},
    "outputs": [
     {
@@ -421,19 +421,75 @@
   },
   {
    "cell_type": "markdown",
-   "id": "european-increase",
+   "id": "attractive-township",
    "metadata": {},
    "source": [
     "As we can see in the output above, the predicted quality score for our input wine was `5.57`."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "diagnostic-participant",
+   "cell_type": "markdown",
+   "id": "impossible-shelter",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### MLflow Scoring Protocol\n",
+    "\n",
+    "MLflow currently ships with an [scoring server with its own protocol](https://www.mlflow.org/docs/latest/models.html#deploy-mlflow-models).\n",
+    "In order to provide a drop-in replacement, the MLflow runtime in MLServer also exposes a custom endpoint which matches the signature of the MLflow's `/invocations` endpoint.\n",
+    "\n",
+    "As an example, we can try to send a request using MLflow's protocol to our running MLServer instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "heavy-filling",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[5.576883967129615]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "\n",
+    "inference_request = {\n",
+    "    \"columns\": [\n",
+    "        \"alcohol\",\n",
+    "        \"chlorides\",\n",
+    "        \"citric acid\",\n",
+    "        \"density\",\n",
+    "        \"fixed acidity\",\n",
+    "        \"free sulfur dioxide\",\n",
+    "        \"pH\",\n",
+    "        \"residual sugar\",\n",
+    "        \"sulphates\",\n",
+    "        \"total sulfur dioxide\",\n",
+    "        \"volatile acidity\",\n",
+    "    ],\n",
+    "    \"data\": [[7.4,0.7,0,1.9,0.076,11,34,0.9978,3.51,0.56,9.4]],\n",
+    "}\n",
+    "\n",
+    "endpoint = \"http://localhost:8080/invocations\"\n",
+    "response = requests.post(endpoint, json=inference_request)\n",
+    "\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rapid-marking",
+   "metadata": {},
+   "source": [
+    "As we can see above, the predicted quality for our input is `5.57`, matching the prediction we obtained above."
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/mlflow/README.ipynb
+++ b/docs/examples/mlflow/README.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "daily-denial",
+   "id": "cooked-value",
    "metadata": {},
    "source": [
     "# Serving MLflow models\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "ongoing-footwear",
+   "id": "duplicate-arnold",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "oriental-reservoir",
+   "id": "structured-arabic",
    "metadata": {},
    "source": [
     "## Training\n",
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "frozen-guess",
+   "id": "accepted-sharing",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "pediatric-deficit",
+   "id": "distinct-senator",
    "metadata": {},
    "outputs": [
     {
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "automated-stable",
+   "id": "black-retreat",
    "metadata": {},
    "source": [
     "The training script will also serialise our trained model, leveraging the [MLflow Model format](https://www.mlflow.org/docs/latest/models.html).\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "proprietary-talent",
+   "id": "honey-necessity",
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "unlike-transport",
+   "id": "retained-sweet",
    "metadata": {},
    "outputs": [
     {
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "reported-salem",
+   "id": "bizarre-parameter",
    "metadata": {},
    "source": [
     "## Serving\n",
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "static-universe",
+   "id": "yellow-newsletter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aggressive-mission",
+   "id": "direct-romantic",
    "metadata": {},
    "source": [
     "Now that we have our config in-place, we can start the server by running `mlserver start .`. This needs to either be ran from the same directory where our config files are or pointing to the folder where they are.\n",
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rapid-commons",
+   "id": "formed-there",
    "metadata": {},
    "source": [
     "### Send test inference request\n",
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "radio-elements",
+   "id": "concrete-setting",
    "metadata": {},
    "outputs": [
     {
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "attractive-township",
+   "id": "paperback-penny",
    "metadata": {},
    "source": [
     "As we can see in the output above, the predicted quality score for our input wine was `5.57`."
@@ -429,7 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "impossible-shelter",
+   "id": "eight-premises",
    "metadata": {},
    "source": [
     "### MLflow Scoring Protocol\n",
@@ -437,13 +437,14 @@
     "MLflow currently ships with an [scoring server with its own protocol](https://www.mlflow.org/docs/latest/models.html#deploy-mlflow-models).\n",
     "In order to provide a drop-in replacement, the MLflow runtime in MLServer also exposes a custom endpoint which matches the signature of the MLflow's `/invocations` endpoint.\n",
     "\n",
-    "As an example, we can try to send a request using MLflow's protocol to our running MLServer instance."
+    "As an example, we can try to send the same request that sent previously, but using MLflow's protocol.\n",
+    "Note that, in both cases, the request will be handled by the same MLServer instance."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "heavy-filling",
+   "id": "portuguese-likelihood",
    "metadata": {},
    "outputs": [
     {
@@ -485,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rapid-marking",
+   "id": "applied-tunisia",
    "metadata": {},
    "source": [
     "As we can see above, the predicted quality for our input is `5.57`, matching the prediction we obtained above."

--- a/docs/examples/mlflow/README.md
+++ b/docs/examples/mlflow/README.md
@@ -303,7 +303,8 @@ As we can see in the output above, the predicted quality score for our input win
 MLflow currently ships with an [scoring server with its own protocol](https://www.mlflow.org/docs/latest/models.html#deploy-mlflow-models).
 In order to provide a drop-in replacement, the MLflow runtime in MLServer also exposes a custom endpoint which matches the signature of the MLflow's `/invocations` endpoint.
 
-As an example, we can try to send a request using MLflow's protocol to our running MLServer instance.
+As an example, we can try to send the same request that sent previously, but using MLflow's protocol.
+Note that, in both cases, the request will be handled by the same MLServer instance.
 
 
 ```python

--- a/docs/examples/mlflow/README.md
+++ b/docs/examples/mlflow/README.md
@@ -298,7 +298,38 @@ response.json()
 
 As we can see in the output above, the predicted quality score for our input wine was `5.57`.
 
+### MLflow Scoring Protocol
+
+MLflow currently ships with an [scoring server with its own protocol](https://www.mlflow.org/docs/latest/models.html#deploy-mlflow-models).
+In order to provide a drop-in replacement, the MLflow runtime in MLServer also exposes a custom endpoint which matches the signature of the MLflow's `/invocations` endpoint.
+
+As an example, we can try to send a request using MLflow's protocol to our running MLServer instance.
+
 
 ```python
+import requests
 
+inference_request = {
+    "columns": [
+        "alcohol",
+        "chlorides",
+        "citric acid",
+        "density",
+        "fixed acidity",
+        "free sulfur dioxide",
+        "pH",
+        "residual sugar",
+        "sulphates",
+        "total sulfur dioxide",
+        "volatile acidity",
+    ],
+    "data": [[7.4,0.7,0,1.9,0.076,11,34,0.9978,3.51,0.56,9.4]],
+}
+
+endpoint = "http://localhost:8080/invocations"
+response = requests.post(endpoint, json=inference_request)
+
+response.json()
 ```
+
+As we can see above, the predicted quality for our input is `5.57`, matching the prediction we obtained above.

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -42,7 +42,6 @@ class MLflowRuntime(MLModel):
 
             https://github.com/mlflow/mlflow/blob/master/mlflow/pyfunc/scoring_server/__init__.py
         """
-        # TODO: What happens if content-type is not present?
         content_type = request.headers.get("content-type", None)
         data = await request.body()
         data = data.decode("utf-8")

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -2,6 +2,8 @@ import mlflow
 
 from io import StringIO
 from fastapi import Request, Response
+
+from mlflow.exceptions import MlflowException
 from mlflow.pyfunc.scoring_server import (
     CONTENT_TYPES,
     CONTENT_TYPE_CSV,

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -45,28 +45,28 @@ class MLflowRuntime(MLModel):
             https://github.com/mlflow/mlflow/blob/master/mlflow/pyfunc/scoring_server/__init__.py
         """
         content_type = request.headers.get("content-type", None)
-        data = await request.body()
-        data = data.decode("utf-8")
+        raw_data = await request.body()
+        as_str = raw_data.decode("utf-8")
 
         if content_type == CONTENT_TYPE_CSV:
-            csv_input = StringIO(data)
+            csv_input = StringIO(as_str)
             data = parse_csv_input(csv_input=csv_input)
         elif content_type == CONTENT_TYPE_JSON:
-            data = infer_and_parse_json_input(data, self._input_schema)
+            data = infer_and_parse_json_input(as_str, self._input_schema)
         elif content_type == CONTENT_TYPE_JSON_SPLIT_ORIENTED:
             data = parse_json_input(
-                json_input=StringIO(data),
+                json_input=StringIO(as_str),
                 orient="split",
                 schema=self._input_schema,
             )
         elif content_type == CONTENT_TYPE_JSON_RECORDS_ORIENTED:
             data = parse_json_input(
-                json_input=StringIO(data),
+                json_input=StringIO(as_str),
                 orient="records",
                 schema=self._input_schema,
             )
         elif content_type == CONTENT_TYPE_JSON_SPLIT_NUMPY:
-            data = parse_split_oriented_json_input_to_numpy(data)
+            data = parse_split_oriented_json_input_to_numpy(as_str)
         else:
             content_type_error_message = (
                 "This predictor only supports the following content types, "

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -1,9 +1,25 @@
 import mlflow
 
+from fastapi import Request
+from mlflow.pyfunc.scoring_server import (
+    CONTENT_TYPES,
+    CONTENT_TYPE_CSV,
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+    CONTENT_TYPE_JSON_RECORDS_ORIENTED,
+    CONTENT_TYPE_JSON_SPLIT_NUMPY,
+    parse_csv_input,
+    infer_and_parse_json_input,
+    parse_json_input,
+    parse_split_oriented_json_input_to_numpy,
+)
+
 from mlserver.types import InferenceRequest, InferenceResponse
 from mlserver.model import MLModel
 from mlserver.utils import get_model_uri
 from mlserver.codecs import get_decoded_or_raw
+from mlserver.handlers import custom_handler
+from mlserver.errors import InferenceError
 
 from .encoding import to_outputs
 
@@ -13,6 +29,51 @@ class MLflowRuntime(MLModel):
     Implementation of the MLModel interface to load and serve `scikit-learn`
     models persisted with `joblib`.
     """
+
+    @custom_handler(rest_path="/invocations")
+    async def invocations(self, request: Request) -> dict:
+        """
+        This custom handler is meant to mimic the behaviour of the existing
+        scoring server in MLflow.
+        For details about its implementation, please consult the original
+        implementation in the MLflow repository:
+
+            https://github.com/mlflow/mlflow/blob/master/mlflow/pyfunc/scoring_server/__init__.py
+        """
+        # TODO: What happens if content-type is not present?
+        content_type = request.headers.get("content-type", None)
+        data = await request.body()
+        data = data.decode("utf-8")
+
+        if content_type == CONTENT_TYPE_CSV:
+            csv_input = StringIO(data)
+            data = parse_csv_input(csv_input=csv_input)
+        elif content_type == CONTENT_TYPE_JSON:
+            data = infer_and_parse_json_input(data, input_schema)
+        elif content_type == CONTENT_TYPE_JSON_SPLIT_ORIENTED:
+            data = parse_json_input(
+                json_input=StringIO(data),
+                orient="split",
+                schema=input_schema,
+            )
+        elif content_type == CONTENT_TYPE_JSON_RECORDS_ORIENTED:
+            data = parse_json_input(
+                json_input=StringIO(data),
+                orient="records",
+                schema=input_schema,
+            )
+        elif content_type == CONTENT_TYPE_JSON_SPLIT_NUMPY:
+            data = parse_split_oriented_json_input_to_numpy(data)
+        else:
+            content_type_error_message = (
+                "This predictor only supports the following content types, "
+                f"{CONTENT_TYPES}. Got '{content_type}'."
+            )
+            raise InferenceError(content_type_error_message)
+
+        breakpoint()
+
+        return {}
 
     async def load(self) -> bool:
         # TODO: Log info message

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -34,8 +34,9 @@ class MLflowRuntime(MLModel):
     models persisted with `joblib`.
     """
 
+    # TODO: Decouple from REST
     @custom_handler(rest_path="/invocations")
-    async def invocations(self, request: Request) -> dict:
+    async def invocations(self, request: Request) -> Response:
         """
         This custom handler is meant to mimic the behaviour of the existing
         scoring server in MLflow.

--- a/runtimes/mlflow/tests/rest/conftest.py
+++ b/runtimes/mlflow/tests/rest/conftest.py
@@ -1,0 +1,71 @@
+import pytest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mlserver.handlers import DataPlane, ModelRepositoryHandlers
+from mlserver.registry import MultiModelRegistry
+from mlserver.rest import RESTServer
+from mlserver.repository import ModelRepository
+from mlserver import Settings
+
+from mlserver_mlflow import MLflowRuntime
+
+
+@pytest.fixture
+def model_repository(model_uri: str) -> ModelRepository:
+    return ModelRepository(model_uri)
+
+
+@pytest.fixture
+async def model_registry(runtime: MLflowRuntime) -> MultiModelRegistry:
+    model_registry = MultiModelRegistry()
+    await model_registry.load(runtime)
+    return model_registry
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings()
+
+
+@pytest.fixture
+def data_plane(settings: Settings, model_registry: MultiModelRegistry) -> DataPlane:
+    return DataPlane(settings=settings, model_registry=model_registry)
+
+
+@pytest.fixture
+def model_repository_handlers(
+    model_repository: ModelRepository, model_registry: MultiModelRegistry
+) -> ModelRepositoryHandlers:
+    return ModelRepositoryHandlers(
+        repository=model_repository, model_registry=model_registry
+    )
+
+
+@pytest.fixture
+async def rest_server(
+    settings: Settings,
+    data_plane: DataPlane,
+    model_repository_handlers: ModelRepositoryHandlers,
+    runtime: MLflowRuntime,
+) -> RESTServer:
+    server = RESTServer(
+        settings,
+        data_plane=data_plane,
+        model_repository_handlers=model_repository_handlers,
+    )
+
+    await server.add_custom_handlers(runtime)
+
+    return server
+
+
+@pytest.fixture
+def rest_app(rest_server: RESTServer) -> FastAPI:
+    return rest_server._app
+
+
+@pytest.fixture
+def rest_client(rest_app: FastAPI) -> TestClient:
+    return TestClient(rest_app)

--- a/runtimes/mlflow/tests/rest/test_invocations.py
+++ b/runtimes/mlflow/tests/rest/test_invocations.py
@@ -2,8 +2,6 @@ import pytest
 
 from typing import Union
 
-from mlserver.types import InferenceRequest
-
 
 @pytest.mark.parametrize("content_type", ["", None, "application/pdf"])
 def test_invocations_invalid_content_type(rest_client, content_type: str):

--- a/runtimes/mlflow/tests/rest/test_invocations.py
+++ b/runtimes/mlflow/tests/rest/test_invocations.py
@@ -1,0 +1,10 @@
+import pytest
+
+from mlserver.types import InferenceRequest
+
+
+@pytest.mark.parametrize("content_type", ["", None, "application/pdf"])
+def test_invocations_invalid_content_type(rest_client, content_type: str):
+    response = rest_client.post("/invocations", headers={"Content-Type": content_type})
+
+    assert response.status_code == 400

--- a/runtimes/mlflow/tests/rest/test_invocations.py
+++ b/runtimes/mlflow/tests/rest/test_invocations.py
@@ -1,5 +1,7 @@
 import pytest
 
+from typing import Union
+
 from mlserver.types import InferenceRequest
 
 
@@ -8,3 +10,24 @@ def test_invocations_invalid_content_type(rest_client, content_type: str):
     response = rest_client.post("/invocations", headers={"Content-Type": content_type})
 
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "content_type, payload",
+    [
+        ("application/json", {"columns": ["a"], "data": [1, 2, 3]}),
+        ("application/json; format=pandas-records", [{"a": 1}, {"a": 2}, {"a": 3}]),
+        ("application/json", {"instances": [1, 2, 3]}),
+        ("application/json", {"inputs": [1, 2, 3]}),
+    ],
+)
+def test_invocations(rest_client, content_type: str, payload: Union[list, dict]):
+    response = rest_client.post(
+        "/invocations", headers={"Content-Type": content_type}, json=payload
+    )
+
+    assert response.status_code == 200
+
+    y_pred = response.json()
+    assert isinstance(y_pred, list)
+    assert len(y_pred) == 3


### PR DESCRIPTION
Fixes #168 

## Changelog
- Add a custom handler to the MLflow runtime which mimics MLflow's `/invocations` endpoint
- Update MLflow example to showcase support for MLflow's scoring protocol