### PR TITLE
Add request codec for numpy and strings which returns the first element

### DIFF
--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -46,7 +46,8 @@ class NumpyCodec(InputCodec):
 
     ContentType = "np"
 
-    def encode(self, name: str, payload: np.ndarray) -> ResponseOutput:
+    @classmethod
+    def encode(cls, name: str, payload: np.ndarray) -> ResponseOutput:
         return ResponseOutput(
             name=name,
             datatype=_to_datatype(payload.dtype),
@@ -54,7 +55,8 @@ class NumpyCodec(InputCodec):
             data=payload.flatten().tolist(),
         )
 
-    def decode(self, request_input: RequestInput) -> np.ndarray:
+    @classmethod
+    def decode(cls, request_input: RequestInput) -> np.ndarray:
         dtype = _to_dtype(request_input.datatype)
         data = getattr(request_input.data, "__root__", request_input.data)
 

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..types import RequestInput, ResponseOutput
 
 from .base import InputCodec, register_input_codec, register_request_codec
-from .utils import DefaultRequestCodec
+from .utils import FirstInputRequestCodec
 
 _DatatypeToNumpy = {
     "BOOL": "bool",
@@ -68,6 +68,6 @@ class NumpyCodec(InputCodec):
 
 
 @register_request_codec
-class NumpyRequestCodec(DefaultRequestCodec):
+class NumpyRequestCodec(FirstInputRequestCodec):
     InputCodec = NumpyCodec
     ContentType = NumpyCodec.ContentType

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -2,7 +2,8 @@ import numpy as np
 
 from ..types import RequestInput, ResponseOutput
 
-from .base import InputCodec, register_input_codec
+from .base import InputCodec, register_input_codec, register_request_codec
+from .utils import DefaultRequestCodec
 
 _DatatypeToNumpy = {
     "BOOL": "bool",
@@ -64,3 +65,9 @@ class NumpyCodec(InputCodec):
 
         # TODO: Check if reshape not valid
         return model_data.reshape(request_input.shape)
+
+
+@register_request_codec
+class NumpyRequestCodec(DefaultRequestCodec):
+    InputCodec = NumpyCodec
+    ContentType = NumpyCodec.ContentType

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -30,8 +30,9 @@ def _to_response_output(series: pd.Series) -> ResponseOutput:
 class PandasCodec(RequestCodec):
     ContentType = "pd"
 
+    @classmethod
     def encode(
-        self, model_name: str, payload: pd.DataFrame, model_version: str = None
+        cls, model_name: str, payload: pd.DataFrame, model_version: str = None
     ) -> InferenceResponse:
         outputs = [_to_response_output(payload[col]) for col in payload]
 
@@ -39,7 +40,8 @@ class PandasCodec(RequestCodec):
             model_name=model_name, model_version=model_version, outputs=outputs
         )
 
-    def decode(self, request: InferenceRequest) -> pd.DataFrame:
+    @classmethod
+    def decode(cls, request: InferenceRequest) -> pd.DataFrame:
         data = {
             request_input.name: _to_series(request_input)
             for request_input in request.inputs

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -1,7 +1,9 @@
 from typing import Generator, Union, List
 
 from ..types import RequestInput, ResponseOutput
-from .base import InputCodec, register_input_codec
+
+from .utils import DefaultRequestCodec
+from .base import InputCodec, register_input_codec, register_request_codec
 
 _DefaultStrCodec = "utf-8"
 
@@ -79,3 +81,9 @@ class StringCodec(InputCodec):
         shape = request_input.shape
 
         return [_decode_str(elem) for elem in _split_elements(encoded, shape)]
+
+
+@register_request_codec
+class StringRequestCodec(DefaultRequestCodec):
+    InputCodec = StringCodec
+    ContentType = StringCodec.ContentType

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -2,7 +2,7 @@ from typing import Generator, Union, List
 
 from ..types import RequestInput, ResponseOutput
 
-from .utils import DefaultRequestCodec
+from .utils import FirstInputRequestCodec
 from .base import InputCodec, register_input_codec, register_request_codec
 
 _DefaultStrCodec = "utf-8"
@@ -84,6 +84,6 @@ class StringCodec(InputCodec):
 
 
 @register_request_codec
-class StringRequestCodec(DefaultRequestCodec):
+class StringRequestCodec(FirstInputRequestCodec):
     InputCodec = StringCodec
     ContentType = StringCodec.ContentType

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -46,7 +46,8 @@ class StringCodec(InputCodec):
 
     ContentType = "str"
 
-    def encode(self, name: str, payload: List[str]) -> ResponseOutput:
+    @classmethod
+    def encode(cls, name: str, payload: List[str]) -> ResponseOutput:
         packed = b""
         common_length = None
         for elem in payload:
@@ -72,7 +73,8 @@ class StringCodec(InputCodec):
             data=packed,
         )
 
-    def decode(self, request_input: RequestInput) -> List[str]:
+    @classmethod
+    def decode(cls, request_input: RequestInput) -> List[str]:
         encoded = request_input.data.__root__
         shape = request_input.shape
 

--- a/mlserver/codecs/utils.py
+++ b/mlserver/codecs/utils.py
@@ -125,4 +125,9 @@ class FirstInputRequestCodec(RequestCodec):
                 f"({len(request.inputs)} were received)"
             )
 
