### PR TITLE
Make model URI in model-settings.json relative to the config file

### DIFF
--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -42,9 +42,11 @@ class ModelRepository:
 
     def _load_model_settings(self, model_settings_path: str) -> ModelSettings:
         model_settings = ModelSettings.parse_file(model_settings_path)
+        model_settings_folder = os.path.dirname(model_settings_path)
+        model_settings._source = model_settings_folder
 
         # If name not present, default to folder name
-        default_model_name = os.path.basename(os.path.dirname(model_settings_path))
+        default_model_name = os.path.basename(model_settings_folder)
         if model_settings.name:
             if model_settings.name != default_model_name:
                 # Raise warning if name is different than folder's name

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -7,7 +7,7 @@ from .settings import ModelParameters, ModelSettings
 from .errors import ModelNotFound
 from .logging import logger
 
-DefaultModelSettingsFilename = "model-settings.json"
+DEFAULT_MODEL_SETTINGS_FILENAME = "model-settings.json"
 
 
 class ModelRepository:
@@ -24,7 +24,7 @@ class ModelRepository:
 
         # TODO: Use an async alternative for filesys ops
         if self._root:
-            pattern = os.path.join(self._root, "**", DefaultModelSettingsFilename)
+            pattern = os.path.join(self._root, "**", DEFAULT_MODEL_SETTINGS_FILENAME)
             matches = glob.glob(pattern, recursive=True)
 
             for model_settings_path in matches:

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -7,7 +7,7 @@ from .settings import ModelParameters, ModelSettings
 from .errors import ModelNotFound
 from .logging import logger
 
-DEFAULT_MODEL_SETTINGS_FILENAME = "model-settings.json"
+DefaultModelSettingsFilename = "model-settings.json"
 
 
 class ModelRepository:
@@ -24,7 +24,7 @@ class ModelRepository:
 
         # TODO: Use an async alternative for filesys ops
         if self._root:
-            pattern = os.path.join(self._root, "**", DEFAULT_MODEL_SETTINGS_FILENAME)
+            pattern = os.path.join(self._root, "**", DefaultModelSettingsFilename)
             matches = glob.glob(pattern, recursive=True)
 
             for model_settings_path in matches:
@@ -42,10 +42,10 @@ class ModelRepository:
 
     def _load_model_settings(self, model_settings_path: str) -> ModelSettings:
         model_settings = ModelSettings.parse_file(model_settings_path)
-        model_settings_folder = os.path.dirname(model_settings_path)
-        model_settings._source = model_settings_folder
+        model_settings._source = model_settings_path
 
         # If name not present, default to folder name
+        model_settings_folder = os.path.dirname(model_settings_path)
         default_model_name = os.path.basename(model_settings_folder)
         if model_settings.name:
             if model_settings.name != default_model_name:

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -70,6 +70,10 @@ class ModelParameters(BaseSettings):
 class ModelSettings(BaseSettings):
     class Config:
         env_prefix = ENV_PREFIX_MODEL_SETTINGS
+        underscore_attrs_are_private = True
+
+    # Source points to the file where model settings were loaded from
+    _source: Optional[str] = None
 
     """Name of the model."""
     name: str = ""

