### PR TITLE
pin version of fastapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(
     install_requires=[
         "grpcio",
         "protobuf",
-        "fastapi",
+        # We pin version of fastapi
+        # check https://github.com/SeldonIO/MLServer/issues/340
+        "fastapi==0.68.2",
         "uvicorn",
         "orjson",
         "click",


### PR DESCRIPTION
with latest version of fastapi (`0.70.0`) we have issues, check https://github.com/SeldonIO/MLServer/issues/340

we pin it for now back to `0.68.2`