-        return get_decoded_or_raw(request.inputs[0])
+        first_input = request.inputs[0]
+        if not has_decoded(first_input):
+            decoded_payload = cls.InputCodec.decode(first_input)  # type: ignore
+            _save_decoded(first_input, decoded_payload)
+
+        return get_decoded_or_raw(first_input)

--- a/mlserver/codecs/utils.py
+++ b/mlserver/codecs/utils.py
@@ -99,10 +99,11 @@ def get_decoded_or_raw(parametrised_obj: Parametrised) -> Any:
     return get_decoded(parametrised_obj)
 
 
-class DefaultRequestCodec(RequestCodec):
+class FirstInputRequestCodec(RequestCodec):
     """
-    The DefaultRequestCodec can be used as a "meta-implementation" for other
-    codecs. Its goal to decode the whole request simply as the first element.
+    The FirstInputRequestCodec can be used as a "meta-implementation" for other
+    codecs. Its goal to decode the whole request simply as the first decoded
+    element.
     """
 
     InputCodec: Optional[InputCodec] = None

--- a/runtimes/mlflow/mlserver_mlflow/codecs.py
+++ b/runtimes/mlflow/mlserver_mlflow/codecs.py
@@ -8,7 +8,8 @@ from .encoding import TensorDict
 class TensorDictCodec(RequestCodec):
     ContentType = "dict"
 
