### PR TITLE
Tweaks to get things working properly if environment.tar.gz is provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ SHELL ["/bin/bash", "-c"]
 
 ENV MLSERVER_MODELS_DIR=/mnt/models \
     MLSERVER_ENV_TARBALL=/mnt/models/environment.tar.gz \
-    PATH=/home/default/.local/bin:$PATH
+    PATH=/home/default/.local/bin:$PATH \
+    MLSERVER_VERSION=0.4.0
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
@@ -44,5 +45,5 @@ RUN useradd -u 1000 -s /bin/bash mlserver && \
 USER 1000
 
 # Need to source `activate-env.sh` so that env changes get persisted
-CMD . ./hack/activate-env.sh $MLSERVER_ENV_TARBALL \
-    && mlserver start $MLSERVER_MODELS_DIR
+CMD . ./hack/activate-env.sh $MLSERVER_ENV_TARBALL $MLSERVER_VERSION \
+    && python -m mlserver.cli.main start $MLSERVER_MODELS_DIR

--- a/hack/activate-env.sh
+++ b/hack/activate-env.sh
@@ -5,10 +5,10 @@ set -o errexit
 set -o pipefail
 
 _printUsage() {
-  echo "Usage: ./run-in-env.sh <envTarball>"
+  echo "Usage: ./run-in-env.sh <envTarball> <version>"
 }
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
   echo 'Invalid number of arguments'
   _printUsage
   exit 1
@@ -34,10 +34,15 @@ _unpackEnv() {
   echo "--> Disabling user-installed packages..."
   # https://github.com/conda/conda/issues/448#issuecomment-195848539
   export PYTHONNOUSERSITE=True
+
+  echo "--> Installing mlserver..."
+  pip install mlserver==$_version
+  pip install mlserver-mlflow==$_version
 }
 
 _main() {
   local _envTarball=$1
+  local _version=$2
 
   if [[ -f $_envTarball ]]; then
     _unpackEnv $_envTarball


### PR DESCRIPTION
If we found a tarball  (`environment.tar.gz`) for the conda environment used during model training, we need to install `mlserver` and deps after unpacking.

We also pin the version to be installed.

