### PR TITLE
Fix gRPC encoding for BYTES payloads

### DIFF
--- a/mlserver/codecs/base64.py
+++ b/mlserver/codecs/base64.py
@@ -5,7 +5,7 @@ from typing import List
 
 from ..types import RequestInput, ResponseOutput
 from .base import InputCodec, register_input_codec
-from .pack import pack, unpack, PackElement
+from .pack import unpack, PackElement
 
 _Base64StrCodec = "ascii"
 

--- a/mlserver/codecs/base64.py
+++ b/mlserver/codecs/base64.py
@@ -44,17 +44,17 @@ class Base64Codec(InputCodec):
     @classmethod
     def encode(cls, name: str, payload: List[bytes]) -> ResponseOutput:
         # Assume that payload is already in b64, so we only need to pack it
-        packed, shape = pack(map(_encode_base64, payload))
+        packed = map(_encode_base64, payload)
+        shape = [len(payload)]
         return ResponseOutput(
             name=name,
             datatype="BYTES",
             shape=shape,
-            data=packed,
+            data=list(packed),
         )
 
     @classmethod
     def decode(cls, request_input: RequestInput) -> List[bytes]:
         packed = request_input.data.__root__
-        shape = request_input.shape
 
-        return list(map(_decode_base64, unpack(packed, shape)))
+        return list(map(_decode_base64, unpack(packed)))

--- a/mlserver/codecs/datetime.py
+++ b/mlserver/codecs/datetime.py
@@ -45,17 +45,17 @@ class DatetimeCodec(InputCodec):
     @classmethod
     def encode(cls, name: str, payload: List[_Datetime]) -> ResponseOutput:
         # Assume that payload is already in b64, so we only need to pack it
-        packed, shape = pack(map(_encode_datetime, payload))
+        packed = map(_encode_datetime, payload)
+        shape = [len(payload)]
         return ResponseOutput(
             name=name,
             datatype="BYTES",
             shape=shape,
-            data=packed,
+            data=list(packed),
         )
 
     @classmethod
     def decode(cls, request_input: RequestInput) -> List[datetime]:
         packed = request_input.data.__root__
-        shape = request_input.shape
 
-        return list(map(_decode_datetime, unpack(packed, shape)))
+        return list(map(_decode_datetime, unpack(packed)))

--- a/mlserver/codecs/datetime.py
+++ b/mlserver/codecs/datetime.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from ..types import RequestInput, ResponseOutput
 from .base import InputCodec, register_input_codec
-from .pack import pack, unpack, PackElement
+from .pack import unpack, PackElement
 
 _Datetime = Union[str, datetime]
 _DatetimeStrCodec = "ascii"

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from typing import Any, Union
+from typing import Union
 
 from ..types import RequestInput, ResponseOutput, Parameters
 

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -59,16 +59,22 @@ def _to_ndarray(v2_data: Union[RequestInput, ResponseOutput]) -> np.ndarray:
     dtype = _to_dtype(v2_data)
 
     if v2_data.datatype == "BYTES":
-        return np.frombuffer(data, dtype)
+        # If the inputs is of type `BYTES`, there could be multiple "lists"
+        # serialised into multiple buffers.
+        # We will deserialise all of them and concatenate them together.
+        decoded = [np.frombuffer(buffer, dtype) for buffer in data]
+        return np.concatenate(decoded)
 
     return np.array(data, dtype)
 
 
-def _encode_data(data: np.ndarray, datatype: str) -> Any:
+def _encode_data(data: np.ndarray, datatype: str) -> list:
     if datatype == "BYTES":
-        # tobytes is way faster than tolist, although it's harder to serialise
-        # and only makes sense for actual bytes inputs (#253)
-        return data.tobytes()
+        # `tobytes` is way faster than tolist, although it's harder to serialise
+        # and only makes sense for actual bytes inputs (#253).
+        # Note that `.tobytes()` will return a single `bytes` payload, thus we
+        # need to encapsulate it into a list so that it's compatible.
+        return [data.tobytes()]
 
     return data.flatten().tolist()
 

--- a/mlserver/codecs/pack.py
+++ b/mlserver/codecs/pack.py
@@ -12,26 +12,3 @@ def unpack(packed: PackedPayload) -> Generator[PackElement, None, None]:
     else:
         # If there is no shape, assume that it's a single element
         yield packed
-
-
-def pack(unpacked: Iterable[bytes]) -> Tuple[PackedPayload, List[int]]:
-    packed = b""
-    common_length = -1
-    N = 0
-    for elem in unpacked:
-        # TODO: Should we use the length of the UTF8 string or the bytes
-        # array?
-        elem_length = len(elem)
-        if common_length == -1:
-            common_length = elem_length
-
-        if common_length != elem_length:
-            # TODO: Raise an error here
-            # TODO: Should we try to add padding?
-            pass
-
-        N += 1
-        packed += elem
-
-    shape = [N, common_length]
-    return packed, shape