--- a/mlserver/utils.py
+++ b/mlserver/utils.py
@@ -13,34 +13,36 @@ async def get_model_uri(
     if not settings.parameters:
         raise InvalidModelURI(settings.name)
 
-    relative_model_uri = settings.parameters.uri
-    if not relative_model_uri:
+    model_uri = settings.parameters.uri
+    if not model_uri:
         raise InvalidModelURI(settings.name)
 
-    model_uri = _to_absolut_path(settings._source, relative_model_uri)
-    if os.path.isfile(model_uri):
-        return model_uri
+    full_model_uri = _to_absolute_path(settings._source, model_uri)
+    if os.path.isfile(full_model_uri):
+        return full_model_uri
 
-    if os.path.isdir(model_uri):
-        # If model_uri is a folder, search for a well-known model filename
+    if os.path.isdir(full_model_uri):
+        # If full_model_uri is a folder, search for a well-known model filename
         for fname in wellknown_filenames:
-            model_path = os.path.join(model_uri, fname)
+            model_path = os.path.join(full_model_uri, fname)
             if os.path.isfile(model_path):
                 return model_path
 
         # If none, return the folder
-        return model_uri
+        return full_model_uri
 
     # Otherwise, the uri is neither a file nor a folder
-    raise InvalidModelURI(settings.name, model_uri)
+    raise InvalidModelURI(settings.name, full_model_uri)
 
 
-def _to_absolut_path(source: Optional[str], relative_model_uri: str) -> str:
+def _to_absolute_path(source: Optional[str], model_uri: str) -> str:
     if source is None:
-        return relative_model_uri
+        # Treat path as either absolute or relative to the working directory of
+        # the MLServer instance
+        return model_uri
 
     parent_folder = os.path.dirname(source)
-    unnormalised = os.path.join(parent_folder, relative_model_uri)
+    unnormalised = os.path.join(parent_folder, model_uri)
     return os.path.normpath(unnormalised)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import shutil
 
 from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
-from mlserver.repository import ModelRepository, DEFAULT_MODEL_SETTINGS_FILENAME
+from mlserver.repository import ModelRepository, DefaultModelSettingsFilename
 from mlserver import types, Settings, ModelSettings
 
 from .fixtures import SumModel
@@ -100,7 +100,7 @@ def model_folder(tmp_path):
 @pytest.fixture
 def multi_model_folder(model_folder, sum_model_settings):
     # Remove original
-    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
+    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
     os.remove(model_settings_path)
 
     num_models = 5
@@ -115,7 +115,7 @@ def multi_model_folder(model_folder, sum_model_settings):
         os.makedirs(model_version_folder)
 
         model_settings_path = os.path.join(
-            model_version_folder, DEFAULT_MODEL_SETTINGS_FILENAME
+            model_version_folder, DefaultModelSettingsFilename
         )
         with open(model_settings_path, "w") as f:
             settings_dict = sum_model_settings.dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import shutil
 
 from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
-from mlserver.repository import ModelRepository, DefaultModelSettingsFilename
+from mlserver.repository import ModelRepository, DEFAULT_MODEL_SETTINGS_FILENAME
 from mlserver import types, Settings, ModelSettings
 
 from .fixtures import SumModel
@@ -100,7 +100,7 @@ def model_folder(tmp_path):
 @pytest.fixture
 def multi_model_folder(model_folder, sum_model_settings):
     # Remove original
-    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
+    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
     os.remove(model_settings_path)
 
     num_models = 5
@@ -115,7 +115,7 @@ def multi_model_folder(model_folder, sum_model_settings):
         os.makedirs(model_version_folder)
 
         model_settings_path = os.path.join(
-            model_version_folder, DefaultModelSettingsFilename
+            model_version_folder, DEFAULT_MODEL_SETTINGS_FILENAME
         )
         with open(model_settings_path, "w") as f:
             settings_dict = sum_model_settings.dict()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from mlserver.repository import ModelRepository, DefaultModelSettingsFilename
+from mlserver.repository import ModelRepository, DEFAULT_MODEL_SETTINGS_FILENAME
 from mlserver.settings import ModelSettings, ENV_PREFIX_MODEL_SETTINGS
 
 from .helpers import get_import_path
@@ -24,7 +24,7 @@ async def test_list(
         model_repository._root
     )
     assert loaded_model_settings._source == os.path.join(
-        model_repository._root, DefaultModelSettingsFilename
+        model_repository._root, DEFAULT_MODEL_SETTINGS_FILENAME
     )
 
 
@@ -40,7 +40,7 @@ async def test_list_multi_model(multi_model_folder: str):
             multi_model_folder,
             model_settings.name,
             model_settings.parameters.version,
-            DefaultModelSettingsFilename,
+            DEFAULT_MODEL_SETTINGS_FILENAME,
         )
 
         assert model_settings.parameters.version == f"v{idx}"  # type: ignore
@@ -63,7 +63,7 @@ async def test_list_fallback(
         get_import_path(sum_model_settings.implementation),  # type: ignore
     )
 
-    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
+    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
     os.remove(model_settings_path)
 
     all_settings = await model_repository.list()
