### PR TITLE
Fix some exception checks in unit tests

### DIFF
--- a/tests/grpc/test_servicers.py
+++ b/tests/grpc/test_servicers.py
@@ -89,8 +89,8 @@ async def test_model_infer_error(inference_service_stub, model_infer_request):
         model_infer_request.model_name = "my-model"
         await inference_service_stub.ModelInfer(model_infer_request)
 
-        assert err.status == grpc.Status.INVALID_ARGUMENT
-        assert err.details == "Model my-model with version v1.2.3 not found"
+    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert err.value.details() == "Model my-model with version v1.2.3 not found"
 
 
 async def test_model_repository_index(
@@ -141,5 +141,5 @@ async def test_model_repository_load_error(
         load_request = mr_pb.RepositoryModelLoadRequest(model_name="my-model")
         await model_repository_service_stub.RepositoryModelLoad(load_request)
 
-        assert err.status == grpc.Status.INVALID_ARGUMENT
-        assert err.details == "Model my-model not found"
+    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert err.value.details() == "Model my-model not found"

--- a/tests/metrics/test_endpoint.py
+++ b/tests/metrics/test_endpoint.py
@@ -22,7 +22,7 @@ async def test_metrics(metrics_client: MetricsClient):
         metrics_client._metrics_endpoint = "/metrics"
         with pytest.raises(ClientResponseError) as err:
             await metrics_client.metrics()
-            assert err.status_code == 404
+        assert err.value.status == 404
     else:
         # Otherwise, assert all metrics are present
         metrics = await metrics_client.metrics()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -49,10 +49,10 @@ async def test_get_model_not_found(model_registry, name, version):
     with pytest.raises(ModelNotFound) as err:
         await model_registry.get_model(name, version)
 
-        if version is not None:
-            assert err.message == f"Model {name} with version {version} not found"
-        else:
-            assert err.message == f"Model {name} not found"
+    if version is not None:
+        assert str(err.value) == f"Model {name} with version {version} not found"
+    else:
+        assert str(err.value) == f"Model {name} not found"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`pytest.raises(...)` is not used correctly in some places meaning that those tests aren't actually verifying the exception as intended.

Specifically, the statement that raises the exception must be the last one in the `with` block and so follow-on assertions must be outside it.