--- a/mlserver/codecs/pack.py
+++ b/mlserver/codecs/pack.py
@@ -1,4 +1,4 @@
-from typing import Generator, Union, Iterable, List, Tuple
+from typing import Generator, Union, List
 
 
 PackElement = Union[bytes, str]

--- a/mlserver/codecs/pack.py
+++ b/mlserver/codecs/pack.py
@@ -5,22 +5,13 @@ PackElement = Union[bytes, str]
 PackedPayload = Union[PackElement, List[PackElement]]
 
 
-def unpack(
-    packed: PackedPayload, shape: List[int]
-) -> Generator[PackElement, None, None]:
+def unpack(packed: PackedPayload) -> Generator[PackElement, None, None]:
     if isinstance(packed, list):
         # If it's a list, assume list of strings
         yield from packed
     else:
-        if len(shape) == 0:
-            # If there is no shape, assume that it's a single element
-            yield packed
-        else:
-            # Otherwise, assume content is a concatenated list of same-length
-            # strings and get the common length from the shape
-            common_length = shape[-1]
-            for i in range(0, len(packed), common_length):
-                yield packed[i : i + common_length]
+        # If there is no shape, assume that it's a single element
+        yield packed
 
 
 def pack(unpacked: Iterable[bytes]) -> Tuple[PackedPayload, List[int]]:

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -4,7 +4,9 @@ import numpy as np
 
 from .base import RequestCodec, register_request_codec
 from .numpy import to_datatype
+from .string import encode_str
 from .utils import get_decoded_or_raw
+from .pack import PackElement
 from ..types import InferenceRequest, InferenceResponse, RequestInput, ResponseOutput
 
 
@@ -18,12 +20,29 @@ def _to_series(request_input: RequestInput) -> pd.Series:
 
 
 def _to_response_output(series: pd.Series) -> ResponseOutput:
+    datatype = to_datatype(series.dtype)
+    data = series.tolist()
+
+    # TODO: Support content types from metadata when decoding series
+    if datatype == "BYTES":
+        # To ensure that "string" columns can be encoded in gRPC, we need to
+        # encode them as bytes
+        data = list(map(_ensure_bytes, data))
+
     return ResponseOutput(
         name=series.name,
         shape=list(series.shape),
-        data=series.tolist(),
-        datatype=to_datatype(series.dtype),
+        # If string, it should be encoded to bytes
+        data=data,
+        datatype=datatype,
     )
+
+
+def _ensure_bytes(elem: PackElement) -> bytes:
+    if isinstance(elem, str):
+        return encode_str(elem)
+
+    return elem
 
 
 @register_request_codec

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -9,7 +9,7 @@ from .pack import unpack, PackElement
 _DefaultStrCodec = "utf-8"
 
 
-def _encode_str(elem: str) -> bytes:
+def encode_str(elem: str) -> bytes:
     return elem.encode(_DefaultStrCodec)
 
 
@@ -35,7 +35,7 @@ class StringCodec(InputCodec):
 
     @classmethod
     def encode(cls, name: str, payload: List[str]) -> ResponseOutput:
