### PR TITLE
fixes to get the docker image built properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@ RUN useradd -u 1000 -s /bin/bash mlserver -d /opt/mlserver && \
     chown -R 1000:0 /opt/mlserver && \
     chmod -R 776 /opt/mlserver
 
-USER 1000
-
 COPY --from=wheel-builder /opt/mlserver/dist ./dist 
 RUN pip install --upgrade pip wheel setuptools && \
     if [[ $RUNTIMES == "all" ]]; then \
@@ -55,6 +53,8 @@ RUN pip install -r requirements/docker.txt
 COPY ./licenses/license.txt .
 
 COPY ./hack/activate-env.sh ./hack/activate-env.sh
+
+USER 1000
 
 # Need to source `activate-env.sh` so that env changes get persisted
 CMD . ./hack/activate-env.sh $MLSERVER_ENV_TARBALL \

--- a/runtimes/alibi-explain/mlserver_alibi_explain/version.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1.dev1"
+__version__ = "0.6.0.dev0"


### PR DESCRIPTION
Fixes to get the mlserver module installed with the right permissions in docker. In `seldon-core` the user is switched from the default one and we need on install `mlserver` system wide.