### PR TITLE
Initial changes to allow loading of multiple versions

### DIFF
--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -37,10 +37,10 @@ async def start(folder: str):
     """
     Start serving a machine learning model with MLServer.
     """
-    settings, models = await load_settings(folder)
+    settings, models_settings = await load_settings(folder)
 
     server = MLServer(settings)
-    await server.start(models)
+    await server.start(models_settings)
 
 
 @root.command("build")

--- a/mlserver/cli/serve.py
+++ b/mlserver/cli/serve.py
@@ -3,14 +3,13 @@ import sys
 
 from typing import List, Tuple, Union
 
-from ..model import MLModel
 from ..repository import ModelRepository
 from ..settings import Settings, ModelSettings
 
 DEFAULT_SETTINGS_FILENAME = "settings.json"
 
 
-async def load_settings(folder: str = None) -> Tuple[Settings, ModelSettings]:
+async def load_settings(folder: str = None) -> Tuple[Settings, List[ModelSettings]]:
     """
     Load server and model settings.
     """

--- a/mlserver/cli/serve.py
+++ b/mlserver/cli/serve.py
@@ -10,7 +10,7 @@ from ..settings import Settings, ModelSettings
 DEFAULT_SETTINGS_FILENAME = "settings.json"
 
 
-async def load_settings(folder: str = None) -> Tuple[Settings, List[MLModel]]:
+async def load_settings(folder: str = None) -> Tuple[Settings, ModelSettings]:
     """
     Load server and model settings.
     """
@@ -31,13 +31,12 @@ async def load_settings(folder: str = None) -> Tuple[Settings, List[MLModel]]:
     if folder is not None:
         settings.model_repository_root = folder
 
-    models = []
+    models_settings = []
     if settings.load_models_at_startup:
         repository = ModelRepository(settings.model_repository_root)
-        available_models = await repository.list()
-        models = [_init_model(model) for model in available_models]
+        models_settings = await repository.list()
 
-    return settings, models
+    return settings, models_settings
 
 
 def _path_exists(folder: Union[str, None], file: str) -> bool:
@@ -46,8 +45,3 @@ def _path_exists(folder: Union[str, None], file: str) -> bool:
 
     file_path = os.path.join(folder, file)
     return os.path.isfile(file_path)
-
-
-def _init_model(model_settings: ModelSettings) -> MLModel:
-    model_class = model_settings.implementation
-    return model_class(model_settings)  # type: ignore

--- a/mlserver/handlers/model_repository.py
+++ b/mlserver/handlers/model_repository.py
@@ -61,11 +61,9 @@ class ModelRepositoryHandlers:
         all_model_settings = await self._repository.find(name)
 
         for model_settings in all_model_settings:
-            # TODO: Move to separate method
-            model_class = model_settings.implementation
-            model = model_class(model_settings)  # type: ignore
+            await self._model_registry.load(model_settings)
 
-            await self._model_registry.load(model)
+        # TODO: Remove delta between existing models and new ones
 
         return True
 

--- a/mlserver/handlers/model_repository.py
+++ b/mlserver/handlers/model_repository.py
@@ -58,13 +58,14 @@ class ModelRepositoryHandlers:
         return State.UNKNOWN
 
     async def load(self, name: str) -> bool:
-        model_settings = await self._repository.find(name)
+        all_model_settings = await self._repository.find(name)
 
-        # TODO: Move to separate method
-        model_class = model_settings.implementation
-        model = model_class(model_settings)  # type: ignore
+        for model_settings in all_model_settings:
+            # TODO: Move to separate method
+            model_class = model_settings.implementation
+            model = model_class(model_settings)  # type: ignore
 
-        await self._model_registry.load(model)
+            await self._model_registry.load(model)
 
         return True
 

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -104,7 +104,8 @@ class SingleModelRegistry:
         if model.version:
             self._versions[model.version] = model
 
-        # TODO: Support version policies
+        # TODO: Set latest as default (i.e. if default is present, compare with
+        # new one to check which one is newer)
         self._default = model
 
 

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -50,6 +50,9 @@ class SingleModelRegistry:
         models = await self.get_models()
         await asyncio.gather(*[self._unload_model(model) for model in models])
 
