### PR TITLE
Add typing-extensions dependency to support older Python versions

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,8 +15,7 @@ mypy==0.910
 mypy-protobuf==2.9
 types-protobuf==3.17.4
 types-orjson==3.6.0
-black==21.8b0
-typing-extensions==3.10.0.2
+black==21.7b0
 
 # Pushing to PyPi
 twine==3.4.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,6 +16,7 @@ mypy-protobuf==2.9
 types-protobuf==3.17.4
 types-orjson==3.6.0
 black==21.8b0
+typing-extenions==3.10.0.2
 
 # Pushing to PyPi
 twine==3.4.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ mypy-protobuf==2.9
 types-protobuf==3.17.4
 types-orjson==3.6.0
 black==21.8b0
-typing-extenions==3.10.0.2
+typing-extensions==3.10.0.2
 
 # Pushing to PyPi
 twine==3.4.2


### PR DESCRIPTION
Downgrade `black` due to incompatibility with `tensorflow` caused by https://github.com/tensorflow/tensorflow/issues/51743