-    def decode(self, request: InferenceRequest) -> TensorDict:
+    @classmethod
+    def decode(cls, request: InferenceRequest) -> TensorDict:
         return {
             request_input.name: get_decoded_or_raw(request_input)
             for request_input in request.inputs

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -3,7 +3,7 @@ from mlflow.pyfunc import PyFuncModel
 from mlserver_mlflow import MLflowRuntime
 from mlserver_mlflow.encoding import DefaultOutputName
 
-from mlserver.codecs import PandasCodec
+from mlserver.codecs import NumpyCodec
 from mlserver.types import InferenceRequest, Parameters, RequestInput
 
 
@@ -27,15 +27,14 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
     # input is a 28*28 image
     data = np.random.randn(1, 28 * 28).astype(np.float32)
     inference_request = InferenceRequest(
-        parameters=Parameters(content_type=PandasCodec.ContentType),
+        parameters=Parameters(content_type=NumpyCodec.ContentType),
         inputs=[
             RequestInput(
-                name=f"predict{idx}",
-                shape=[1, 1],
-                data=[i],
+                name=f"predict",
+                shape=data.shape,
+                data=data.tolist(),
                 datatype="FP32",
             )
-            for idx, i in enumerate(data.flat)
         ],
     )
     response = await runtime_pytorch.predict(inference_request)

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from mlserver.types import InferenceRequest
+from mlserver.codecs.base import CodecError
+from mlserver.codecs.utils import DefaultRequestCodec, get_decoded_or_raw
+
+
+def test_default_decode(inference_request: InferenceRequest):
+    inference_request.inputs = [inference_request.inputs[0]]
+    first_input = DefaultRequestCodec.decode(inference_request)
+
+    assert first_input == get_decoded_or_raw(inference_request.inputs[0])
+
+
+def test_default_error(inference_request: InferenceRequest):
+    with pytest.raises(CodecError):
+        DefaultRequestCodec.decode(inference_request)

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -2,16 +2,16 @@ import pytest
 
 from mlserver.types import InferenceRequest
 from mlserver.codecs.base import CodecError
-from mlserver.codecs.utils import DefaultRequestCodec, get_decoded_or_raw
+from mlserver.codecs.utils import FirstInputRequestCodec, get_decoded_or_raw
 
 
 def test_default_decode(inference_request: InferenceRequest):
     inference_request.inputs = [inference_request.inputs[0]]
-    first_input = DefaultRequestCodec.decode(inference_request)
+    first_input = FirstInputRequestCodec.decode(inference_request)
 
     assert first_input == get_decoded_or_raw(inference_request.inputs[0])
 
 
 def test_default_error(inference_request: InferenceRequest):
     with pytest.raises(CodecError):
-        DefaultRequestCodec.decode(inference_request)
+        FirstInputRequestCodec.decode(inference_request)

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -1,17 +1,52 @@
 import pytest
+import numpy as np
 
-from mlserver.types import InferenceRequest
+from mlserver.types import InferenceRequest, RequestInput, Parameters
 from mlserver.codecs.base import CodecError
-from mlserver.codecs.utils import FirstInputRequestCodec, get_decoded_or_raw
+from mlserver.codecs.utils import (
+    FirstInputRequestCodec,
+    get_decoded_or_raw,
+    DecodedParameterName,
+)
+from mlserver.codecs.numpy import NumpyRequestCodec
 
 
-def test_default_decode(inference_request: InferenceRequest):
+@pytest.mark.parametrize(
+    "inference_request, expected",
+    [
+        (
+            InferenceRequest(
+                inputs=[
+                    RequestInput(
+                        name="foo", shape=[2, 2], data=[1, 2, 3, 4], datatype="INT32"
+                    )
+                ]
+            ),
+            np.array([[1, 2], [3, 4]]),
+        ),
+        (
+            InferenceRequest(
+                inputs=[
+                    RequestInput(
+                        name="foo",
+                        shape=[2, 2],
+                        data=[1, 2, 3, 4],
+                        datatype="INT32",
+                        parameters=Parameters(**{DecodedParameterName: np.array([23])}),
+                    )
+                ]
+            ),
+            np.array([23]),
+        ),
+    ],
+)
+def test_first_input_decode(inference_request: InferenceRequest, expected: np.ndarray):
     inference_request.inputs = [inference_request.inputs[0]]
-    first_input = FirstInputRequestCodec.decode(inference_request)
+    first_input = NumpyRequestCodec.decode(inference_request)
 
-    assert first_input == get_decoded_or_raw(inference_request.inputs[0])
+    np.testing.assert_equal(first_input, expected)
 
 
-def test_default_error(inference_request: InferenceRequest):
+def test_first_input_error(inference_request: InferenceRequest):
     with pytest.raises(CodecError):
         FirstInputRequestCodec.decode(inference_request)


### PR DESCRIPTION
Fixes #274

## Changelog

- Add "dummy" request codec whose sole responsibility is to return the first input element
- Update existing PyTorch tests to use this approach