### PR TITLE
Add workaround for pip issues in CI

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ grpcio-tools==1.41.1
 datamodel-code-generator==0.11.14
 ## Locking `prance` (a subdep of `datamodel-code-generator`) to an older
 ## version due to issues with the latest version of `pip`:
-## https://github.com/pypa/pip/issues/10644 
+## https://github.com/pypa/pip/issues/9613 
 prance==0.20.0
 
 # Testing

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,10 @@
 # Code generation
 grpcio-tools==1.41.1
 datamodel-code-generator==0.11.14
+## Locking `prance` (a subdep of `datamodel-code-generator`) to an older
+## version due to issues with the latest version of `pip`:
+## https://github.com/pypa/pip/issues/10644 
+prance==0.20.0
 
 # Testing
 pytest==6.2.2
@@ -22,3 +26,4 @@ twine==3.4.2
 
 # Fetch licenses
 pip-licenses==3.5.3
+

--- a/runtimes/alibi-explain/requirements-dev.txt
+++ b/runtimes/alibi-explain/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Pin Tensorflow to avoid previous issues with 2.6.0 and 2.6.1
-tensorflow>=2.6.2
+tensorflow==2.6.2
 numpy
 nest_asyncio
 types-requests

--- a/runtimes/alibi-explain/requirements-dev.txt
+++ b/runtimes/alibi-explain/requirements-dev.txt
@@ -1,4 +1,5 @@
-tensorflow
+# Pin Tensorflow to avoid previous issues with 2.6.0 and 2.6.1
+tensorflow>=2.6.2
 numpy
 nest_asyncio
 types-requests


### PR DESCRIPTION
## Changelog

- Lock `prance` to an older version to avoid strange `six` clash with latest version of `pip`. For more information, please check https://github.com/pypa/pip/issues/9613. 