### PR TITLE
Sherif akoush/quickfix/get names from metadata endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ mlruns
 
 # Sphinx documentation
 docs/_build/
+
+# alibi .data
+runtimes/alibi-explain/tests/.data/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV MLSERVER_MODELS_DIR=/mnt/models \
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
-        libgomp1 libgl1-mesa-dev libglib2.0-0
+        libgomp1 libgl1-mesa-dev libglib2.0-0 build-essential
 
 RUN mkdir /opt/mlserver
 WORKDIR /opt/mlserver

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ html_title = "MLServer Documentation"
 author = "Seldon Technologies"
 
 # The full version, including alpha/beta/rc tags
-release = "0.6.0.dev3"
+release = "0.6.0.dev4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/mlserver/version.py
+++ b/mlserver/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/alibi-detect/mlserver_alibi_detect/version.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/alibi-explain/mlserver_alibi_explain/alibi_dependency_reference.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/alibi_dependency_reference.py
@@ -15,6 +15,7 @@ class ExplainerDependencyReference:
 _ANCHOR_IMAGE_TAG = "anchor_image"
 _ANCHOR_TEXT_TAG = "anchor_text"
 _ANCHOR_TABULAR_TAG = "anchor_tabular"
+_KERNEL_SHAP_TAG = "kernel_shap"
 _INTEGRATED_GRADIENTS_TAG = "integrated_gradients"
 
 
@@ -22,6 +23,10 @@ _INTEGRATED_GRADIENTS_TAG = "integrated_gradients"
 # ExplainerDependencyReference, referencing the specific runtime class in mlserver
 # and the specific alibi explain class.
 # this can be simplified when alibi moves to a config based init.
+
+# Steps:
+#  update _TAG_TO_RT_IMPL
+#  update ExplainerEnum
 
 _BLACKBOX_MODULDE = "mlserver_alibi_explain.explainers.black_box_runtime"
 _INTEGRATED_GRADIENTS_MODULE = "mlserver_alibi_explain.explainers.integrated_gradients"
@@ -42,6 +47,11 @@ _TAG_TO_RT_IMPL: Dict[str, ExplainerDependencyReference] = {
         runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
         alibi_class="alibi.explainers.AnchorText",
     ),
+    _KERNEL_SHAP_TAG: ExplainerDependencyReference(
+        explainer_name=_KERNEL_SHAP_TAG,
+        runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
+        alibi_class="alibi.explainers.KernelShap",
+    ),
     _INTEGRATED_GRADIENTS_TAG: ExplainerDependencyReference(
         explainer_name=_INTEGRATED_GRADIENTS_TAG,
         runtime_class=f"{_INTEGRATED_GRADIENTS_MODULE}.IntegratedGradientsWrapper",
@@ -54,6 +64,7 @@ class ExplainerEnum(str, Enum):
     anchor_image = _ANCHOR_IMAGE_TAG
     anchor_text = _ANCHOR_TEXT_TAG
     anchor_tabular = _ANCHOR_TABULAR_TAG
+    kernel_shap = _KERNEL_SHAP_TAG
     integrated_gradients = _INTEGRATED_GRADIENTS_TAG
 
 

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -15,7 +15,7 @@ from mlserver.types import (
     ResponseOutput,
     InferenceResponse,
     InferenceRequest,
-    Parameters,
+    Parameters, MetadataModelResponse,
 )
 
 EXPLAINER_TYPE_TAG = "explainer_type"
@@ -41,7 +41,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type]) -> Any:
         return literal_eval(py_str)
 
 
-# TODO: add retry
+# TODO: add retry and better exceptions handling
 def remote_predict(
     v2_payload: InferenceRequest, predictor_url: str
 ) -> InferenceResponse:
@@ -49,6 +49,13 @@ def remote_predict(
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return InferenceResponse.parse_raw(response_raw.text)
+
+
+def remote_metadata(url: str) -> MetadataModelResponse:
+    response_raw = requests.get(url)
+    if response_raw.status_code != 200:
+        raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
+    return MetadataModelResponse.parse_raw(response_raw.text)
 
 
 # TODO: this is very similar to `asyncio.to_thread` (python 3.9+),

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import functools
+import re
 from asyncio import AbstractEventLoop
 from importlib import import_module
 from typing import Any, Optional, Type, Callable, Awaitable, Union, List
@@ -52,10 +53,16 @@ def remote_predict(
 
 
 def remote_metadata(url: str) -> MetadataModelResponse:
+    """ Get metadata from v2 endpoint """
     response_raw = requests.get(url)
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return MetadataModelResponse.parse_raw(response_raw.text)
+
+
+def construct_metadata_url(infer_url: str) -> str:
+    """ Construct v2 metadata endpoint from v2 infer endpoint """
+    return re.sub(r"/infer$", "", infer_url)
 
 
 # TODO: this is very similar to `asyncio.to_thread` (python 3.9+),

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -113,13 +113,13 @@ def to_v2_inference_request(
 
     # MLServer does not really care about a correct input name!
     input_name = "predict"
-    output_names = []
+    outputs = []
     if metadata is not None:
         if metadata.inputs:
             # we only support a big single input numpy
             input_name = metadata.inputs[0].name
         if metadata.outputs:
-            output_names = metadata.outputs
+            outputs = metadata.outputs
 
     # For List[str] (e.g. AnchorText), we use StringCodec for input
     input_payload_codec = StringCodec if type(input_data) == list else NumpyCodec
@@ -133,6 +133,6 @@ def to_v2_inference_request(
             )
         ],
         # set outputs as empty list, this will return everything?
-        outputs=[]
+        outputs=outputs
     )
     return v2_request

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -143,7 +143,6 @@ def to_v2_inference_request(
                 name=input_name, payload=input_data
             )
         ],
-        # set outputs as empty list, this will return everything?
         outputs=outputs,
     )
     return v2_request

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -19,8 +19,7 @@ from mlserver.types import (
     Parameters,
     MetadataModelResponse,
 )
-
-_DEFAULT_ID_NAME = "explain_inference"
+from mlserver.utils import generate_uuid
 
 _DEFAULT_INPUT_NAME = "predict"
 