-        packed = map(_encode_str, payload)
+        packed = map(encode_str, payload)
         shape = [len(payload)]
         return ResponseOutput(
             name=name,

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -4,7 +4,7 @@ from ..types import RequestInput, ResponseOutput, Parameters
 
 from .utils import FirstInputRequestCodec
 from .base import InputCodec, register_input_codec, register_request_codec
-from .pack import pack, unpack, PackElement
+from .pack import unpack, PackElement
 
 _DefaultStrCodec = "utf-8"
 
@@ -35,20 +35,20 @@ class StringCodec(InputCodec):
 
     @classmethod
     def encode(cls, name: str, payload: List[str]) -> ResponseOutput:
-        packed, shape = pack(map(_encode_str, payload))
+        packed = map(_encode_str, payload)
+        shape = [len(payload)]
         return ResponseOutput(
             name=name,
             datatype="BYTES",
             shape=shape,
-            data=packed,
+            data=list(packed),
         )
 
     @classmethod
     def decode(cls, request_input: RequestInput) -> List[str]:
         packed = request_input.data.__root__
-        shape = request_input.shape
 
-        unpacked = map(_decode_str, unpack(packed, shape))
+        unpacked = map(_decode_str, unpack(packed))
         return list(unpacked)
 
     @classmethod
@@ -59,7 +59,7 @@ class StringCodec(InputCodec):
         return RequestInput(
             name=name,
             datatype="BYTES",
-            shape=[len(payload), -1],  # this is discarded downstream?
+            shape=[len(payload)],  # this is discarded downstream?
             data=payload,
             parameters=Parameters(content_type=cls.ContentType),
         )

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -13,7 +13,7 @@ def encode_str(elem: str) -> bytes:
     return elem.encode(_DefaultStrCodec)
 
 
-def _decode_str(encoded: PackElement, str_codec=_DefaultStrCodec) -> str:
+def decode_str(encoded: PackElement, str_codec=_DefaultStrCodec) -> str:
     if isinstance(encoded, bytes):
         return encoded.decode(str_codec)
 
@@ -48,7 +48,7 @@ class StringCodec(InputCodec):
     def decode(cls, request_input: RequestInput) -> List[str]:
         packed = request_input.data.__root__
 
-        unpacked = map(_decode_str, unpack(packed))
+        unpacked = map(decode_str, unpack(packed))
         return list(unpacked)
 
     @classmethod

--- a/mlserver/errors.py
+++ b/mlserver/errors.py
@@ -26,11 +26,6 @@ class InferenceError(MLServerError):
         super().__init__(msg)
 
 
-class RemoteInferenceError(MLServerError):
-    def __init__(self, code: int, reason: str):
-        super().__init__(f"Remote inference call failed with {code}, {reason}")
-
-
 class ModelParametersMissing(MLServerError):
     def __init__(self, model_name: str):
         super().__init__(f"Parameters missing for model {model_name}")

--- a/mlserver/rest/responses.py
+++ b/mlserver/rest/responses.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from starlette.responses import JSONResponse as _JSONResponse
 
+from ..codecs.string import decode_str
+
 try:
     import orjson
 except ImportError:
@@ -23,4 +25,13 @@ class Response(_JSONResponse):
         # This is equivalent to the ORJSONResponse implementation in FastAPI:
         # https://github.com/tiangolo/fastapi/blob/
         # 864643ef7608d28ac4ed321835a7fb4abe3dfc13/fastapi/responses.py#L32-L34
-        return orjson.dumps(content)
+        return orjson.dumps(content, default=_encode_bytes)
+
+
+def _encode_bytes(obj: Any) -> str:
+    if isinstance(obj, bytes):
+        # If we get a bytes payload, try to decode it back to a string as a
+        # "best effort"
+        return decode_str(obj)
+
+    raise TypeError

--- a/mlserver/rest/responses.py
+++ b/mlserver/rest/responses.py
@@ -1,3 +1,5 @@
+import json
+
 from typing import Any
 
 from starlette.responses import JSONResponse as _JSONResponse
@@ -10,6 +12,16 @@ except ImportError:
     orjson = None  # type: ignore
 
 
+class BytesJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            # If we get a bytes payload, try to decode it back to a string on a
+            # "best effort" basis
+            return decode_str(obj)
+
+        return super().default(self, obj)
+
+
 class Response(_JSONResponse):
     """
     Custom Response class to use `orjson` if present.
@@ -20,7 +32,19 @@ class Response(_JSONResponse):
 
     def render(self, content: Any) -> bytes:
         if orjson is None:
-            return super().render(content)
+            # Original implementation of starlette's JSONResponse, using our
+            # custom encoder (capable of "encoding" bytes).
+            # Original implementation can be seen here:
+            # https://github.com/encode/starlette/blob/
+            # f53faba229e3fa2844bc3753e233d9c1f54cca52/starlette/responses.py#L173-L180
+            return json.dumps(
+                content,
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=None,
+                separators=(",", ":"),
+                cls=BytesJSONEncoder,
+            ).encode("utf-8")
 
         # This is equivalent to the ORJSONResponse implementation in FastAPI:
         # https://github.com/tiangolo/fastapi/blob/
@@ -29,9 +53,12 @@ class Response(_JSONResponse):
 
 
 def _encode_bytes(obj: Any) -> str:
+    """
+    Add compatibility with `bytes` payloads to `orjson`
+    """
     if isinstance(obj, bytes):
-        # If we get a bytes payload, try to decode it back to a string as a
-        # "best effort"
+        # If we get a bytes payload, try to decode it back to a string on a
+        # "best effort" basis
         return decode_str(obj)
 
     raise TypeError

--- a/runtimes/alibi-detect/mlserver_alibi_detect/protocols/request_handler.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/protocols/request_handler.py
@@ -12,7 +12,7 @@ class RequestHandler(object):
         """
         raise NotImplementedError
 
-    def extract_request(self) -> np.array:
+    def extract_request(self) -> np.ndarray:
         """
         Extract the request
 

--- a/runtimes/alibi-detect/mlserver_alibi_detect/protocols/seldon_http.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/protocols/seldon_http.py
@@ -10,7 +10,7 @@ class SeldonPayload(Enum):
     TFTENSOR = 3
 
 
-def _extract_list(body: dict) -> np.array:
+def _extract_list(body: dict) -> np.ndarray:
     data_def = body["data"]
     if "tensor" in data_def:
         arr = np.array(data_def.get("tensor").get("values")).reshape(
@@ -52,5 +52,5 @@ class SeldonRequestHandler(RequestHandler):
 
         _get_request_ty(self.request)
 
-    def extract_request(self) -> np.array:
+    def extract_request(self) -> np.ndarray:
         return _extract_list(self.request)

--- a/runtimes/alibi-detect/mlserver_alibi_detect/protocols/tensorflow_http.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/protocols/tensorflow_http.py
@@ -11,5 +11,5 @@ class TensorflowRequestHandler(RequestHandler):
         if "instances" not in self.request:
             raise InferenceError("Expected key `instances` in request body")
 
-    def extract_request(self) -> np.array:
+    def extract_request(self) -> np.ndarray:
         return np.array(self.request["instances"])

--- a/runtimes/alibi-detect/mlserver_alibi_detect/protocols/v2.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/protocols/v2.py
@@ -21,7 +21,7 @@ class KFservingV2RequestHandler(RequestHandler):
                 "KFServing protocol BYTES data can not be presently handled"
             )
 
-    def extract_request(self) -> np.array:
+    def extract_request(self) -> np.ndarray:
         inputs = self.request["inputs"][0]
         default_codec = NumpyCodec()
         return default_codec.decode(types.RequestInput(**inputs))

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -33,7 +33,7 @@ EXPLAIN_PARAMETERS_TAG = "explain_parameters"
 
 
 #  TODO: add this utility in the codec.
-def convert_from_bytes(output: ResponseOutput, ty: Optional[Type]) -> Any:
+def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any:
     """
     This utility function decodes the response from bytes string to python object dict.
     It is related to decoding StringCodec

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -37,10 +37,15 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type]) -> Any:
     This utility function decodes the response from bytes string to python object dict.
     It is related to decoding StringCodec
     """
+    if output.shape != [1]:
+        # TODO: Does this default value make sense here?
+        return ""
+
     if ty == str:
-        return bytearray(output.data).decode("UTF-8")
+        return bytearray(output.data[0]).decode("UTF-8")
     else:
-        py_str = bytearray(output.data).decode("UTF-8")
+        py_str = bytearray(output.data[0]).decode("UTF-8")
+
         from ast import literal_eval
 
         return literal_eval(py_str)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -11,7 +11,6 @@ import requests
 from pydantic import BaseSettings
 
 from mlserver.codecs import StringCodec, NumpyCodec
-from mlserver.errors import RemoteInferenceError
 from mlserver.types import (
     ResponseOutput,
     InferenceResponse,
@@ -20,6 +19,8 @@ from mlserver.types import (
     MetadataModelResponse,
 )
 from mlserver.utils import generate_uuid
+
+from mlserver_alibi_explain.errors import RemoteInferenceError, InvalidExplanationShape
 
 _DEFAULT_INPUT_NAME = "predict"
 
@@ -38,8 +39,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type]) -> Any:
     It is related to decoding StringCodec
     """
     if output.shape != [1]:
