### PR TITLE
Return DataFrames from SKLearn models

### DIFF
--- a/runtimes/sklearn/mlserver_sklearn/sklearn.py
+++ b/runtimes/sklearn/mlserver_sklearn/sklearn.py
@@ -7,7 +7,6 @@ from pandas import DataFrame
 from sklearn.pipeline import Pipeline
 
 from mlserver import types
-from mlserver.codecs.base import find_input_codec, find_request_codec
 from mlserver.model import MLModel
 from mlserver.errors import InferenceError
 from mlserver.types import ResponseOutput, RequestOutput
@@ -95,7 +94,7 @@ class SKLearnModel(MLModel):
 
         return outputs
 
-    def _encode_outputs(self, outputs: List[Tuple[RequestOutput, object]]) -> List[types.ResponseOutput]:
+    def _encode_outputs(self, outputs: List[Tuple[RequestOutput, object]]) -> List[ResponseOutput]:
         response_outputs = []
 
         all_output_names = [o[0].name for o in outputs]

--- a/runtimes/sklearn/mlserver_sklearn/sklearn.py
+++ b/runtimes/sklearn/mlserver_sklearn/sklearn.py
@@ -1,14 +1,16 @@
 import joblib
 
-from typing import List
+from typing import List, Tuple
 
+import pandas as pd
+from pandas import DataFrame
 from sklearn.pipeline import Pipeline
 
 from mlserver import types
 from mlserver.codecs.base import find_input_codec, find_request_codec
 from mlserver.model import MLModel
 from mlserver.errors import InferenceError
-from mlserver.types import ResponseOutput
+from mlserver.types import ResponseOutput, RequestOutput
 from mlserver.utils import get_model_uri
 from mlserver.codecs import NumpyCodec, NumpyRequestCodec, PandasCodec
 
@@ -38,11 +40,21 @@ class SKLearnModel(MLModel):
     async def predict(self, payload: types.InferenceRequest) -> types.InferenceResponse:
         payload = self._check_request(payload)
 
+        model_responses = self._get_model_outputs(payload)
+
+        if (len(model_responses) == 1 and isinstance(model_responses[0][1], DataFrame)):
+            print("Trying to encode data frame")
+            df: DataFrame = model_responses[0][1]
+            return PandasCodec.encode(model_name=self.name,
+                                      model_version=self.version,
+                                      payload=df)
+
+        print("Not encoding dataframe")
         return types.InferenceResponse(
-            model_name=self.name,
-            model_version=self.version,
-            outputs=self._predict_outputs(payload),
-        )
+                model_name=self.name,
+                model_version=self.version,
+                outputs=self._encode_outputs(model_responses),
+            )
 
     def _check_request(self, payload: types.InferenceRequest) -> types.InferenceRequest:
         if not payload.outputs:
@@ -72,37 +84,30 @@ class SKLearnModel(MLModel):
 
         return payload
 
-    def _predict_outputs(
-        self, payload: types.InferenceRequest
-    ) -> List[types.ResponseOutput]:
+    def _get_model_outputs(self, payload: types.InferenceRequest) -> List[Tuple[RequestOutput, object]]:
         decoded_request = self.decode_request(payload, default_codec=NumpyRequestCodec)
 
         outputs = []
         for request_output in payload.outputs:  # type: ignore
             predict_fn = getattr(self._model, request_output.name)
             y = predict_fn(decoded_request)
-
-            output_codec = NumpyCodec
-            if request_output.parameters:
-                output_content_type = request_output.parameters.content_type
-                if output_content_type:
-                    output_codec = None#find_input_codec(output_content_type)
-                    if not output_codec:
-                        output_codec = find_request_codec(output_content_type)
-
-            # TODO: Set datatype (cast from numpy?)
-            # response_output = output_codec.encode(name=request_output.name, payload=y)
-
-            # response_output = output_codec.encode(model_name="foo", payload=y)
-
-            print("encoding ", y)
-            response_output = PandasCodec.encode(model_name=self.name, payload=y)
-
-            foo = ResponseOutput(name=request_output.name, shape=[1], datatype="pd", data=response_output.outputs)
-            outputs.append(foo)
-
-            print("got", response_output)
-
-            # self.
+            outputs.append((request_output, y))
 
         return outputs
+
+    def _encode_outputs(self, outputs: List[Tuple[RequestOutput, object]]) -> List[types.ResponseOutput]:
+        response_outputs = []
+
+        all_output_names = [o[0].name for o in outputs]
+
+        for output, response in outputs:
+            if isinstance(response, pd.DataFrame):
+                raise InferenceError(f"{output.name} is of type DataFrame and {all_output_names} were"
+                                     f" requested. Cannot encode multiple DataFrames in one response."
+                                     f" Please request only a single DataFrame output.")
+
+            # TODO: accommodate more things like Strings
+            response_output = NumpyCodec.encode(name=output.name, payload=response)
+            response_outputs.append(response_output)
+
+        return response_outputs

--- a/runtimes/sklearn/tests/conftest.py
+++ b/runtimes/sklearn/tests/conftest.py
@@ -8,6 +8,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.base import BaseEstimator
 
 from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import InferenceRequest
@@ -153,3 +154,58 @@ def pandas_inference_request() -> InferenceRequest:
         ],
     }
     return InferenceRequest.parse_obj(inference_request)
