### PR TITLE
Revert "Bump black from 21.7b0 to 21.8b0"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ mypy==0.910
 mypy-protobuf==2.9
 types-protobuf==3.17.4
 types-orjson==3.6.0
-black==21.8b0
+black==21.7b0
 
 # Pushing to PyPi
 twine==3.4.2


### PR DESCRIPTION
Reverts SeldonIO/MLServer#295

Downgrade black due to an incompatibility with `tensorflow` caused by tensorflow/tensorflow#51743