### PR TITLE
feat: add warm worker pool capability

### DIFF
--- a/mlserver/parallel.py
+++ b/mlserver/parallel.py
@@ -59,9 +59,14 @@ def _mp_predict(payload: InferenceRequest) -> InferenceResponse:
     return asyncio.run(_mp_model.predict(payload))
 
 def _mp_noop():
+    """
+    This method is called to "warm workers."
+    """
+    # This sleep is important. Without it, workers in
+    # the pool can finish the noop too quickly and run multiple operations.
+    # Thus not "warming" all the workers in the pool
     time.sleep(0.1)
     return None
-
 
 
 class InferencePool:

--- a/mlserver/parallel.py
+++ b/mlserver/parallel.py
@@ -58,6 +58,7 @@ def _mp_predict(payload: InferenceRequest) -> InferenceResponse:
     global _mp_model
     return asyncio.run(_mp_model.predict(payload))
 
+
 def _mp_noop():
     """
     This method is called to "warm workers."
@@ -159,7 +160,7 @@ async def load_inference_pool(model: MLModel):
     # Conditionally load models to all workers in thread pool executor
     # This will cut down on initial inference response times but
     # will increase the amount of RAM utilized
-    if model.settings.warm_workers == True:
+    if model.settings.warm_workers:
         await pool.warm_workers(model)
 
     return model

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -132,6 +132,10 @@ class ModelSettings(BaseSettings):
     across."""
     parallel_workers: int = 4
 
+    """When parallel inference is enabled, optionally load model to all workers
+    on startup"""
+    warm_workers: bool = False
+
     # Adaptive Batching settings (disabled by default)
     """When adaptive batching is enabled, maximum number of requests to group
     together in a single batch."""

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -70,6 +70,17 @@ async def test_load_inference_pool(sum_model: MLModel):
 
     assert hasattr(sum_model, _InferencePoolAttr)
 
+async def test_load_inference_pool_warmed(sum_model: MLModel):
+    sum_model.settings.warm_workers = True
+    await load_inference_pool(sum_model)
+    pool = getattr(sum_model, _InferencePoolAttr)
+    assert hasattr(pool, "_warmed")
+
+async def test_load_inference_pool_not_warmed(sum_model: MLModel):
+    sum_model.settings.warm_workers = False
+    await load_inference_pool(sum_model)
+    pool = getattr(sum_model, _InferencePoolAttr)
+    assert not hasattr(pool, "_warmed")
 
 async def test_dont_load_if_disabled(sum_model: MLModel):
     sum_model.settings.parallel_workers = 0

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -70,17 +70,20 @@ async def test_load_inference_pool(sum_model: MLModel):
 
     assert hasattr(sum_model, _InferencePoolAttr)
 
+
 async def test_load_inference_pool_warmed(sum_model: MLModel):
     sum_model.settings.warm_workers = True
     await load_inference_pool(sum_model)
     pool = getattr(sum_model, _InferencePoolAttr)
     assert hasattr(pool, "_warmed")
 
+
 async def test_load_inference_pool_not_warmed(sum_model: MLModel):
     sum_model.settings.warm_workers = False
     await load_inference_pool(sum_model)
     pool = getattr(sum_model, _InferencePoolAttr)
     assert not hasattr(pool, "_warmed")
+
 
 async def test_dont_load_if_disabled(sum_model: MLModel):
     sum_model.settings.parallel_workers = 0


### PR DESCRIPTION
This PR will add a conditional option to force the ProcessPoolExecutor workers to run the initializer before "loading" is complete (i.e. the server endpoint will wait for all the process workers to load the model). This cuts down on initial inference request latency significantly see below:

## With "warmed workers" 
```

❯ hey \
   -n 10 \
   -c 5 \
   -m POST \
   -T 'application/json' \
   -D ./data/iris/rest-requests.json \
   http://localhost:8080/v2/models/iris/infer

Summary:
  Total:	0.8286 secs
  Slowest:	0.4160 secs
  Fastest:	0.4090 secs
  Average:	0.4133 secs
  Requests/sec:	12.0690

  Total data:	1950 bytes
  Size/request:	195 bytes

Response time histogram:
  0.409 [1]	|■■■■■■■■■■■■■
  0.410 [0]	|
  0.410 [0]	|
  0.411 [0]	|
  0.412 [1]	|■■■■■■■■■■■■■
  0.412 [0]	|
  0.413 [1]	|■■■■■■■■■■■■■
  0.414 [3]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.415 [2]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.415 [1]	|■■■■■■■■■■■■■
  0.416 [1]	|■■■■■■■■■■■■■


Latency distribution:
  10% in 0.4115 secs
  25% in 0.4136 secs
  50% in 0.4138 secs
  75% in 0.4148 secs
  90% in 0.4160 secs
  0% in 0.0000 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0009 secs, 0.4090 secs, 0.4160 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0008 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0002 secs
  resp wait:	0.4122 secs, 0.4070 secs, 0.4159 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0002 secs

Status code distribution:
  [200]	10 responses
```

## Without

```
hey \
 -n 10 \
 -c 5 \
 -m POST \
 -T 'application/json' \
 -D ./data/iris/rest-requests.json \
 http://localhost:8080/v2/models/iris/infer

Summary:
  Total:	2.0543 secs
  Slowest:	1.6380 secs
  Fastest:	0.4156 secs
  Average:	1.0261 secs
  Requests/sec:	4.8679

  Total data:	1950 bytes
  Size/request:	195 bytes

Response time histogram:
  0.416 [1]	|■■■■■■■■
  0.538 [4]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.660 [0]	|
  0.782 [0]	|
  0.905 [0]	|
  1.027 [0]	|
  1.149 [0]	|
  1.271 [0]	|
  1.394 [0]	|
  1.516 [0]	|
  1.638 [5]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■


Latency distribution:
  10% in 0.4157 secs
  25% in 0.4160 secs
  50% in 1.6346 secs
  75% in 1.6372 secs
  90% in 1.6380 secs
  0% in 0.0000 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0014 secs, 0.4156 secs, 1.6380 secs
  DNS-lookup:	0.0006 secs, 0.0000 secs, 0.0012 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0003 secs
  resp wait:	1.0243 secs, 0.4155 secs, 1.6344 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0001 secs

Status code distribution:
  [200]	10 responses
```