### PR TITLE
Refactor Dockerfile and split images per runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,44 @@
-FROM python:3.8-slim
+FROM python:3.8-slim AS wheel-builder
+SHELL ["/bin/bash", "-c"]
 
+COPY ./hack/build-wheels.sh ./hack/build-wheels.sh
+
+COPY setup.py .
+COPY README.md .
+COPY ./mlserver/ ./mlserver/
+COPY ./runtimes/ ./runtimes/
+
+# TODO: Cache this step with BuildKit?
+# This will build the wheels and place will place them in the
+# /opt/mlserver/dist folder
+RUN ./hack/build-wheels.sh /opt/mlserver/dist
+
+FROM python:3.8-slim
 SHELL ["/bin/bash", "-c"]
 
 ENV MLSERVER_MODELS_DIR=/mnt/models \
     MLSERVER_ENV_TARBALL=/mnt/models/environment.tar.gz \
-    PATH=/home/default/.local/bin:$PATH
+    PATH=/opt/mlserver/.local/bin:$PATH
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
-    libgomp1 && \
-    apt-get install -y libgl1-mesa-dev && \
-    apt-get install -y libglib2.0-0 && \
-    pip install --upgrade pip wheel setuptools
+        libgomp1 libgl1-mesa-dev libglib2.0-0
 
 RUN mkdir /opt/mlserver
 WORKDIR /opt/mlserver
 
-COPY setup.py .
-# TODO: This busts the Docker cache before installing the rest of packages,
-# which we don't want, but I can't see any way to install only deps from
-# setup.py
-COPY README.md .
-COPY ./mlserver/ ./mlserver/
-RUN pip install .
+# Create user and fix permissions
+# NOTE: We need to make /opt/mlserver world-writable so that the image is
+# compatible with random UIDs.
+RUN useradd -u 1000 -s /bin/bash mlserver -d /opt/mlserver && \
+    chown -R 1000:0 /opt/mlserver && \
+    chmod -R 776 /opt/mlserver
 