@@ -82,7 +82,7 @@ async def test_list_fallback(
 async def test_name_fallback(model_folder: str, model_repository: ModelRepository):
     # Create empty model-settings.json file
     model_settings = ModelSettings()
-    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
+    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
     with open(model_settings_path, "w") as model_settings_file:
         d = model_settings.dict()
         del d["name"]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -13,25 +13,33 @@ async def test_list(
     settings_list = await model_repository.list()
 
     assert len(settings_list) == 1
-    assert settings_list[0].name == sum_model_settings.name
+
+    loaded_model_settings = settings_list[0]
+    assert loaded_model_settings.name == sum_model_settings.name
     assert (
-        settings_list[0].parameters.version  # type: ignore
+        loaded_model_settings.parameters.version  # type: ignore
         == sum_model_settings.parameters.version  # type: ignore
     )
-    assert settings_list[0].parameters.uri == str(  # type: ignore
+    assert loaded_model_settings.parameters.uri == str(  # type: ignore
         model_repository._root
     )
+    assert loaded_model_settings._source == str(model_repository._root)
 
 
 async def test_list_multi_model(multi_model_folder: str):
-    multi_model_loader = ModelRepository(multi_model_folder)
+    multi_model_repository = ModelRepository(multi_model_folder)
 
-    settings_list = await multi_model_loader.list()
+    settings_list = await multi_model_repository.list()
     settings_list.sort(key=lambda ms: ms.parameters.version)  # type: ignore
 
     assert len(settings_list) == 5
     for idx, model_settings in enumerate(settings_list):
+        model_path = os.path.join(
+            multi_model_folder, model_settings.name, model_settings.parameters.version
+        )
+
         assert model_settings.parameters.version == f"v{idx}"  # type: ignore
+        assert model_settings._source == model_path
 
 
 async def test_list_fallback(
@@ -56,11 +64,14 @@ async def test_list_fallback(
     all_settings = await model_repository.list()
 
     assert len(all_settings) == 1
-    assert all_settings[0].name == sum_model_settings.name
+
+    default_model_settings = all_settings[0]
+    assert default_model_settings.name == sum_model_settings.name
     assert (
-        all_settings[0].parameters.version  # type: ignore
+        default_model_settings.parameters.version  # type: ignore
         == sum_model_settings.parameters.version  # type: ignore
     )
+    assert default_model_settings._source is None
 
 
 async def test_name_fallback(model_folder: str, model_repository: ModelRepository):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from mlserver.repository import ModelRepository, DEFAULT_MODEL_SETTINGS_FILENAME
+from mlserver.repository import ModelRepository, DefaultModelSettingsFilename
 from mlserver.settings import ModelSettings, ENV_PREFIX_MODEL_SETTINGS
 
 from .helpers import get_import_path
@@ -23,7 +23,9 @@ async def test_list(
     assert loaded_model_settings.parameters.uri == str(  # type: ignore
         model_repository._root
     )
-    assert loaded_model_settings._source == str(model_repository._root)
+    assert loaded_model_settings._source == os.path.join(
+        model_repository._root, DefaultModelSettingsFilename
+    )
 
 
 async def test_list_multi_model(multi_model_folder: str):
@@ -34,12 +36,15 @@ async def test_list_multi_model(multi_model_folder: str):
 
     assert len(settings_list) == 5
     for idx, model_settings in enumerate(settings_list):
-        model_path = os.path.join(
-            multi_model_folder, model_settings.name, model_settings.parameters.version
+        model_settings_path = os.path.join(
+            multi_model_folder,
+            model_settings.name,
+            model_settings.parameters.version,
+            DefaultModelSettingsFilename,
         )
 
         assert model_settings.parameters.version == f"v{idx}"  # type: ignore
-        assert model_settings._source == model_path
+        assert model_settings._source == model_settings_path
 
 
 async def test_list_fallback(
@@ -58,7 +63,7 @@ async def test_list_fallback(
         get_import_path(sum_model_settings.implementation),  # type: ignore
     )
 
-    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
+    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
     os.remove(model_settings_path)
 
     all_settings = await model_repository.list()
@@ -77,7 +82,7 @@ async def test_list_fallback(
 async def test_name_fallback(model_folder: str, model_repository: ModelRepository):
     # Create empty model-settings.json file
     model_settings = ModelSettings()
-    model_settings_path = os.path.join(model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
+    model_settings_path = os.path.join(model_folder, DefaultModelSettingsFilename)
     with open(model_settings_path, "w") as model_settings_file:
         d = model_settings.dict()
         del d["name"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,11 @@ from mlserver.settings import ModelSettings, ModelParameters
             "./my-model-folder/../model-settings.json",
             "my-model.bin",
         ),
+        (
+            "/an/absolute/path/my-model.bin",
+            "/mnt/models/model-settings.json",
+            "/an/absolute/path/my-model.bin",
+        ),
     ],
 )
 @patch("os.path.isfile", return_value=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from typing import Optional
+from unittest.mock import patch
+
+from mlserver.utils import get_model_uri
+from mlserver.settings import ModelSettings, ModelParameters
+
+
+@pytest.mark.parametrize(
+    "uri, source, expected",
+    [
+        ("my-model.bin", None, "my-model.bin"),
+        (
+            "my-model.bin",
+            "./my-model-folder/model-settings.json",
+            "my-model-folder/my-model.bin",
+        ),
+        (
+            "my-model.bin",
+            "./my-model-folder/../model-settings.json",
+            "my-model.bin",
+        ),
+    ],
+)
+@patch("os.path.isfile", return_value=True)
+async def test_get_model_uri(
+    mock_isfile, uri: str, source: Optional[str], expected: str
+):
+    model_settings = ModelSettings(parameters=ModelParameters(uri=uri))
+    model_settings._source = source
+    model_uri = await get_model_uri(model_settings)
+
+    assert model_uri == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,12 +28,10 @@ from mlserver.settings import ModelSettings, ModelParameters
         ),
     ],
 )
-@patch("os.path.isfile", return_value=True)
-async def test_get_model_uri(
-    mock_isfile, uri: str, source: Optional[str], expected: str
-):
+async def test_get_model_uri(uri: str, source: Optional[str], expected: str):
     model_settings = ModelSettings(parameters=ModelParameters(uri=uri))
     model_settings._source = source
-    model_uri = await get_model_uri(model_settings)
+    with patch("os.path.isfile", return_value=True):
+        model_uri = await get_model_uri(model_settings)
 
     assert model_uri == expected


### PR DESCRIPTION
Fixes #325 

## Changelog
- Add private `_source` field to `ModelSettings` and tweak `ModelRepository` to store there the original file path of the `model-settings.json` file (if any).
- Tweak the `get_model_uri` utility method to base the model's URI on the location of the `model-settings.json` file.