+
+
+class DummyStringModel(BaseEstimator):
+    """Predict returns a string"""
+
+    def predict(self, X):
+        return "some string"
+
+@pytest.fixture
+async def string_model(tmp_path) -> SKLearnModel:
+    dummy = DummyStringModel()
+    model_uri = os.path.join(tmp_path, "string-model.joblib")
+    joblib.dump(dummy, model_uri)
+
+    dummy_model_settings = ModelSettings(
+        name="string-model",
+        parameters=ModelParameters(uri=model_uri, version="v1.2.3"),
+    )
+
+    model = SKLearnModel(dummy_model_settings)
+    await model.load()
+    return model
+
+
+class DummyDataframeModel(BaseEstimator):
+    """predict/_proba return data frames"""
+
+    def predict(self, X):
+        frame = pd.DataFrame()
+        frame["label_1"] = np.array([1])
+        frame["label_2"] = np.array([2])
+        frame["label_3"] = 3
+        return frame
+
+    def predict_proba(self, X):
+        frame = pd.DataFrame()
+        frame["label_1_prob"] = np.array([0.123])
+        frame["label_2_prob"] = np.array([0.456])
+        frame["label_3_prob"] = 0.789
+        return frame
+
+@pytest.fixture
+async def dataframe_model(tmp_path) -> SKLearnModel:
+    dummy = DummyDataframeModel()
+    model_uri = os.path.join(tmp_path, "dataframe-model.joblib")
+    joblib.dump(dummy, model_uri)
+
+    dummy_model_settings = ModelSettings(
+        name="frame-model",
+        parameters=ModelParameters(uri=model_uri, version="v1.2.3"),
+    )
+
+    model = SKLearnModel(dummy_model_settings)
+    await model.load()
+    return model

--- a/runtimes/sklearn/tests/test_sklearn.py
+++ b/runtimes/sklearn/tests/test_sklearn.py
@@ -133,7 +133,7 @@ async def test_no_predict_proba_for_regression_pipelines(
     with pytest.raises(InferenceError):
         await pandas_model.predict(pandas_inference_request)
 
-# TODO: not implemeted yet
+# TODO: implement other basic codecs
 # async def test_string_model_output(string_model: SKLearnModel, inference_request):
 #     inference_request.outputs = [RequestOutput(name=PREDICT_OUTPUT,
 #                                                parameters=Parameters(content_type="str"))]
@@ -141,7 +141,6 @@ async def test_no_predict_proba_for_regression_pipelines(
 #     response = await string_model.predict(inference_request)
 
 
-# TODO: is error case
 async def test_error_on_multiple_dataframe_outputs(dataframe_model: SKLearnModel, inference_request):
     inference_request.outputs = [RequestOutput(name=PREDICT_OUTPUT,
                                                parameters=Parameters(content_type="pd")),
@@ -152,7 +151,6 @@ async def test_error_on_multiple_dataframe_outputs(dataframe_model: SKLearnModel
         await dataframe_model.predict(inference_request)
 
     assert "Please request only a single DataFrame output" in str(e.value)
-
 
 
 async def test_dataframe_model_output(dataframe_model: SKLearnModel, inference_request):

--- a/runtimes/sklearn/tests/test_sklearn.py
+++ b/runtimes/sklearn/tests/test_sklearn.py
@@ -6,7 +6,8 @@ from sklearn.pipeline import Pipeline
 from mlserver.settings import ModelSettings
 from mlserver.codecs import CodecError
 from mlserver.errors import InferenceError
-from mlserver.types import RequestInput, RequestOutput
+from mlserver.types import RequestInput, RequestOutput, Parameters
+from mlserver.codecs.base import _codec_registry
 
 from mlserver_sklearn import SKLearnModel
 from mlserver_sklearn.sklearn import (
@@ -130,3 +131,31 @@ async def test_no_predict_proba_for_regression_pipelines(
 
     with pytest.raises(InferenceError):
         await pandas_model.predict(pandas_inference_request)
+
+
+async def test_string_model_output(string_model: SKLearnModel, inference_request):
+    inference_request.outputs = [RequestOutput(name=PREDICT_OUTPUT,
+                                               parameters=Parameters(content_type="str"))]
+
+    print("codecccccccccccccs")
+    print(_codec_registry)
+    print(_codec_registry.__dict__)
+
+    response = await string_model.predict(inference_request)
+
+
+async def test_dataframe_model_output(dataframe_model: SKLearnModel, inference_request):
+    inference_request.outputs = [RequestOutput(name=PREDICT_OUTPUT,
+                                               parameters=Parameters(content_type="pd")),
+                                 RequestOutput(name=PREDICT_PROBA_OUTPUT,
+                                               parameters=Parameters(content_type="pd"))
+                                 ]
+
+    print("codecccccccccccccs")
+    print(_codec_registry)
+    print(_codec_registry.__dict__)
+
+    response = await dataframe_model.predict(inference_request)
+
+    print("\n\n\n", response, "\n\n\n")
+    assert 1 == 2


### PR DESCRIPTION
For https://github.com/SeldonIO/MLServer/issues/416

Still kinda WIP- we're focusing on getting this working internally at the moment.

This PR splits out the `_predict_outputs` logic into two functions, `_get_model_outputs` to run the model and `_encode_outputs` to encode the results.

This allows us to easily check if the list of model outputs contains just a single dataframe, and use the dataframe codec to encode that as the entire output. Otherwise, we roll through the outputs and use the numpy codec to encode each one, as `_predict_outputs` does currently.

If multiple DataFrames are output, an error will be thrown 