-COPY ./runtimes/ ./runtimes/
-RUN for _runtime in ./runtimes/*; \
-    do \
-    pip install $_runtime; \
-    done
+USER 1000
+
+COPY --from=wheel-builder /opt/mlserver/dist ./dist 
+RUN pip install --upgrade pip wheel setuptools && \
+    pip install ./dist/*.whl
 
 COPY requirements/docker.txt requirements/docker.txt
 RUN pip install -r requirements/docker.txt
@@ -36,15 +46,6 @@ RUN pip install -r requirements/docker.txt
 COPY ./licenses/license.txt .
 
 COPY ./hack/activate-env.sh ./hack/activate-env.sh
-
-# Create user and fix permissions
-# NOTE: We need to make /opt/mlserver world-writable so that the image is
-# compatible with random UIDs.
-RUN useradd -u 1000 -s /bin/bash mlserver && \
-    chown -R 1000:0 /opt/mlserver && \
-    chmod -R 776 /opt/mlserver
-
-USER 1000
 
 # Need to source `activate-env.sh` so that env changes get persisted
 CMD . ./hack/activate-env.sh $MLSERVER_ENV_TARBALL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ RUN pip install --upgrade pip wheel setuptools && \
     if [[ $RUNTIMES == "all" ]]; then \
         pip install ./dist/*.whl; \
     else \
-        pip install "./dist/mlserver-*.whl"; \
+        pip install "./dist/mlserver-"*.whl; \
         for _runtime in $RUNTIMES; do \
             _wheelName=$(echo $_runtime | tr '-' '_'); \
-            pip install "./dist/$_wheelName-*.whl"; \
+            pip install "./dist/$_wheelName-"*.whl; \
         done \
     fi
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ run:
 		./tests/testdata
 
 build: clean 
-	docker build . -t ${IMAGE_NAME}:${VERSION}
+	./hack/build-images.sh ${VERSION}
 	./hack/build-wheels.sh ./dist
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL := /bin/bash
 VERSION := $(shell sed 's/^__version__ = "\(.*\)"/\1/' ./mlserver/version.py)
 IMAGE_NAME := seldonio/mlserver
 
-.PHONY: install-dev _generate generate run build push-test push test lint fmt version clean licenses
+.PHONY: install-dev _generate generate run build build-pypy build-docker\
+	push-test push test lint fmt version clean licenses
 
 install-dev:
 	pip install -r requirements/dev.txt
@@ -25,17 +26,9 @@ run:
 	mlserver start \
 		./tests/testdata
 
-build: clean
+build: clean 
 	docker build . -t ${IMAGE_NAME}:${VERSION}
-	python setup.py sdist bdist_wheel
-	for _runtime in ./runtimes/*; \
-	do \
-		cd $$_runtime; \
-		python setup.py \
-			sdist -d ../../dist \
-			bdist_wheel -d ../../dist; \
-		cd ../../; \
-	done
+	./hack/build-wheels.sh ./dist
 
 clean:
 	rm -rf ./dist ./build

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ push-test:
 
 push:
 	docker push ${IMAGE_NAME}:${VERSION}
+	docker push ${IMAGE_NAME}:${VERSION}-slim
+	for _runtime in ./runtimes/*; \
+	do \
+	  _runtimeName=$$(basename $$_runtime); \
+		docker push ${IMAGE_NAME}:${VERSION}-$$_runtimeName; \
+	done
 	twine upload dist/*
 
 test:

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -17,7 +17,7 @@ _buildImage() {
   local _runtimes=$1
   local _tag=$2
 
-  docker build $ROOT_FOLDER \
+  DOCKER_BUILDKIT=1 docker build $ROOT_FOLDER \
     --build-arg RUNTIMES="$_runtimes" \
     -t "$IMAGE_NAME:$_tag"
 }

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+ROOT_FOLDER="$(dirname "${0}")/.."
+IMAGE_NAME="seldonio/mlserver"
+
+if [ "$#" -ne 1 ]; then
+  echo 'Invalid number of arguments'
+  echo "Usage: ./build-images.sh <version>"
+  exit 1
+fi
+
+_buildImage() {
+  local _runtimes=$1
+  local _tag=$2
+
+  docker build $ROOT_FOLDER \
+    --build-arg RUNTIMES="$_runtimes" \
+    -t "$IMAGE_NAME:$_tag"
+}
+
+_buildRuntimeImage() {
+  local _runtimePath=$1
+  local _version=$2
+  local _runtimeName=$(basename $_runtimePath)
+
+  echo "---> Building MLServer runtime image: $_runtimeName"
+  _buildImage "mlserver-$_runtimeName" "$_version-$_runtimeName"
+}
+
+_main() {
+  local _version=$1
+
+  echo "---> Building core MLServer images"
+  _buildImage "all" $_version
+  _buildImage "" $_version-slim
+
+  for _runtimePath in "$ROOT_FOLDER/runtimes/"*; do
+    _buildRuntimeImage $_runtimePath $_version
+  done
+}
+
+_main $1

--- a/hack/build-wheels.sh
+++ b/hack/build-wheels.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+ROOT_FOLDER="$(dirname "${0}")/.."
+
+if [ "$#" -ne 1 ]; then
+  echo 'Invalid number of arguments'
+  echo "Usage: ./build-wheels.sh <outputPath>"
+  exit 1
+fi
+
+_buildWheel() {
+  local _srcPath=$1
+  local _outputPath=$2
+  local _currentDir=$PWD
+
+  # Python really expects the `setup.py` to be on the current folder, so we'll
+  # `cd` into it and the go back again.
+  cd $_srcPath
+  python setup.py \
+    sdist -d $_outputPath \
+    bdist_wheel -d $_outputPath >/dev/null
+  cd $_currentDir
+}
+
+_main() {
+  local _outputPath="$PWD/$1"
+
+  # Build MLServer
+  echo "---> Building MLServer wheel"
+  _buildWheel $ROOT_FOLDER $_outputPath
+
+  for _runtime in "$ROOT_FOLDER/runtimes/"*; do
+    echo "---> Building MLServer runtime: '$_runtime'"
+    _buildWheel $_runtime $_outputPath
+  done
+}
+
+_main $1

--- a/hack/build-wheels.sh
+++ b/hack/build-wheels.sh
@@ -22,7 +22,7 @@ _buildWheel() {
   cd $_srcPath
   python setup.py \
     sdist -d $_outputPath \
-    bdist_wheel -d $_outputPath >/dev/null
+    bdist_wheel -d $_outputPath
   cd $_currentDir
 }
 

--- a/hack/update-version.sh
+++ b/hack/update-version.sh
@@ -15,13 +15,25 @@ _updateVersion() {
   local _newVersion=$1
   local _versionPy=$2
 
-  sed -i "s/^__version__ = \"\(.*\)\"$/__version__ = \"$_newVersion\"/" "$_versionPy"
+  sed \
+    -i "s/^__version__ = \"\(.*\)\"$/__version__ = \"$_newVersion\"/" \
+    "$_versionPy"
 }
 
 _updateDocs() {
   local _newVersion=$1
 
-  sed -i "s/^release = \"\(.*\)\"$/release = \"$_newVersion\"/" $ROOT_FOLDER/docs/conf.py
+  sed \
+    -i "s/^release = \"\(.*\)\"$/release = \"$_newVersion\"/" \
+    "$ROOT_FOLDER/docs/conf.py"
+}
+
+_updateDockerfile() {
+  local _newVersion=$1
+
+  sed \
+    -i "s/^ARG VERSION \"\(.*\)\"$/ARG VERSION \"$_newVersion\"/" \
+    "$ROOT_FOLDER/Dockerfile"
 }
 
 _main() {
@@ -39,6 +51,7 @@ _main() {
     -exec bash -c "_updateVersion $_newVersion {}" \;
 
   _updateDocs $_newVersion
+  _updateDockerfile $_newVersion
 }
 
 _main $1

--- a/hack/update-version.sh
+++ b/hack/update-version.sh
@@ -28,14 +28,6 @@ _updateDocs() {
     "$ROOT_FOLDER/docs/conf.py"
 }
 
-_updateDockerfile() {
-  local _newVersion=$1
-
-  sed \
-    -i "s/^ARG VERSION \"\(.*\)\"$/ARG VERSION \"$_newVersion\"/" \
-    "$ROOT_FOLDER/Dockerfile"
-}
-
 _main() {
   local _newVersion=$1
 
@@ -51,7 +43,6 @@ _main() {
     -exec bash -c "_updateVersion $_newVersion {}" \;
 
   _updateDocs $_newVersion
-  _updateDockerfile $_newVersion
 }
 
 _main $1


### PR DESCRIPTION
Fixes #302 

## Changelog
- Refactor `Dockerfile`, which now builds the images in 2 stages: 
  1. Build all the Python wheels in a first "builder" image
  2. Install the wheels which are selected
- Add a special `slim` image, with no runtimes (meant to be used with custom environments)
  