@@ -121,7 +120,7 @@ def to_v2_inference_request(
 
     # MLServer does not really care about a correct input name!
     input_name = _DEFAULT_INPUT_NAME
-    id_name = _DEFAULT_ID_NAME
+    id_name = generate_uuid()
     outputs = []
 
     if metadata is not None:

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -16,7 +16,8 @@ from mlserver.types import (
     ResponseOutput,
     InferenceResponse,
     InferenceRequest,
-    Parameters, MetadataModelResponse,
+    Parameters,
+    MetadataModelResponse,
 )
 
 EXPLAINER_TYPE_TAG = "explainer_type"
@@ -53,7 +54,7 @@ def remote_predict(
 
 
 def remote_metadata(url: str) -> MetadataModelResponse:
-    """ Get metadata from v2 endpoint """
+    """Get metadata from v2 endpoint"""
     response_raw = requests.get(url)
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
@@ -61,7 +62,7 @@ def remote_metadata(url: str) -> MetadataModelResponse:
 
 
 def construct_metadata_url(infer_url: str) -> str:
-    """ Construct v2 metadata endpoint from v2 infer endpoint """
+    """Construct v2 metadata endpoint from v2 infer endpoint"""
     return re.sub(r"/infer$", "", infer_url)
 
 
@@ -97,8 +98,8 @@ def import_and_get_class(class_path: str) -> type:
 
 
 def to_v2_inference_request(
-        input_data: Union[np.ndarray, List[str]],
-        metadata: Optional[MetadataModelResponse],
+    input_data: Union[np.ndarray, List[str]],
+    metadata: Optional[MetadataModelResponse],
 ) -> InferenceRequest:
     """
     Encode numpy payload to v2 protocol.
@@ -133,6 +134,6 @@ def to_v2_inference_request(
             )
         ],
         # set outputs as empty list, this will return everything?
-        outputs=outputs
+        outputs=outputs,
     )
     return v2_request

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -20,6 +20,10 @@ from mlserver.types import (
     MetadataModelResponse,
 )
 
+_DEFAULT_ID_NAME = "explain_inference"
+
+_DEFAULT_INPUT_NAME = "predict"
+
 EXPLAINER_TYPE_TAG = "explainer_type"
 
 _MAX_RETRY_ATTEMPT = 3
@@ -113,8 +117,10 @@ def to_v2_inference_request(
     """
 
     # MLServer does not really care about a correct input name!
-    input_name = "predict"
+    input_name = _DEFAULT_INPUT_NAME
+    id_name = _DEFAULT_ID_NAME
     outputs = []
+
     if metadata is not None:
         if metadata.inputs:
             # we only support a big single input numpy
@@ -125,6 +131,7 @@ def to_v2_inference_request(
     # For List[str] (e.g. AnchorText), we use StringCodec for input
     input_payload_codec = StringCodec if type(input_data) == list else NumpyCodec
     v2_request = InferenceRequest(
+        id=id_name,
         parameters=Parameters(content_type=input_payload_codec.ContentType),
         # TODO: we probably need to tell alibi about the expected types to use
         # or even whether it is a probability of classes or targets etc

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -108,6 +108,9 @@ def to_v2_inference_request(
     """
     Encode numpy payload to v2 protocol.
 
+    Note: We only fetch the first-input name and the list of outputs from the metadata
+    endpoint currently. We should consider wider reconciliation with data types etc.
+
     Parameters
     ----------
     input_data

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -38,6 +38,9 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         super().__init__(settings, explainer_settings)
 
     async def load(self) -> bool:
+        # get the metadata of the underlying inference model via v2 metadata endpoint
+        self.infer_metadata = remote_metadata(construct_metadata_url(self.infer_uri))
+
         # TODO: use init explainer field instead?
         if self.alibi_explain_settings.init_parameters is not None:
             init_parameters = self.alibi_explain_settings.init_parameters
@@ -45,9 +48,6 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             self._model = self._explainer_class(**init_parameters)  # type: ignore
         else:
             self._model = self._load_from_uri(self._infer_impl)
-
-        # get the metadata of the underlying inference model via v2 metadata endpoint
-        self.infer_metadata = remote_metadata(construct_metadata_url(self.infer_uri))
 
         self.ready = True
         return self.ready
@@ -67,7 +67,6 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         # TODO: for now we only support v2 protocol, do we need more support?
 
         v2_request = to_v2_inference_request(input_data, self.infer_metadata)
-
         v2_response = remote_predict(
             v2_payload=v2_request, predictor_url=self.infer_uri
         )

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -8,7 +8,9 @@ from mlserver.codecs import NumpyCodec
 from mlserver_alibi_explain.common import (
     AlibiExplainSettings,
     remote_predict,
-    to_v2_inference_request, remote_metadata, construct_metadata_url,
+    to_v2_inference_request,
+    remote_metadata,
+    construct_metadata_url,
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntimeBase
 

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -8,7 +8,7 @@ from mlserver.codecs import NumpyCodec
 from mlserver_alibi_explain.common import (
     AlibiExplainSettings,
     remote_predict,
-    to_v2_inference_request, remote_metadata,
+    to_v2_inference_request, remote_metadata, construct_metadata_url,
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntimeBase
 
@@ -44,7 +44,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             self._model = self._load_from_uri(self._infer_impl)
 
         # get the metadata of the underlying inference model via v2 metadata endpoint
-        self.infer_metadata = remote_metadata()
+        self.infer_metadata = remote_metadata(construct_metadata_url(self.infer_uri))
 
         self.ready = True
         return self.ready
@@ -63,7 +63,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         # in the case of AnchorText, we have a list of strings instead though.
         # TODO: for now we only support v2 protocol, do we need more support?
 
-        v2_request = to_v2_inference_request(input_data)
+        v2_request = to_v2_inference_request(input_data, self.infer_metadata)
 
         v2_response = remote_predict(
             v2_payload=v2_request, predictor_url=self.infer_uri

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -1,10 +1,11 @@
-from typing import Type, Any, Dict, List, Union
+from typing import Type, Any, Dict, List, Union, Optional
 
 import numpy as np
 from alibi.api.interfaces import Explanation, Explainer
 
 from mlserver import ModelSettings
 from mlserver.codecs import NumpyCodec
+from mlserver.types import MetadataModelResponse
 from mlserver_alibi_explain.common import (
     AlibiExplainSettings,
     remote_predict,
@@ -31,7 +32,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         explainer_settings = AlibiExplainSettings(**extra)  # type: ignore
 
         self.infer_uri = explainer_settings.infer_uri
-        self.infer_metadata = None
+        self.infer_metadata: Optional[MetadataModelResponse] = None
 
         # TODO: validate the settings are ok with this specific explainer
         super().__init__(settings, explainer_settings)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -8,7 +8,7 @@ from mlserver.codecs import NumpyCodec
 from mlserver_alibi_explain.common import (
     AlibiExplainSettings,
     remote_predict,
-    to_v2_inference_request,
+    to_v2_inference_request, remote_metadata,
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntimeBase
 
@@ -29,6 +29,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         explainer_settings = AlibiExplainSettings(**extra)  # type: ignore
 
         self.infer_uri = explainer_settings.infer_uri
+        self.infer_metadata = None
 
         # TODO: validate the settings are ok with this specific explainer
         super().__init__(settings, explainer_settings)
@@ -41,6 +42,9 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             self._model = self._explainer_class(**init_parameters)  # type: ignore
         else:
             self._model = self._load_from_uri(self._infer_impl)
+
+        # get the metadata of the underlying inference model via v2 metadata endpoint
+        self.infer_metadata = remote_metadata()
 
         self.ready = True
         return self.ready

--- a/runtimes/alibi-explain/mlserver_alibi_explain/version.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/alibi-explain/setup.py
+++ b/runtimes/alibi-explain/setup.py
@@ -33,14 +33,7 @@ setup(
     author_email="hello@seldon.io",
     description="Alibi-Explain runtime for MLServer",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=[
-        "mlserver",
-        "alibi",
-        # Pin TF to avoid previous issues with 2.6.0 and 2.6.1.
-        # This should be removed when we move to a new version of alibi that
-        # would deal internally with TF versions
-        "tensorflow==2.6.2",
-    ],
+    install_requires=["mlserver", "alibi[shap]"],
     long_description=_load_description(),
     long_description_content_type="text/markdown",
     license="Apache 2.0",

--- a/runtimes/alibi-explain/setup.py
+++ b/runtimes/alibi-explain/setup.py
@@ -33,7 +33,14 @@ setup(
     author_email="hello@seldon.io",
     description="Alibi-Explain runtime for MLServer",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=["mlserver", "alibi[shap]"],
+    install_requires=[
+        "mlserver",
+        "alibi[shap]",
+        # Pin TF to avoid previous issues with 2.6.0 and 2.6.1.
+        # This should be removed when we move to a new version of alibi that
+        # would deal internally with TF versions
+        "tensorflow==2.6.2",
+    ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",
     license="Apache 2.0",

--- a/runtimes/alibi-explain/setup.py
+++ b/runtimes/alibi-explain/setup.py
@@ -36,10 +36,6 @@ setup(
     install_requires=[
         "mlserver",
         "alibi[shap]",
-        # Pin TF to avoid previous issues with 2.6.0 and 2.6.1.
-        # This should be removed when we move to a new version of alibi that
-        # would deal internally with TF versions
-        "tensorflow==2.6.2",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -143,10 +143,7 @@ async def anchor_image_runtime_with_remote_predict_patch(
         with patch(remote_metadata_mock_path) as remote_metadata:
 
             def mock_metadata(*args, **kwargs):
-                return MetadataModelResponse(
-                    name="dummy",
-                    platform="dummy"
-                )
+                return MetadataModelResponse(name="dummy", platform="dummy")
 
             def mock_predict(*args, **kwargs):
                 # note: sometimes the event loop is not running and in this case

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -30,7 +30,7 @@ from helpers.tf_model import TFMNISTModel, get_tf_mnist_model_uri
 nest_asyncio.apply()
 
 TESTS_PATH = Path(os.path.dirname(__file__))
-_ANCHOR_IMAGE_DIR = TESTS_PATH / "data" / "mnist_anchor_image"
+_ANCHOR_IMAGE_DIR = TESTS_PATH / ".data" / "mnist_anchor_image"
 
 
 # TODO: how to make this in utils?

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -19,6 +19,7 @@ from mlserver.registry import MultiModelRegistry
 from mlserver.repository import ModelRepository
 from mlserver.rest import RESTServer
 from mlserver.settings import ModelSettings, ModelParameters, Settings
+from mlserver.types import MetadataModelResponse
 from mlserver_alibi_explain.common import AlibiExplainSettings
 from mlserver_alibi_explain.runtime import AlibiExplainRuntime
 from helpers.tf_model import TFMNISTModel, get_tf_mnist_model_uri
@@ -136,45 +137,54 @@ async def anchor_image_runtime_with_remote_predict_patch(
     anchor_image_directory,
     custom_runtime_tf: MLModel,
     remote_predict_mock_path: str = "mlserver_alibi_explain.common.remote_predict",
+    remote_metadata_mock_path: str = "mlserver_alibi_explain.common.remote_metadata",
 ) -> AlibiExplainRuntime:
     with patch(remote_predict_mock_path) as remote_predict:
+        with patch(remote_metadata_mock_path) as remote_metadata:
 
-        def mock_predict(*args, **kwargs):
-            # note: sometimes the event loop is not running and in this case
-            # we create a new one otherwise
-            # we use the existing one.
-            # this mock implementation is required as we dont want to spin up a server,
-            # we just use MLModel.predict
-            try:
-                loop = asyncio.get_event_loop()
-                res = loop.run_until_complete(
-                    custom_runtime_tf.predict(kwargs["v2_payload"])
+            def mock_metadata(*args, **kwargs):
+                return MetadataModelResponse(
+                    name="dummy",
+                    platform="dummy"
                 )
-                return res
-            except Exception:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                res = loop.run_until_complete(
-                    custom_runtime_tf.predict(kwargs["v2_payload"])
-                )
-                return res
 
-        remote_predict.side_effect = mock_predict
+            def mock_predict(*args, **kwargs):
+                # note: sometimes the event loop is not running and in this case
+                # we create a new one otherwise
+                # we use the existing one.
+                # mock implementation is required as we dont want to spin up a server,
+                # we just use MLModel.predict
+                try:
+                    loop = asyncio.get_event_loop()
+                    res = loop.run_until_complete(
+                        custom_runtime_tf.predict(kwargs["v2_payload"])
+                    )
+                    return res
+                except Exception:
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+                    res = loop.run_until_complete(
+                        custom_runtime_tf.predict(kwargs["v2_payload"])
+                    )
+                    return res
 
-        rt = AlibiExplainRuntime(
-            ModelSettings(
-                parallel_workers=0,
-                parameters=ModelParameters(
-                    uri=str(anchor_image_directory),
-                    extra=AlibiExplainSettings(
-                        explainer_type="anchor_image", infer_uri="dummy_call"
+            remote_predict.side_effect = mock_predict
+            remote_metadata.side_effect = mock_metadata
+
+            rt = AlibiExplainRuntime(
+                ModelSettings(
+                    parallel_workers=0,
+                    parameters=ModelParameters(
+                        uri=str(anchor_image_directory),
+                        extra=AlibiExplainSettings(
+                            explainer_type="anchor_image", infer_uri="dummy_call"
+                        ),
                     ),
-                ),
+                )
             )
-        )
-        await rt.load()
+            await rt.load()
 
-        return rt
+            return rt
 
 
 @pytest.fixture

--- a/runtimes/alibi-explain/tests/helpers/tf_model.py
+++ b/runtimes/alibi-explain/tests/helpers/tf_model.py
@@ -12,7 +12,7 @@ from mlserver.codecs import NumpyCodec
 from mlserver.types import InferenceRequest, InferenceResponse
 
 
-_MODEL_PATH = Path(os.path.dirname(__file__)).parent / "data" / "tf_mnist" / "model.h5"
+_MODEL_PATH = Path(os.path.dirname(__file__)).parent / ".data" / "tf_mnist" / "model.h5"
 
 
 def get_tf_mnist_model_uri() -> Path:

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -20,7 +20,12 @@ from mlserver.types import (
     RequestOutput,
 )
 from mlserver_alibi_explain import AlibiExplainRuntime
-from mlserver_alibi_explain.common import convert_from_bytes, to_v2_inference_request
+from mlserver_alibi_explain.common import (
+    convert_from_bytes,
+    to_v2_inference_request,
+    _DEFAULT_INPUT_NAME,
+    _DEFAULT_ID_NAME,
+)
 
 TESTS_PATH = Path(os.path.dirname(__file__))
 
@@ -114,11 +119,12 @@ async def test_end_2_end(
             np.zeros([2, 4]),
             None,
             InferenceRequest(
+                id=_DEFAULT_ID_NAME,
                 parameters=Parameters(content_type=NumpyCodec.ContentType),
                 inputs=[
                     RequestInput(
                         parameters=Parameters(content_type=NumpyCodec.ContentType),
-                        name="predict",
+                        name=_DEFAULT_INPUT_NAME,
                         data=np.zeros([2, 4]).flatten().tolist(),
                         shape=[2, 4],
                         datatype="FP64",  # default for np.zeros
@@ -139,6 +145,7 @@ async def test_end_2_end(
                 ],
             ),
             InferenceRequest(
+                id=_DEFAULT_ID_NAME,
                 parameters=Parameters(content_type=NumpyCodec.ContentType),
                 inputs=[
                     RequestInput(
@@ -159,11 +166,12 @@ async def test_end_2_end(
             ["dummy", "dummy text"],
             None,
             InferenceRequest(
+                id=_DEFAULT_ID_NAME,
                 parameters=Parameters(content_type=StringCodec.ContentType),
                 inputs=[
                     RequestInput(
                         parameters=Parameters(content_type=StringCodec.ContentType),
-                        name="predict",
+                        name=_DEFAULT_INPUT_NAME,
                         data=["dummy", "dummy text"],
                         shape=[2, -1],
                         datatype="BYTES",

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pytest
@@ -24,10 +25,10 @@ from mlserver_alibi_explain.common import (
     convert_from_bytes,
     to_v2_inference_request,
     _DEFAULT_INPUT_NAME,
-    _DEFAULT_ID_NAME,
 )
 
 TESTS_PATH = Path(os.path.dirname(__file__))
+_DEFAULT_ID_NAME = "dummy_id"
 
 
 @pytest.fixture
@@ -181,6 +182,10 @@ async def test_end_2_end(
             ),
         ),
     ],
+)
+@patch(
+    "mlserver_alibi_explain.common.generate_uuid",
+    MagicMock(return_value=_DEFAULT_ID_NAME),
 )
 def test_encode_inference_request__as_expected(payload, metadata, expected_v2_request):
     encoded_request = to_v2_inference_request(payload, metadata)

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -11,8 +11,14 @@ from numpy.testing import assert_array_equal
 from helpers.tf_model import get_tf_mnist_model_uri
 from mlserver import MLModel
 from mlserver.codecs import NumpyCodec, StringCodec
-from mlserver.types import InferenceRequest, Parameters, RequestInput, \
-    MetadataModelResponse, MetadataTensor, RequestOutput
+from mlserver.types import (
+    InferenceRequest,
+    Parameters,
+    RequestInput,
+    MetadataModelResponse,
+    MetadataTensor,
+    RequestOutput,
+)
 from mlserver_alibi_explain import AlibiExplainRuntime
 from mlserver_alibi_explain.common import convert_from_bytes, to_v2_inference_request
 
@@ -123,44 +129,31 @@ async def test_end_2_end(
         ),
         # numpy with metadata
         (
-                np.zeros([2, 4]),
-                MetadataModelResponse(
-                    name="dummy",
-                    platform="dummy",
-                    inputs=[
-                        MetadataTensor(
-                            name="input_name",
-                            datatype="dummy",
-                            shape=[]
-                        )
-                    ],
-                    outputs=[
-                        MetadataTensor(
-                            name="output_name",
-                            datatype="dummy",
-                            shape=[]
-                        )
-                    ]
-                ),
-                InferenceRequest(
-                    parameters=Parameters(content_type=NumpyCodec.ContentType),
-                    inputs=[
-                        RequestInput(
-                            parameters=Parameters(content_type=NumpyCodec.ContentType),
-                            name="input_name",  # inserted from metadata above
-                            data=np.zeros([2, 4]).flatten().tolist(),
-                            shape=[2, 4],
-                            datatype="FP64",  # default for np.zeros
-                        )
-                    ],
-                    outputs=[
-                        RequestOutput(
-                            name="output_name"
-                        )
-                    ],  # inserted from metadata above
-                ),
+            np.zeros([2, 4]),
+            MetadataModelResponse(
+                name="dummy",
+                platform="dummy",
+                inputs=[MetadataTensor(name="input_name", datatype="dummy", shape=[])],
+                outputs=[
+                    MetadataTensor(name="output_name", datatype="dummy", shape=[])
+                ],
+            ),
+            InferenceRequest(
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
+                inputs=[
+                    RequestInput(
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
+                        name="input_name",  # inserted from metadata above
+                        data=np.zeros([2, 4]).flatten().tolist(),
+                        shape=[2, 4],
+                        datatype="FP64",  # default for np.zeros
+                    )
+                ],
+                outputs=[
+                    RequestOutput(name="output_name")
+                ],  # inserted from metadata above
+            ),
         ),
-
         # List[str] payload
         (
             ["dummy", "dummy text"],

--- a/runtimes/alibi-explain/tests/test_utils.py
+++ b/runtimes/alibi-explain/tests/test_utils.py
@@ -4,8 +4,11 @@ from unittest.mock import patch
 import pytest
 from fastapi import FastAPI
 
-from mlserver_alibi_explain.common import import_and_get_class, remote_metadata, \
-    construct_metadata_url
+from mlserver_alibi_explain.common import (
+    import_and_get_class,
+    remote_metadata,
+    construct_metadata_url,
+)
 from mlserver_alibi_explain.alibi_dependency_reference import _TAG_TO_RT_IMPL
 from fastapi.testclient import TestClient
 
@@ -17,7 +20,7 @@ def test_can_load_runtime_impl(explainer_reference):
 
 
 class _TestClientWrapper:
-    def __init__(self, data:Dict):
+    def __init__(self, data: Dict):
         self.response = data
 
     def get_test_client(self):
@@ -39,21 +42,12 @@ class _TestClientWrapper:
                 "versions": ["1"],
                 "platform": "tensorflow_savedmodel",
                 "inputs": [
-                    {
-                        "name": "input_1",
-                        "datatype": "FP32",
-                        "shape": [-1, 32, 32, 3]}
+                    {"name": "input_1", "datatype": "FP32", "shape": [-1, 32, 32, 3]}
                 ],
-                "outputs": [
-                    {
-                        "name": "fc10",
-                        "datatype": "FP32",
-                        "shape": [-1, 10]
-                    }
-                ]
+                "outputs": [{"name": "fc10", "datatype": "FP32", "shape": [-1, 10]}],
             },
             "input_1",
-            "cifar10"
+            "cifar10",
         ),
         (
             {
@@ -61,12 +55,12 @@ class _TestClientWrapper:
                 "versions": [],
                 "platform": "",
                 "inputs": [],
-                "outputs": []
+                "outputs": [],
             },
             None,
-            "classifier"
-        )
-    ]
+            "classifier",
+        ),
+    ],
 )
 def test_remote_metadata__smoke(data, expected_input_name, expected_name):
     with patch("mlserver_alibi_explain.common.requests") as mock_requests:
@@ -86,7 +80,7 @@ def test_remote_metadata__smoke(data, expected_input_name, expected_name):
         ("http://v2/model/infer", "http://v2/model"),
         ("http://v2/infer/infer", "http://v2/infer"),
         ("http://v2/model", "http://v2/model"),
-    ]
+    ],
 )
 def test_metadata_url_from_infer_url(infer_url, metadata_url):
     assert construct_metadata_url(infer_url) == metadata_url

--- a/runtimes/alibi-explain/tests/test_utils.py
+++ b/runtimes/alibi-explain/tests/test_utils.py
@@ -1,10 +1,63 @@
-import pytest
+from unittest.mock import patch
 
-from mlserver_alibi_explain.common import import_and_get_class
+import pytest
+from fastapi import FastAPI
+
+from mlserver_alibi_explain.common import import_and_get_class, remote_metadata, \
+    construct_metadata_url
 from mlserver_alibi_explain.alibi_dependency_reference import _TAG_TO_RT_IMPL
+from fastapi.testclient import TestClient
 
 
 @pytest.mark.parametrize("explainer_reference", _TAG_TO_RT_IMPL.values())
 def test_can_load_runtime_impl(explainer_reference):
     import_and_get_class(explainer_reference.runtime_class)
     import_and_get_class(explainer_reference.alibi_class)
+
+
+@pytest.fixture()
+def test_client() -> TestClient:
+    app = FastAPI()
+
+    @app.get("/")
+    async def metadata():
+        return {
+            "name": "cifar10",
+            "versions": ["1"],
+            "platform": "tensorflow_savedmodel",
+            "inputs": [
+                {
+                    "name": "input_1",
+                    "datatype": "FP32",
+                    "shape": [-1, 32, 32, 3]}
+            ],
+            "outputs": [
+                {
+                    "name": "fc10",
+                    "datatype": "FP32",
+                    "shape": [-1, 10]
+                }
+            ]
+        }
+
+    return TestClient(app)
+
+
+def test_remote_metadata__smoke(test_client):
+    with patch("mlserver_alibi_explain.common.requests") as mock_requests:
+        mock_requests.get = test_client.get
+        result = remote_metadata("/")
+        assert result.inputs[0].name == "input_1"
+        assert result.name == "cifar10"
+
+
+@pytest.mark.parametrize(
+    "infer_url, metadata_url",
+    [
+        ("http://v2/model/infer", "http://v2/model"),
+        ("http://v2/infer/infer", "http://v2/infer"),
+        ("http://v2/model", "http://v2/model"),
+    ]
+)
+def test_metadata_url_from_infer_url(infer_url, metadata_url):
+    assert construct_metadata_url(infer_url) == metadata_url

--- a/runtimes/lightgbm/mlserver_lightgbm/version.py
+++ b/runtimes/lightgbm/mlserver_lightgbm/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/mlflow/mlserver_mlflow/version.py
+++ b/runtimes/mlflow/mlserver_mlflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/mllib/mlserver_mllib/version.py
+++ b/runtimes/mllib/mlserver_mllib/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/sklearn/mlserver_sklearn/version.py
+++ b/runtimes/sklearn/mlserver_sklearn/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"

--- a/runtimes/xgboost/mlserver_xgboost/version.py
+++ b/runtimes/xgboost/mlserver_xgboost/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev3"
+__version__ = "0.6.0.dev4"


### PR DESCRIPTION
Fetch metadata from v2 endpoint inference model and use the info to construct the internal inference request from alibi explain model.

Also in this pr:
- upgrade to alibi 0.6.2
- bump mlserver version to 0.6.0.dev4
- add KernelShap explainer