-        # TODO: Does this default value make sense here?
-        return ""
+        raise InvalidExplanationShape(output.shape)
 
     if ty == str:
         return bytearray(output.data[0]).decode("UTF-8")

--- a/runtimes/alibi-explain/mlserver_alibi_explain/errors.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/errors.py
@@ -1,0 +1,15 @@
+from mlserver.errors import MLServerError
+
+from typing import List, Union
+
+
+class RemoteInferenceError(MLServerError):
+    def __init__(self, code: int, reason: str):
+        super().__init__(f"Remote inference call failed with {code}, {reason}")
+
+
+class InvalidExplanationShape(MLServerError):
+    def __init__(self, shape: Union[List[int], int]):
+        super().__init__(
+            f"Expected a single element, but multiple were returned {shape}"
+        )

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -58,7 +58,12 @@ class AlibiExplainRuntimeBase(MLModel):
         in the endpoint.
         """
         v2_response = await self.predict(request)
-        explanation = json.loads(v2_response.outputs[0].data.__root__)
+        output = v2_response.outputs[0]
+
+        # TODO: Does this default value make sense here?
+        explanation = {}
+        if output.shape == [1]:
+            explanation = json.loads(output.data[0])
 
         return Response(content=explanation, media_type="application/json")
 

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -10,7 +10,7 @@ from mlserver.codecs import (
     StringCodec,
     RequestCodecLike,
 )
-from mlserver.errors import MLServerError, ModelParametersMissing, InvalidModelURI
+from mlserver.errors import ModelParametersMissing, InvalidModelURI
 from mlserver.handlers import custom_handler
 from mlserver.model import MLModel
 from mlserver.rest.responses import Response
@@ -35,6 +35,7 @@ from mlserver_alibi_explain.common import (
     EXPLAIN_PARAMETERS_TAG,
     EXPLAINER_TYPE_TAG,
 )
+from mlserver_alibi_explain.errors import InvalidExplanationShape
 
 
 class AlibiExplainRuntimeBase(MLModel):
@@ -60,16 +61,12 @@ class AlibiExplainRuntimeBase(MLModel):
         v2_response = await self.predict(request)
 
         if len(v2_response.outputs) != 1:
-            raise MLServerError(
-                f"Expected a single output, but multiple outputs were returned ({len(v2_response.outputs)})"
-            )
+            raise InvalidExplanationShape(len(v2_response.outputs))
 
         output = v2_response.outputs[0]
 
         if output.shape != [1]:
-            raise MLServerError(
-                f"Expected a single element, but multiple were returned ({output.shape})"
-            )
+            raise InvalidExplanationShape(output.shape)
 
         explanation = json.loads(output.data[0])
 

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -8,7 +8,6 @@ from alibi.api.interfaces import Explanation
 from numpy.testing import assert_array_equal
 
 from mlserver import ModelSettings, MLModel
-from mlserver.errors import MLServerError
 from mlserver.codecs import NumpyCodec
 from mlserver.types import (
     InferenceRequest,
@@ -25,6 +24,7 @@ from mlserver_alibi_explain.common import (
     AlibiExplainSettings,
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntime, AlibiExplainRuntimeBase
+from mlserver_alibi_explain.errors import InvalidExplanationShape
 
 """
 Smoke tests for runtimes
