### PR TITLE
Sherif akoush/quickfix/explainer output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ html_title = "MLServer Documentation"
 author = "Seldon Technologies"
 
 # The full version, including alpha/beta/rc tags
-release = "0.6.0.dev4"
+release = "0.6.0.dev5"
 
 
 # -- General configuration ---------------------------------------------------

--- a/mlserver/version.py
+++ b/mlserver/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/alibi-detect/mlserver_alibi_detect/version.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -53,11 +53,13 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         return self.ready
 
     def _explain_impl(self, input_data: Any, explain_parameters: Dict) -> Explanation:
-        if type(input_data) == list:
-            # if we get a list of strings, we can only explain the first elem and there
-            # is no way of just sending a plain string in v2, it has to be in a list
-            # as the encoding is List[str] with content_type "BYTES"
-            input_data = input_data[0]
+
+        # if we get a list of strings, we can only explain the first elem and there
+        # is no way of just sending a plain string in v2, it has to be in a list
+        # as the encoding is List[str] with content_type "BYTES"
+        # we also assume that the explain data will contain a batch dimession, and in
+        # current implementation we will only explain the first data element.
+        input_data = input_data[0]
 
         return self._model.explain(input_data, **explain_parameters)
 

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -61,7 +61,7 @@ class AlibiExplainRuntimeBase(MLModel):
         """
         # convert raw to v2
         raw_data = await request.body()
-        payload = InferenceRequest.parse_raw(json.loads(raw_data))
+        payload = InferenceRequest.parse_raw(raw_data)
 
         v2_response = await self.predict(payload)
         explanation = orjson.dumps(json.loads(v2_response.outputs[0].data.__root__))

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -1,10 +1,8 @@
 import json
 from typing import Any, Optional, List, Dict
 
-import orjson
 from alibi.api.interfaces import Explanation, Explainer
 from alibi.saving import load_explainer
-from starlette.requests import Request
 
 from mlserver.codecs import (
     NumpyRequestCodec,

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -51,7 +51,7 @@ class AlibiExplainRuntimeBase(MLModel):
         self.alibi_explain_settings = explainer_settings
         super().__init__(settings)
 
-    @custom_handler(rest_path="/explain_v1_output")
+    @custom_handler(rest_path="/explain")
     async def explain_v1_output(self, request: Request) -> Response:
         """
         A custom endpoint to return explanation results in plain json format (no v2
@@ -198,4 +198,3 @@ class AlibiExplainRuntime(MLModel):
 
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
         return await self._rt.predict(payload)
-

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -5,7 +5,6 @@ import orjson
 from alibi.api.interfaces import Explanation, Explainer
 from alibi.saving import load_explainer
 from starlette.requests import Request
-from starlette.responses import Response
 
 from mlserver.codecs import (
     NumpyRequestCodec,
@@ -16,6 +15,7 @@ from mlserver.codecs import (
 from mlserver.errors import ModelParametersMissing, InvalidModelURI
 from mlserver.handlers import custom_handler
 from mlserver.model import MLModel
+from mlserver.rest.responses import Response
 from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import (
     InferenceRequest,
@@ -64,7 +64,7 @@ class AlibiExplainRuntimeBase(MLModel):
         payload = InferenceRequest.parse_raw(raw_data)
 
         v2_response = await self.predict(payload)
-        explanation = orjson.dumps(json.loads(v2_response.outputs[0].data.__root__))
+        explanation = json.loads(v2_response.outputs[0].data.__root__)
 
         return Response(content=explanation, media_type="application/json")
 
@@ -198,8 +198,8 @@ class AlibiExplainRuntime(MLModel):
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
         return await self._rt.predict(payload)
 
-    # we add explain_v1_output here to enable the registration and routing of custom
+    # we add _explain_v1_output here to enable the registration and routing of custom
     # endpoint to `_rt.explain_v1_output`
     @custom_handler(rest_path="/explain")
-    async def explain_v1_output(self, request: Request) -> Response:
+    async def _explain_v1_output(self, request: Request) -> Response:
         return await self._rt.explain_v1_output(request)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -26,16 +26,16 @@ from mlserver.types import (
     MetadataTensor,
     ResponseOutput,
 )
+from mlserver_alibi_explain.alibi_dependency_reference import (
+    get_mlmodel_class_as_str,
+    get_alibi_class_as_str,
+)
 from mlserver_alibi_explain.common import (
     execute_async,
     AlibiExplainSettings,
     import_and_get_class,
     EXPLAIN_PARAMETERS_TAG,
     EXPLAINER_TYPE_TAG,
-)
-from mlserver_alibi_explain.alibi_dependency_reference import (
-    get_mlmodel_class_as_str,
-    get_alibi_class_as_str,
 )
 
 
@@ -51,7 +51,6 @@ class AlibiExplainRuntimeBase(MLModel):
         self.alibi_explain_settings = explainer_settings
         super().__init__(settings)
 
-    @custom_handler(rest_path="/explain")
     async def explain_v1_output(self, request: Request) -> Response:
         """
         A custom endpoint to return explanation results in plain json format (no v2
@@ -198,3 +197,9 @@ class AlibiExplainRuntime(MLModel):
 
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
         return await self._rt.predict(payload)
+
+    # we add explain_v1_output here to enable the registration and routing of custom
+    # endpoint to `_rt.explain_v1_output`
+    @custom_handler(rest_path="/explain")
+    async def explain_v1_output(self, request: Request) -> Response:
+        return await self._rt.explain_v1_output(request)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/version.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/alibi-explain/setup.py
+++ b/runtimes/alibi-explain/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "mlserver",
         "alibi[shap]",
+        "orjson",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -245,7 +245,8 @@ async def dummy_alibi_explain_client(tmp_path, settings) -> TestClient:
 
 
 async def _build_rest_server_with_dummy_explain_model(
-        rt: AlibiExplainRuntime, settings: Settings, tmp_path: Path) -> RESTServer:
+    rt: AlibiExplainRuntime, settings: Settings, tmp_path: Path
+) -> RESTServer:
     model_registry = MultiModelRegistry()
     await model_registry.load(rt)
     data_plane = DataPlane(settings=settings, model_registry=model_registry)

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -2,17 +2,18 @@ import asyncio
 import json
 import os
 from pathlib import Path
-from typing import AsyncIterable
+from typing import AsyncIterable, Dict, Any
 from unittest.mock import patch
-
-import tensorflow as tf
 
 import nest_asyncio
 import pytest
+import tensorflow as tf
+from alibi.api.interfaces import Explanation
 from alibi.explainers import AnchorImage
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from helpers.tf_model import TFMNISTModel, get_tf_mnist_model_uri
 from mlserver import MLModel
 from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
@@ -21,8 +22,7 @@ from mlserver.rest import RESTServer
 from mlserver.settings import ModelSettings, ModelParameters, Settings
 from mlserver.types import MetadataModelResponse
 from mlserver_alibi_explain.common import AlibiExplainSettings
-from mlserver_alibi_explain.runtime import AlibiExplainRuntime
-from helpers.tf_model import TFMNISTModel, get_tf_mnist_model_uri
+from mlserver_alibi_explain.runtime import AlibiExplainRuntime, AlibiExplainRuntimeBase
 
 # allow nesting loop
 # in our case this allows multiple runtimes to execute
@@ -201,6 +201,70 @@ async def integrated_gradients_runtime() -> AlibiExplainRuntime:
     await rt.load()
 
     return rt
+
+
+@pytest.yield_fixture
+async def dummy_alibi_explain_client(tmp_path, settings) -> TestClient:
+    rt = AlibiExplainRuntime(
+        ModelSettings(
+            parallel_workers=0,
+            parameters=ModelParameters(
+                extra=AlibiExplainSettings(
+                    explainer_type="anchor_image", infer_uri="dummy_call"
+                ),
+            ),
+        )
+    )
+
+    # dummy inner runtime
+    class _DummyExplainer(AlibiExplainRuntimeBase):
+        def _explain_impl(
+            self, input_data: Any, explain_parameters: Dict
+        ) -> Explanation:
+            return Explanation(meta={}, data={})
+
+    _rt = _DummyExplainer(
+        settings=ModelSettings(name="dummy_name"),
+        explainer_settings=AlibiExplainSettings(
+            infer_uri="dummy_call",
+            explainer_type="anchor_image",
+            init_parameters=None,
+        ),
+    )
+
+    # set the actual runtime inside wrapper to the dummy runtime we created
+    rt._rt = _rt
+
+    model_registry = MultiModelRegistry()
+    await model_registry.load(rt)
+
+    data_plane = DataPlane(settings=settings, model_registry=model_registry)
+
+    model_settings_path = tmp_path.joinpath("model-settings.json")
+    model_settings_dict = {
+        "name": rt.settings.name,
+        "implementation": "mlserver_alibi_explain.AlibiExplainRuntime",
+        "parallel_workers": 0,
+    }
+
+    model_settings_path.write_text(json.dumps(model_settings_dict, indent=4))
+    model_repository = ModelRepository(tmp_path)
+
+    handlers = ModelRepositoryHandlers(
+        repository=model_repository, model_registry=model_registry
+    )
+
+    server = RESTServer(
+        settings=settings,
+        data_plane=data_plane,
+        model_repository_handlers=handlers,
+    )
+
+    await asyncio.gather(server.add_custom_handlers(rt))
+
+    yield TestClient(server._app)
+
+    await asyncio.gather(server.delete_custom_handlers(rt))
 
 
 def _train_anchor_image_explainer() -> None:

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -204,7 +204,7 @@ async def integrated_gradients_runtime() -> AlibiExplainRuntime:
 
 
 @pytest.yield_fixture
-async def dummy_alibi_explain_client(tmp_path, settings) -> TestClient:
+async def dummy_alibi_explain_client(tmp_path, settings) -> AsyncIterable[TestClient]:
     rt = AlibiExplainRuntime(
         ModelSettings(
             parallel_workers=0,
@@ -257,7 +257,7 @@ async def _build_rest_server_with_dummy_explain_model(
         "parallel_workers": 0,
     }
     model_settings_path.write_text(json.dumps(model_settings_dict, indent=4))
-    model_repository = ModelRepository(tmp_path)
+    model_repository = ModelRepository(str(tmp_path))
     handlers = ModelRepositoryHandlers(
         repository=model_repository, model_registry=model_registry
     )

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -49,13 +49,16 @@ async def test_integrated_gradients__smoke(
         ],
     )
     response = await integrated_gradients_runtime.predict(inference_request)
-    _ = convert_from_bytes(response.outputs[0], ty=str)
+    res = convert_from_bytes(response.outputs[0], ty=str)
+    res_dict = json.dumps(res)
+    assert "meta" in res_dict
+    assert "data" in res_dict
 
 
 async def test_anchors__smoke(
     anchor_image_runtime_with_remote_predict_patch: AlibiExplainRuntime,
 ):
-    data = np.random.randn(28, 28, 1) * 255
+    data = np.random.randn(1, 28, 28, 1) * 255
     inference_request = InferenceRequest(
         parameters=Parameters(
             content_type=NumpyCodec.ContentType,
@@ -108,7 +111,7 @@ def test_remote_predict__smoke(custom_runtime_tf, rest_client):
 
 async def test_alibi_runtime_wrapper(custom_runtime_tf: MLModel):
     """
-    Checks that the wrappers returns back the expected valued from the underlying rt
+    Checks that the wrapper returns back the expected valued from the underlying rt
     """
 
     class _MockInit(AlibiExplainRuntime):
@@ -128,7 +131,7 @@ async def test_alibi_runtime_wrapper(custom_runtime_tf: MLModel):
         ],
     )
 
-    # settings is dummy and discarded
+    # settings object is dummy and discarded
     wrapper = _MockInit(ModelSettings())
 
     assert wrapper.settings == custom_runtime_tf.settings

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -231,7 +231,7 @@ async def test_custom_explain_endpoint(dummy_alibi_explain_client):
     )
 
     response = dummy_alibi_explain_client.post(
-        "/explain", json=inference_request.json()
+        "/explain", json=inference_request.dict()
     )
     response_text = json.loads(response.text)
     assert "meta" in response_text

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -213,3 +213,26 @@ async def test_explain_parameters_pass_through():
 
     res = await rt.predict(inference_request)
     assert isinstance(res, InferenceResponse)
+
+
+async def test_custom_explain_endpoint(dummy_alibi_explain_client):
+    # a test for `/explain` endpoint that returns raw explanation directly
+    data = np.random.randn(1, 1)
+    inference_request = InferenceRequest(
+        parameters=Parameters(content_type=NumpyCodec.ContentType),
+        inputs=[
+            RequestInput(
+                name="predict",
+                shape=data.shape,
+                data=data.tolist(),
+                datatype="FP32",
+            )
+        ],
+    )
+
+    response = dummy_alibi_explain_client.post(
+        "/explain", json=inference_request.json()
+    )
+    response_text = json.loads(response.text)
+    assert "meta" in response_text
+    assert "data" in response_text

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -121,17 +121,9 @@ async def test_end_2_end_explain_v1_output(
 ):
     # in this test we get raw explanation as opposed to v2
 
-    async def _receive():
-        return {
-            "type": "http.request",
-            "body": json.dumps(payload.dict()).encode("utf-8"),
-        }
-
-    request = Request(scope={"type": "http"}, receive=_receive)
-
     response = (
         await anchor_image_runtime_with_remote_predict_patch._rt.explain_v1_output(
-            request
+            payload
         )
     )
 

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -129,10 +129,11 @@ async def test_end_2_end_explain_v1_output(
 
     request = Request(scope={"type": "http"}, receive=_receive)
 
-    response = await \
-        anchor_image_runtime_with_remote_predict_patch._rt.explain_v1_output(
+    response = (
+        await anchor_image_runtime_with_remote_predict_patch._rt.explain_v1_output(
             request
         )
+    )
 
     response_body = json.loads(response.body)
     assert "meta" in response_body

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -124,7 +124,7 @@ async def test_end_2_end_explain_v1_output(
     async def _receive():
         return {
             "type": "http.request",
-            "body": json.dumps(payload.json()).encode("utf-8"),
+            "body": json.dumps(payload.dict()).encode("utf-8"),
         }
 
     request = Request(scope={"type": "http"}, receive=_receive)

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -8,6 +8,7 @@ import pytest
 import tensorflow as tf
 from alibi.saving import load_explainer
 from numpy.testing import assert_array_equal
+from starlette.requests import Request
 
 from helpers.tf_model import get_tf_mnist_model_uri
 from mlserver import MLModel
@@ -33,7 +34,7 @@ _DEFAULT_ID_NAME = "dummy_id"
 
 @pytest.fixture
 def payload() -> InferenceRequest:
-    data = np.random.randn(28, 28, 1) * 255
+    data = np.random.randn(1, 28, 28, 1) * 255
 
     # now we go via the inference model and see if we get the same results
     inference_request = InferenceRequest(
@@ -95,7 +96,7 @@ async def test_end_2_end(
     alibi_anchor_image_model,
     payload: InferenceRequest,
 ):
-    # in this test we are getting explanation and making sure that it the same one
+    # in this test we are getting explanation and making sure that is the same one
     # as returned by alibi directly
     runtime_result = await anchor_image_runtime_with_remote_predict_patch.predict(
         payload
@@ -104,12 +105,38 @@ async def test_end_2_end(
         convert_from_bytes(runtime_result.outputs[0], ty=str)
     )
     alibi_result = alibi_anchor_image_model.explain(
-        NumpyCodec.decode(payload.inputs[0])
+        NumpyCodec.decode(payload.inputs[0])[0]  # payload has batch dimension,
+        # we remove it for alibi
     )
 
     assert_array_equal(
         np.array(decoded_runtime_results["data"]["anchor"]), alibi_result.data["anchor"]
     )
+
+
+async def test_end_2_end_explain_v1_output(
+    anchor_image_runtime_with_remote_predict_patch: AlibiExplainRuntime,
+    alibi_anchor_image_model,
+    payload: InferenceRequest,
+):
+    # in this test we get raw explanation as opposed to v2
+
+    async def _receive():
+        return {
+            "type": "http.request",
+            "body": json.dumps(payload.json()).encode("utf-8"),
+        }
+
+    request = Request(scope={"type": "http"}, receive=_receive)
+
+    response = await \
+        anchor_image_runtime_with_remote_predict_patch._rt.explain_v1_output(
+            request
+        )
+
+    response_body = json.loads(response.body)
+    assert "meta" in response_body
+    assert "data" in response_body
 
 
 @pytest.mark.parametrize(

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -8,7 +8,6 @@ import pytest
 import tensorflow as tf
 from alibi.saving import load_explainer
 from numpy.testing import assert_array_equal
-from starlette.requests import Request
 
 from helpers.tf_model import get_tf_mnist_model_uri
 from mlserver import MLModel

--- a/runtimes/lightgbm/mlserver_lightgbm/version.py
+++ b/runtimes/lightgbm/mlserver_lightgbm/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/mlflow/mlserver_mlflow/version.py
+++ b/runtimes/mlflow/mlserver_mlflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/mllib/mlserver_mllib/version.py
+++ b/runtimes/mllib/mlserver_mllib/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/sklearn/mlserver_sklearn/version.py
+++ b/runtimes/sklearn/mlserver_sklearn/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"

--- a/runtimes/xgboost/mlserver_xgboost/version.py
+++ b/runtimes/xgboost/mlserver_xgboost/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0.dev4"
+__version__ = "0.6.0.dev5"


### PR DESCRIPTION
add a custom endpoint `/explain` for alibi runtime for backward compatibility with legacy downstream users.