+        self._versions.clear()
+        self._default = None
+
     async def _unload_model(self, model: MLModel):
         if self._on_model_unload:
             await asyncio.gather(
@@ -120,8 +123,7 @@ class MultiModelRegistry:
         if name not in self._models:
             raise ModelNotFound(name, version)
 
-        model = await self._models[name].get_model(version)
-        return model
+        return await self._models[name].get_model(version)
 
     async def get_models(self) -> List[MLModel]:
         models_list = await asyncio.gather(

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -38,7 +38,7 @@ class SingleModelRegistry:
         self._on_model_unload = on_model_unload
 
     @property
-    def default(self) -> MLModel:
+    def default(self) -> Optional[MLModel]:
         if self._default is None:
             self._default = self._find_default()
 

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -106,7 +106,7 @@ class SingleModelRegistry:
                 return self._default
 
             # Otherwise, compare versions
-            if _is_newer(new_model, self._default) > 0:
+            if _is_newer(new_model, self._default) >= 0:
                 self._default = new_model
                 return new_model
 
@@ -177,6 +177,9 @@ class SingleModelRegistry:
             await asyncio.gather(
                 *[callback(model) for callback in self._on_model_unload]
             )
+
+        if model == self.default:
+            self._clear_default()
 
         logger.info(f"Unloaded model '{model.name}' succesfully.")
 

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -23,6 +23,8 @@ def _get_version(model_settings: ModelSettings) -> Optional[str]:
 def _is_newer(a: MLModel, b: MLModel) -> int:
     """
     Returns true if 'a' is newer than 'b'.
+
+    TODO: Support other ordering schemes (e.g. semver).
     """
     if a.version is None:
         return a
@@ -104,8 +106,11 @@ class SingleModelRegistry:
                 return self._default
 
             # Otherwise, compare versions
-            # TODO: Compare versions
-            self._default = new_model
+            if _is_newer(new_model, self._default) > 0:
+                self._default = new_model
+                return new_model
+
+            return self._default
 
         if self._default and self._default.version is None:
             # If there isn't a new model to compare, and current default has no

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -27,10 +27,10 @@ def _is_newer(a: MLModel, b: MLModel) -> int:
     TODO: Support other ordering schemes (e.g. semver).
     """
     if a.version is None:
-        return a
+        return 1
 
     if b.version is None:
-        return b
+        return -1
 
     try:
         a_int = int(a.version)

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -101,8 +101,9 @@ class SingleModelRegistry:
         # NOTE: `.values()` returns a "view" instead of a list
         models = list(self._versions.values())
 
-        # Add default if not versioned
-        if not self._default.version:
+        # Add default if not versioned (as it won't be present on the
+        # `_versions` dict
+        if self._default and not self._default.version:
             models.append(self._default)
 
         return models

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -49,10 +49,14 @@ class ModelRepository:
         default_model_name = os.path.basename(model_settings_folder)
         if model_settings.name:
             if model_settings.name != default_model_name:
-                # Raise warning if name is different than folder's name
-                logger.warning(
-                    f"Model name '{model_settings.name}' is different than "
-                    f"model's folder name '{default_model_name}'."
+                if model_settings.parameters and \
+                        model_settings.parameters.version == default_model_name:
+                    pass
+                else:
+                    # Raise warning if name is different than folder's name
+                    logger.warning(
+                       f"Model name '{model_settings.name}' is different than "
+                       f"model's folder name '{default_model_name}'."
                 )
         else:
             model_settings.name = default_model_name
@@ -67,11 +71,16 @@ class ModelRepository:
 
         return model_settings
 
-    async def find(self, name: str) -> ModelSettings:
+    async def find(self, name: str) -> List[ModelSettings]:
         all_settings = await self.list()
+        selected = []
         for model_settings in all_settings:
             if model_settings.name == name:
+                selected.append(model_settings)
                 # TODO: Implement version policy
-                return model_settings
 
-        raise ModelNotFound(name)
+        if len(selected) == 0:
+            raise ModelNotFound(name)
+        else:
+            return selected
+

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -46,20 +46,16 @@ class ModelRepository:
 
         # If name not present, default to folder name
         model_settings_folder = os.path.dirname(model_settings_path)
-        default_model_name = os.path.basename(model_settings_folder)
+        folder_name = os.path.basename(model_settings_folder)
         if model_settings.name:
-            if model_settings.name != default_model_name:
-                if model_settings.parameters and \
-                        model_settings.parameters.version == default_model_name:
-                    pass
-                else:
-                    # Raise warning if name is different than folder's name
-                    logger.warning(
-                       f"Model name '{model_settings.name}' is different than "
-                       f"model's folder name '{default_model_name}'."
+            if not self._folder_matches(folder_name, model_settings):
+                # Raise warning if name is different than folder's name
+                logger.warning(
+                    f"Model name '{model_settings.name}' is different than "
+                    f"model's folder name '{folder_name}'."
                 )
         else:
-            model_settings.name = default_model_name
+            model_settings.name = folder_name
 
         if not model_settings.parameters:
             model_settings.parameters = ModelParameters()
@@ -71,16 +67,28 @@ class ModelRepository:
 
         return model_settings
 
+    def _folder_matches(self, folder_name: str, model_settings: ModelSettings) -> bool:
+        if model_settings.name == folder_name:
+            return True
+
+        # To be compatible with Triton, check whether the folder name matches
+        # with the model's version
+        if model_settings.parameters and model_settings.parameters.version:
+            model_version = model_settings.parameters.version
+            if model_version == folder_name:
+                return True
+
+        return False
+
     async def find(self, name: str) -> List[ModelSettings]:
         all_settings = await self.list()
         selected = []
         for model_settings in all_settings:
+            # TODO: Implement other version policies
             if model_settings.name == name:
                 selected.append(model_settings)
-                # TODO: Implement version policy
 
         if len(selected) == 0:
             raise ModelNotFound(name)
-        else:
-            return selected
 
+        return selected

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -84,7 +84,7 @@ class ModelRepository:
         all_settings = await self.list()
         selected = []
         for model_settings in all_settings:
-            # TODO: Implement other version policies
+            # TODO: Implement other version policies (e.g. "Last N")
             if model_settings.name == name:
                 selected.append(model_settings)
 

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -4,7 +4,7 @@ from ..settings import Settings
 from ..handlers import DataPlane, ModelRepositoryHandlers, get_custom_handlers
 from ..model import MLModel
 
-from .utils import to_scope
+from .utils import matches
 from .app import create_app
 
 
@@ -40,22 +40,16 @@ class RESTServer:
 
     async def delete_custom_handlers(self, model: MLModel):
         handlers = get_custom_handlers(model)
-        scopes = [to_scope(custom_handler) for custom_handler, _ in handlers]
+        if len(handlers) == 0:
+            return
 
         # NOTE: Loop in reverse, so that it's quicker to find all the recently
         # added routes and we can remove routes on-the-fly
         for i, route in reversed(list(enumerate(self._app.routes))):
-            if len(scopes) == 0:
-                return
-
-            for j, scope in enumerate(scopes):
-                match, _ = route.matches(scope)
-                if match == match.NONE:
-                    continue
-
-                # Remove route and scope
-                self._app.routes.pop(i)
-                scopes.pop(j)
+            for j, (custom_handler, handler_method) in enumerate(handlers):
+                if matches(route, custom_handler, handler_method):
+                    self._app.routes.pop(i)
+                    handlers.pop(j)
 
     async def start(self):
         cfg = uvicorn.Config(

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -47,7 +47,7 @@ class RESTServer:
         # added routes and we can remove routes on-the-fly
         for i, route in reversed(list(enumerate(self._app.routes))):
             for j, (custom_handler, handler_method) in enumerate(handlers):
-                if matches(route, custom_handler, handler_method):
+                if matches(route, custom_handler, handler_method):  # type: ignore
                     self._app.routes.pop(i)
                     handlers.pop(j)
 

--- a/mlserver/rest/utils.py
+++ b/mlserver/rest/utils.py
@@ -1,4 +1,7 @@
+from typing import Callable
+
 from fastapi import status
+from fastapi.routing import APIRoute
 from starlette.types import Scope
 
 from ..handlers.custom import CustomHandler
@@ -12,6 +15,20 @@ def to_status_code(flag: bool, error_code: int = status.HTTP_400_BAD_REQUEST) ->
         return status.HTTP_200_OK
 
     return error_code
+
+
+def matches(
+    route: APIRoute, custom_handler: CustomHandler, handler_method: Callable
+) -> bool:
+    if route.endpoint != handler_method:
+        return False
+
+    scope = to_scope(custom_handler)
+    match, _ = route.matches(scope)
+    if match == match.NONE:
+        return False
+
+    return True
 
 
 def to_scope(custom_handler: CustomHandler) -> Scope:

--- a/runtimes/alibi-explain/mlserver_alibi_explain/alibi_dependency_reference.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/alibi_dependency_reference.py
@@ -28,28 +28,28 @@ _INTEGRATED_GRADIENTS_TAG = "integrated_gradients"
 #  update _TAG_TO_RT_IMPL
 #  update ExplainerEnum
 
-_BLACKBOX_MODULDE = "mlserver_alibi_explain.explainers.black_box_runtime"
+_BLACKBOX_MODULE = "mlserver_alibi_explain.explainers.black_box_runtime"
 _INTEGRATED_GRADIENTS_MODULE = "mlserver_alibi_explain.explainers.integrated_gradients"
 
 _TAG_TO_RT_IMPL: Dict[str, ExplainerDependencyReference] = {
     _ANCHOR_IMAGE_TAG: ExplainerDependencyReference(
         explainer_name=_ANCHOR_IMAGE_TAG,
-        runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
+        runtime_class=f"{_BLACKBOX_MODULE}.AlibiExplainBlackBoxRuntime",
         alibi_class="alibi.explainers.AnchorImage",
     ),
     _ANCHOR_TABULAR_TAG: ExplainerDependencyReference(
         explainer_name=_ANCHOR_TABULAR_TAG,
-        runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
+        runtime_class=f"{_BLACKBOX_MODULE}.AlibiExplainBlackBoxRuntime",
         alibi_class="alibi.explainers.AnchorTabular",
     ),
     _ANCHOR_TEXT_TAG: ExplainerDependencyReference(
         explainer_name=_ANCHOR_TEXT_TAG,
-        runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
+        runtime_class=f"{_BLACKBOX_MODULE}.AlibiExplainBlackBoxRuntime",
         alibi_class="alibi.explainers.AnchorText",
     ),
     _KERNEL_SHAP_TAG: ExplainerDependencyReference(
         explainer_name=_KERNEL_SHAP_TAG,
-        runtime_class=f"{_BLACKBOX_MODULDE}.AlibiExplainBlackBoxRuntime",
+        runtime_class=f"{_BLACKBOX_MODULE}.AlibiExplainBlackBoxRuntime",
         alibi_class="alibi.explainers.KernelShap",
     ),
     _INTEGRATED_GRADIENTS_TAG: ExplainerDependencyReference(

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -108,11 +108,11 @@ async def rest_server(
         model_repository_handlers=model_repository_handlers,
     )
 
-    await asyncio.gather(server.add_custom_handlers(custom_runtime_tf))
+    await server.add_custom_handlers(custom_runtime_tf)
 
     yield server
 
-    await asyncio.gather(server.delete_custom_handlers(custom_runtime_tf))
+    await server.delete_custom_handlers(custom_runtime_tf)
 
 
 @pytest.fixture
@@ -240,11 +240,11 @@ async def dummy_alibi_explain_client(
 ) -> AsyncIterable[TestClient]:
     dummy_explainer = await model_registry.load(dummy_explainer_settings)
 
-    await asyncio.gather(rest_server.add_custom_handlers(dummy_explainer))
+    await rest_server.add_custom_handlers(dummy_explainer)
 
     yield TestClient(rest_server._app)
 
-    await asyncio.gather(rest_server.add_custom_handlers(dummy_explainer))
+    await rest_server.add_custom_handlers(dummy_explainer)
 
 
 def _train_anchor_image_explainer() -> None:

--- a/runtimes/mlflow/tests/conftest.py
+++ b/runtimes/mlflow/tests/conftest.py
@@ -90,6 +90,7 @@ def pytorch_model_uri() -> str:
 def model_settings(model_uri: str) -> ModelSettings:
     return ModelSettings(
         name="mlflow-model",
+        implementation=MLflowRuntime,
         parameters=ModelParameters(uri=model_uri),
     )
 

--- a/runtimes/mlflow/tests/rest/conftest.py
+++ b/runtimes/mlflow/tests/rest/conftest.py
@@ -7,7 +7,7 @@ from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
 from mlserver.rest import RESTServer
 from mlserver.repository import ModelRepository
-from mlserver import Settings
+from mlserver import Settings, ModelSettings
 
 from mlserver_mlflow import MLflowRuntime
 
@@ -18,10 +18,17 @@ def model_repository(model_uri: str) -> ModelRepository:
 
 
 @pytest.fixture
-async def model_registry(runtime: MLflowRuntime) -> MultiModelRegistry:
+async def model_registry(model_settings: ModelSettings) -> MultiModelRegistry:
     model_registry = MultiModelRegistry()
-    await model_registry.load(runtime)
+    await model_registry.load(model_settings)
     return model_registry
+
+
+@pytest.fixture
+async def runtime(
+    model_registry: MultiModelRegistry, model_settings: ModelSettings
+) -> MLflowRuntime:
+    return await model_registry.get_model(model_settings.name)
 
 
 @pytest.fixture

--- a/runtimes/mlflow/tests/rest/conftest.py
+++ b/runtimes/mlflow/tests/rest/conftest.py
@@ -7,6 +7,7 @@ from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
 from mlserver.rest import RESTServer
 from mlserver.repository import ModelRepository
+from mlserver.model import MLModel
 from mlserver import Settings, ModelSettings
 
 from mlserver_mlflow import MLflowRuntime
@@ -27,7 +28,7 @@ async def model_registry(model_settings: ModelSettings) -> MultiModelRegistry:
 @pytest.fixture
 async def runtime(
     model_registry: MultiModelRegistry, model_settings: ModelSettings
-) -> MLflowRuntime:
+) -> MLModel:
     return await model_registry.get_model(model_settings.name)
 
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -5,11 +5,11 @@ from mlserver.settings import Settings, ModelSettings
 
 
 async def test_load_models(sum_model_settings: ModelSettings, model_folder: str):
-    _, models = await load_settings(model_folder)
+    _, models_settings = await load_settings(model_folder)
 
-    assert len(models) == 1
-    assert models[0].name == sum_model_settings.name
-    assert models[0].version == sum_model_settings.parameters.version  # type: ignore
+    assert len(models_settings) == 1
+    assert models_settings[0].name == sum_model_settings.name
+    assert models_settings[0].parameters.version == sum_model_settings.parameters.version  # type: ignore
 
 
 async def test_disable_load_models(settings: Settings, model_folder: str):
@@ -19,6 +19,6 @@ async def test_disable_load_models(settings: Settings, model_folder: str):
     with open(settings_path, "w") as settings_file:
         settings_file.write(settings.json())
 
-    _, models = await load_settings(model_folder)
+    _, models_settings = await load_settings(model_folder)
 
-    assert len(models) == 0
+    assert len(models_settings) == 0

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -8,8 +8,11 @@ async def test_load_models(sum_model_settings: ModelSettings, model_folder: str)
     _, models_settings = await load_settings(model_folder)
 
     assert len(models_settings) == 1
-    assert models_settings[0].name == sum_model_settings.name
-    assert models_settings[0].parameters.version == sum_model_settings.parameters.version  # type: ignore
+
+    model_settings = models_settings[0]
+    parameters = models_settings[0].parameters
+    assert model_settings.name == sum_model_settings.name
+    assert parameters.version == sum_model_settings.parameters.version  # type: ignore
 
 
 async def test_disable_load_models(settings: Settings, model_folder: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,10 @@ def sum_model_settings() -> ModelSettings:
 
 
 @pytest.fixture
-def sum_model(sum_model_settings: ModelSettings) -> SumModel:
-    return SumModel(settings=sum_model_settings)
+async def sum_model(
+    model_registry: MultiModelRegistry, sum_model_settings: ModelSettings
+) -> SumModel:
+    return await model_registry.get_model(sum_model_settings.name)
 
 
 @pytest.fixture
@@ -59,9 +61,9 @@ def inference_response() -> types.InferenceResponse:
 
 
 @pytest.fixture
-async def model_registry(sum_model: SumModel) -> MultiModelRegistry:
+async def model_registry(sum_model_settings: ModelSettings) -> MultiModelRegistry:
     model_registry = MultiModelRegistry()
-    await model_registry.load(sum_model)
+    await model_registry.load(sum_model_settings)
     return model_registry
 
 

--- a/tests/handlers/conftest.py
+++ b/tests/handlers/conftest.py
@@ -2,7 +2,9 @@ import pytest
 
 from mlserver.handlers.custom import CustomHandler
 
+from ..fixtures import SumModel
+
 
 @pytest.fixture
-def custom_handler() -> CustomHandler:
+def custom_handler(sum_model: SumModel) -> CustomHandler:
     return CustomHandler(rest_path="/my-custom-endpoint")

--- a/tests/handlers/test_dataplane.py
+++ b/tests/handlers/test_dataplane.py
@@ -12,8 +12,7 @@ async def test_ready(data_plane, model_registry, ready):
     model_settings = ModelSettings(
         name="sum-model-2", parameters=ModelParameters(version="v1.2.3")
     )
-    new_model = SumModel(model_settings)
-    await model_registry.load(new_model)
+    new_model = await model_registry.load(model_settings)
 
     new_model.ready = ready
 

--- a/tests/handlers/test_dataplane.py
+++ b/tests/handlers/test_dataplane.py
@@ -4,8 +4,6 @@ import uuid
 from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import MetadataTensor
 
-from ..fixtures import SumModel
-
 
 @pytest.mark.parametrize("ready", [True, False])
 async def test_ready(data_plane, model_registry, ready):

--- a/tests/handlers/test_model_repository.py
+++ b/tests/handlers/test_model_repository.py
@@ -87,8 +87,12 @@ async def test_load_removes_stale_models(
     model_registry: MultiModelRegistry,
     sum_model_settings: ModelSettings,
 ):
-    # Load a few models which are not present on the repository, therefore they
-    # will be stale
+    # Load a few models which are not present on the repository (including a
+    # default one), therefore they will be stale
+    stale_settings = sum_model_settings.copy(deep=True)
+    stale_settings.parameters.version = None
+    await model_registry.load(stale_settings)
+
     to_load = ["v0", "v1", "v2"]
     for version in to_load:
         stale_settings = sum_model_settings.copy(deep=True)
@@ -97,7 +101,12 @@ async def test_load_removes_stale_models(
 
     # Validate that the stale test models have been loaded
     registry_models = await model_registry.get_models(sum_model_settings.name)
-    assert len(registry_models) == len(to_load) + 1
+    stale_length = (
+        len(to_load)
+        + 1  # Count the (stale) default model
+        + 1  # Count the previous (non-stale) model
+    )
+    assert len(registry_models) == stale_length
 
     # Reload our model and validate whether stale models have been removed
     await model_repository_handlers.load(sum_model_settings.name)

--- a/tests/handlers/test_model_repository.py
+++ b/tests/handlers/test_model_repository.py
@@ -79,3 +79,37 @@ async def test_load_not_found(
 ):
     with pytest.raises(ModelNotFound):
         await model_repository_handlers.load("not-existing")
+
+
+async def test_load_removes_stale_models(
+    model_repository_handlers: ModelRepositoryHandlers,
+    repository_index_request: RepositoryIndexRequest,
+    model_registry: MultiModelRegistry,
+    sum_model_settings: ModelSettings,
+):
+    # Load a few models which are not present on the repository, therefore they
+    # will be stale
+    to_load = ["v0", "v1", "v2"]
+    for version in to_load:
+        stale_settings = sum_model_settings.copy(deep=True)
+        stale_settings.parameters.version = version
+        await model_registry.load(stale_settings)
+
+    # Validate that the stale test models have been loaded
+    registry_models = await model_registry.get_models(sum_model_settings.name)
+    assert len(registry_models) == len(to_load) + 1
+
+    # Reload our model and validate whether stale models have been removed
+    await model_repository_handlers.load(sum_model_settings.name)
+
+    # Assert that stale models have been removed from both the registry (and
+    # ensure they are not present on the repository either)
+    registry_models = await model_registry.get_models(sum_model_settings.name)
+    repo_models = list(await model_repository_handlers.index(repository_index_request))
+    expected_version = sum_model_settings.parameters.version
+
+    assert len(registry_models) == 1
+    assert registry_models[0].version == expected_version
+
+    assert len(repo_models) == 1
+    assert repo_models[0].version == expected_version

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -5,8 +5,7 @@ from prometheus_client.registry import REGISTRY, CollectorRegistry
 from starlette_exporter import PrometheusMiddleware
 
 from mlserver.server import MLServer
-from mlserver.settings import Settings
-from mlserver.model import MLModel
+from mlserver.settings import Settings, ModelSettings
 
 from ..utils import get_available_port
 from .utils import MetricsClient
@@ -48,7 +47,7 @@ def settings(settings: Settings) -> Settings:
 @pytest.fixture
 async def mlserver(
     settings: Settings,
-    sum_model: MLModel,
+    sum_model_settings: ModelSettings,
     prometheus_registry: CollectorRegistry,  # noqa: F811
 ):
     server = MLServer(settings)
@@ -58,7 +57,7 @@ async def mlserver(
     server_task = loop.create_task(server.start())
 
     # Load sample model
-    await server._model_registry.load(sum_model)
+    await server._model_registry.load(sum_model_settings)
 
     yield server
 

--- a/tests/rest/test_utils.py
+++ b/tests/rest/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fastapi import status
+from fastapi.routing import APIRoute
 from mlserver.rest.utils import to_status_code
 
 

--- a/tests/rest/test_utils.py
+++ b/tests/rest/test_utils.py
@@ -1,7 +1,6 @@
 import pytest
 
 from fastapi import status
-from fastapi.routing import APIRoute
 from mlserver.rest.utils import to_status_code
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,6 @@
 import pytest
 
 from mlserver.errors import ModelNotFound
-from mlserver.model import MLModel
 from mlserver.registry import MultiModelRegistry
 from mlserver.settings import ModelSettings
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@ import pytest
 from mlserver.errors import ModelNotFound
 from mlserver.model import MLModel
 from mlserver.registry import MultiModelRegistry
+from mlserver.settings import ModelSettings
 
 
 @pytest.mark.parametrize(
@@ -34,9 +35,9 @@ async def test_get_model(model_registry, sum_model, name, version):
 
 
 async def test_model_hooks(
-    model_registry: MultiModelRegistry, sum_model: MLModel, mocker
+    model_registry: MultiModelRegistry, sum_model_settings: ModelSettings, mocker
 ):
-    sum_model._settings.name = "sum-model-2"
+    sum_model_settings.name = "sum-model-2"
 
     async def _async_val():
         return None
@@ -47,7 +48,7 @@ async def test_model_hooks(
     model_registry._on_model_unload = [mocker.stub("_on_model_unload")]
     model_registry._on_model_unload[0].return_value = _async_val()
 
-    await model_registry.load(sum_model)
+    sum_model = await model_registry.load(sum_model_settings)
     for callback in model_registry._on_model_load:
         callback.assert_called_once_with(sum_model)
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -102,8 +102,9 @@ async def test_load_multi_version(
     existing_version = sum_model_settings.parameters.version
 
     # Load new model
-    sum_model_settings.parameters.version = "v2.0.0"
-    new_model = await model_registry.load(sum_model_settings)
+    new_model_settings = sum_model_settings.copy(deep=True)
+    new_model_settings.parameters.version = "v2.0.0"
+    new_model = await model_registry.load(new_model_settings)
 
     # Ensure latest model is now the default one
     default_model = await model_registry.get_model(sum_model_settings.name)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,6 @@
 import pytest
-import asyncio
 
-from typing import List, Union, Union
+from typing import List, Union
 
 from mlserver.errors import ModelNotFound
 from mlserver.registry import MultiModelRegistry

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -98,4 +98,5 @@ async def test_find(
 ):
     found_model_settings = await model_repository.find(sum_model_settings.name)
 
-    assert found_model_settings.name == sum_model_settings.name
+    assert len(found_model_settings) == 1
+    assert found_model_settings[0].name == sum_model_settings.name


### PR DESCRIPTION
Fixes #433 

## Changelog

- After loading a new model, refresh existing ones to ensure stale models (i.e. loaded, but not present in the repo anymore) get unloaded.
- When (re)loading an existing model (i.e. same name and version, but potentially different artifacts), unload the previous instance of the model.
- Ensure that default model (i.e. reached when there's no version in the URI path) points to the "latest" version, where latest is the highest integer version (if all versions are integers), or the lexicographically highest version (if all versions are not integers).
- Allow models to be loaded from folders named after the model's version (note that this won't change the model version!!). 