@@ -274,7 +274,7 @@ async def test_v1_invalid_predict(
 
     with patch.object(integrated_gradients_runtime._rt, "predict", _mocked_predict):
         request = InferenceRequest(inputs=[])
-        with pytest.raises(MLServerError):
+        with pytest.raises(InvalidExplanationShape):
             v1_output = await integrated_gradients_runtime._rt.explain_v1_output(
                 request
             )

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -16,7 +16,6 @@ from mlserver.types import (
     RequestInput,
     ResponseOutput,
     MetadataTensor,
-    InferenceResponse,
 )
 from mlserver_alibi_explain.common import (
     convert_from_bytes,
@@ -275,6 +274,4 @@ async def test_v1_invalid_predict(
     with patch.object(integrated_gradients_runtime._rt, "predict", _mocked_predict):
         request = InferenceRequest(inputs=[])
         with pytest.raises(InvalidExplanationShape):
-            v1_output = await integrated_gradients_runtime._rt.explain_v1_output(
-                request
-            )
+            await integrated_gradients_runtime._rt.explain_v1_output(request)

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -193,7 +193,7 @@ async def test_end_2_end_explain_v1_output(
                         parameters=Parameters(content_type=StringCodec.ContentType),
                         name=_DEFAULT_INPUT_NAME,
                         data=["dummy", "dummy text"],
-                        shape=[2, -1],
+                        shape=[2],
                         datatype="BYTES",
                     )
                 ],

--- a/runtimes/alibi-explain/tests/test_common.py
+++ b/runtimes/alibi-explain/tests/test_common.py
@@ -1,0 +1,18 @@
+import pytest
+
+from mlserver.types import ResponseOutput
+
+from mlserver_alibi_explain.common import convert_from_bytes
+from mlserver_alibi_explain.errors import InvalidExplanationShape
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        ResponseOutput(name="foo", datatype="INT32", shape=[1, 1], data=[1]),
+        ResponseOutput(name="foo", datatype="INT32", shape=[1, 2], data=[1, 2]),
+    ],
+)
+def test_convert_from_bytes_invalid(output: ResponseOutput):
+    with pytest.raises(InvalidExplanationShape):
+        convert_from_bytes(output)

--- a/tests/codecs/test_base64.py
+++ b/tests/codecs/test_base64.py
@@ -12,9 +12,9 @@ from mlserver.types import RequestInput, ResponseOutput
             [b"Python is fun"],
             ResponseOutput(
                 name="foo",
-                shape=[1, 20],
+                shape=[1],
                 datatype="BYTES",
-                data=b"UHl0aG9uIGlzIGZ1bg==",
+                data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
         ),
         (
@@ -22,9 +22,9 @@ from mlserver.types import RequestInput, ResponseOutput
             ["Python is fun"],
             ResponseOutput(
                 name="foo",
-                shape=[1, 20],
+                shape=[1],
                 datatype="BYTES",
-                data=b"UHl0aG9uIGlzIGZ1bg==",
+                data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
         ),
         (
@@ -32,9 +32,9 @@ from mlserver.types import RequestInput, ResponseOutput
             [b"Python is fun", b"Python is fun"],
             ResponseOutput(
                 name="foo",
-                shape=[2, 20],
+                shape=[2],
                 datatype="BYTES",
-                data=b"UHl0aG9uIGlzIGZ1bg==UHl0aG9uIGlzIGZ1bg==",
+                data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),
         ),
     ],
@@ -53,7 +53,7 @@ def test_encode(decoded, expected):
             # Single base64-encoded binary string
             RequestInput(
                 name="foo",
-                shape=[1, 20],
+                shape=[1],
                 datatype="BYTES",
                 data="UHl0aG9uIGlzIGZ1bg==",
             ),
@@ -63,7 +63,7 @@ def test_encode(decoded, expected):
             # Single (non-base64-encoded) binary string
             RequestInput(
                 name="foo",
-                shape=[1, 13],
+                shape=[1],
                 datatype="BYTES",
                 data=b"Python is fun",
             ),
@@ -73,7 +73,7 @@ def test_encode(decoded, expected):
             # Single (non-base64-encoded) (non-binary) string
             RequestInput(
                 name="foo",
-                shape=[1, 13],
+                shape=[1],
                 datatype="BYTES",
                 data="Python is fun",
             ),
@@ -83,9 +83,9 @@ def test_encode(decoded, expected):
             # Multiple base64-encoded binary strings
             RequestInput(
                 name="foo",
-                shape=[2, 20],
+                shape=[2],
                 datatype="BYTES",
-                data=b"UHl0aG9uIGlzIGZ1bg==UHl0aG9uIGlzIGZ1bg==",
+                data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),
             [b"Python is fun", b"Python is fun"],
         ),

--- a/tests/codecs/test_datetime.py
+++ b/tests/codecs/test_datetime.py
@@ -22,9 +22,9 @@ TestTzDatetime = datetime.fromisoformat(TestTzDatetimeIso)
             [TestDatetime],
             ResponseOutput(
                 name="foo",
-                shape=[1, 19],
+                shape=[1],
                 datatype="BYTES",
-                data=TestDatetimeIsoB,
+                data=[TestDatetimeIsoB],
             ),
         ),
         (
@@ -32,9 +32,9 @@ TestTzDatetime = datetime.fromisoformat(TestTzDatetimeIso)
             [TestDatetime, TestDatetime],
             ResponseOutput(
                 name="foo",
-                shape=[2, 19],
+                shape=[2],
                 datatype="BYTES",
-                data=TestDatetimeIsoB + TestDatetimeIsoB,
+                data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
         ),
         (
@@ -42,9 +42,9 @@ TestTzDatetime = datetime.fromisoformat(TestTzDatetimeIso)
             [TestDatetimeIso],
             ResponseOutput(
                 name="foo",
-                shape=[1, 19],
+                shape=[1],
                 datatype="BYTES",
-                data=TestDatetimeIsoB,
+                data=[TestDatetimeIsoB],
             ),
         ),
         (
@@ -52,9 +52,9 @@ TestTzDatetime = datetime.fromisoformat(TestTzDatetimeIso)
             [TestTzDatetime],
             ResponseOutput(
                 name="foo",
-                shape=[1, 25],
+                shape=[1],
                 datatype="BYTES",
-                data=TestTzDatetimeIsoB,
+                data=[TestTzDatetimeIsoB],
             ),
         ),
     ],
@@ -73,7 +73,7 @@ def test_encode(decoded, expected):
             # Single binary ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1, 19],
+                shape=[1],
                 datatype="BYTES",
                 data=TestDatetimeIsoB,
             ),
@@ -83,9 +83,9 @@ def test_encode(decoded, expected):
             # Single (non-binary) ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1, 19],
+                shape=[1],
                 datatype="BYTES",
-                data=TestDatetimeIso,
+                data=[TestDatetimeIso],
             ),
             [TestDatetime],
         ),
@@ -93,9 +93,9 @@ def test_encode(decoded, expected):
             # Multiple binary ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1, 19],
+                shape=[2],
                 datatype="BYTES",
-                data=TestDatetimeIsoB + TestDatetimeIsoB,
+                data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
             [TestDatetime, TestDatetime],
         ),
@@ -103,9 +103,9 @@ def test_encode(decoded, expected):
             # Multiple (non-binary) ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1, 19],
+                shape=[2],
                 datatype="BYTES",
-                data=TestDatetimeIso + TestDatetimeIso,
+                data=[TestDatetimeIso, TestDatetimeIso],
             ),
             [TestDatetime, TestDatetime],
         ),
@@ -113,9 +113,9 @@ def test_encode(decoded, expected):
             # Single (non-binary) ISO-encoded datetime with timezone
             RequestInput(
                 name="foo",
-                shape=[1, 25],
+                shape=[1],
                 datatype="BYTES",
-                data=TestTzDatetimeIso,
+                data=[TestTzDatetimeIso],
             ),
             [TestTzDatetime],
         ),

--- a/tests/codecs/test_middleware.py
+++ b/tests/codecs/test_middleware.py
@@ -41,8 +41,8 @@ from mlserver.settings import ModelSettings
                     ),
                     RequestInput(
                         name="bar",
-                        shape=[2, 3],
-                        data=b"heyabc",
+                        shape=[2],
+                        data=[b"hey", b"abc"],
                         datatype="BYTES",
                         parameters=Parameters(content_type=StringCodec.ContentType),
                     ),

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -18,7 +18,7 @@ from mlserver.types import (
         (
             pd.Series(data=["hey", "abc"], name="foo"),
             ResponseOutput(
-                name="foo", shape=[2], data=["hey", "abc"], datatype="BYTES"
+                name="foo", shape=[2], data=[b"hey", b"abc"], datatype="BYTES"
             ),
         ),
         (
@@ -62,7 +62,7 @@ def test_to_response_output(series, expected):
                         name="a", shape=[3], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="b", shape=[3], datatype="BYTES", data=["A", "B", "C"]
+                        name="b", shape=[3], datatype="BYTES", data=[b"A", b"B", b"C"]
                     ),
                 ],
             ),
@@ -95,7 +95,7 @@ def test_encode(dataframe, expected):
                         name="b",
                         data=b"hello world",
                         datatype="BYTES",
-                        shape=[1, 11],
+                        shape=[1],
                         parameters=Parameters(_decoded_payload=["hello world"]),
                     ),
                 ]
@@ -118,7 +118,7 @@ def test_encode(dataframe, expected):
                         name="b",
                         data=b"ABC",
                         datatype="BYTES",
-                        shape=[3, 1],
+                        shape=[3],
                     ),
                 ]
             ),

--- a/tests/grpc/test_codecs.py
+++ b/tests/grpc/test_codecs.py
@@ -10,6 +10,7 @@ from mlserver.codecs import (
     NumpyCodec,
     StringCodec,
     PandasCodec,
+    Base64Codec,
     decode_inference_request,
 )
 from mlserver.grpc import dataplane_pb2 as pb
@@ -117,6 +118,16 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
             ),
         ),
         (
+            np.array([[b"\x01"], [b"\x02"]], dtype=bytes),
+            NumpyCodec,
+            pb.ModelInferResponse.InferOutputTensor(
+                name="output-0",
+                datatype="BYTES",
+                shape=[2, 1],
+                contents=pb.InferTensorContents(bytes_contents=[b"\x01\x02"]),
+            ),
+        ),
+        (
             ["hey", "what's", "up"],
             StringCodec,
             pb.ModelInferResponse.InferOutputTensor(
@@ -125,6 +136,18 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
                 shape=[3],
                 contents=pb.InferTensorContents(
                     bytes_contents=[b"hey", b"what's", b"up"]
+                ),
+            ),
+        ),
+        (
+            [b"Python is fun"],
+            Base64Codec,
+            pb.ModelInferResponse.InferOutputTensor(
+                name="output-0",
+                datatype="BYTES",
+                shape=[1],
+                contents=pb.InferTensorContents(
+                    bytes_contents=[b"UHl0aG9uIGlzIGZ1bg=="]
                 ),
             ),
         ),

--- a/tests/grpc/test_converters.py
+++ b/tests/grpc/test_converters.py
@@ -141,13 +141,13 @@ def test_parameters_from_types(grpc_parameters):
             types.ResponseOutput(
                 name="output-0",
                 datatype="BYTES",
-                shape=[2, 3],
+                shape=[2],
                 data=[b"hey", b"hello world"],
             ),
             pb.ModelInferResponse.InferOutputTensor(
                 name="output-0",
                 datatype="BYTES",
-                shape=[2, 3],
+                shape=[2],
                 contents=pb.InferTensorContents(
                     bytes_contents=[b"hey", b"hello world"]
                 ),

--- a/tests/grpc/test_converters.py
+++ b/tests/grpc/test_converters.py
@@ -1,4 +1,7 @@
+import pytest
+
 from google.protobuf import json_format
+
 from mlserver import types
 from mlserver.grpc.converters import (
     ModelInferRequestConverter,
@@ -8,6 +11,7 @@ from mlserver.grpc.converters import (
     RepositoryIndexRequestConverter,
     RepositoryIndexResponseConverter,
     ParametersConverter,
+    InferOutputTensorConverter,
 )
 from mlserver.grpc import dataplane_pb2 as pb
 
@@ -117,3 +121,43 @@ def test_parameters_from_types(grpc_parameters):
     conv_parameters = ParametersConverter.from_types(parameters)
 
     assert conv_parameters == grpc_parameters
+
+
+@pytest.mark.parametrize(
+    "response_output, expected",
+    [
+        (
+            types.ResponseOutput(
+                name="output-0", datatype="FP32", shape=[1], data=[21.0]
+            ),
+            pb.ModelInferResponse.InferOutputTensor(
+                name="output-0",
+                datatype="FP32",
+                shape=[1],
+                contents=pb.InferTensorContents(fp32_contents=[21.0]),
+            ),
+        ),
+        (
+            types.ResponseOutput(
+                name="output-0",
+                datatype="BYTES",
+                shape=[2, 3],
+                data=[b"hey", b"hello world"],
+            ),
+            pb.ModelInferResponse.InferOutputTensor(
+                name="output-0",
+                datatype="BYTES",
+                shape=[2, 3],
+                contents=pb.InferTensorContents(
+                    bytes_contents=[b"hey", b"hello world"]
+                ),
+            ),
+        ),
+    ],
+)
+def test_inferoutputtensor_from_types(
+    response_output: types.ResponseOutput,
+    expected: pb.ModelInferResponse.InferOutputTensor,
+):
+    infer_output_tensor = InferOutputTensorConverter.from_types(response_output)
+    assert infer_output_tensor == expected

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -1,0 +1,48 @@
+import pytest
+import numpy as np
+import json
+
+from typing import Any
+
+from mlserver.codecs import NumpyCodec, StringCodec, InputCodec
+from mlserver.types import RequestInput
+from mlserver.rest.responses import Response
+
+
+@pytest.mark.parametrize(
+    "decoded, codec, expected",
+    [
+        (
+            np.array([21.0]),
+            NumpyCodec,
+            {
+                "name": "output-0",
+                "datatype": "FP64",
+                "shape": [1],
+                "parameters": None,
+                "data": [21.0],
+            },
+        ),
+        (
+            ["hey", "what's", "up"],
+            StringCodec,
+            {
+                "name": "output-0",
+                "datatype": "BYTES",
+                "shape": [3],
+                "parameters": None,
+                "data": ["hey", "what's", "up"],
+            },
+        ),
+    ],
+)
+def test_encode_output_tensor(decoded: Any, codec: InputCodec, expected: dict):
+    # Serialise response into final output bytes
+    payload = codec.encode(name="output-0", payload=decoded)
+    response = Response()
+    rendered_as_bytes = response.render(payload.dict())
+
+    # Decode response back into JSON and check if it matches the expected one
+    rendered = rendered_as_bytes.decode("utf8")
+    loaded_back = json.loads(rendered)
+    assert loaded_back == expected

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -4,7 +4,7 @@ import json
 
 from typing import Any
 
-from mlserver.codecs import NumpyCodec, StringCodec, InputCodec
+from mlserver.codecs import NumpyCodec, StringCodec, InputCodec, Base64Codec
 from mlserver.types import RequestInput
 from mlserver.rest.responses import Response
 
@@ -21,6 +21,17 @@ from mlserver.rest.responses import Response
                 "shape": [1],
                 "parameters": None,
                 "data": [21.0],
+            },
+        ),
+        (
+            np.array([[b"\x01"], [b"\x02"]], dtype=bytes),
+            NumpyCodec,
+            {
+                "name": "output-0",
+                "datatype": "BYTES",
+                "shape": [2, 1],
+                "parameters": None,
+                "data": ["\x01\x02"],
             },
         ),
         (

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -5,7 +5,6 @@ import json
 from typing import Any
 
 from mlserver.codecs import NumpyCodec, StringCodec, InputCodec, Base64Codec
-from mlserver.types import RequestInput
 from mlserver.rest.responses import Response
 
 

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -34,6 +34,17 @@ from mlserver.rest.responses import Response
                 "data": ["hey", "what's", "up"],
             },
         ),
+        (
+            [b"Python is fun"],
+            Base64Codec,
+            {
+                "name": "output-0",
+                "datatype": "BYTES",
+                "shape": [1],
+                "parameters": None,
+                "data": ["UHl0aG9uIGlzIGZ1bg=="],
+            },
+        ),
     ],
 )
 def test_encode_output_tensor(decoded: Any, codec: InputCodec, expected: dict):


### PR DESCRIPTION
Fixes #400

## Changelog
- Change current codec logic so that `BYTES` payloads don't get packed into a single bytes array, but instead is treated as a list of multiple bytes arrays.
- Add tests to ensure codecs work properly in both gRPC and REST