### PR TITLE
More accurate REST/gRPC response status codes for errors

### DIFF
--- a/mlserver/errors.py
+++ b/mlserver/errors.py
@@ -32,4 +32,6 @@ class InferenceError(MLServerError):
 
 class ModelParametersMissing(MLServerError):
     def __init__(self, model_name: str):
-        super().__init__(f"Parameters missing for model {model_name}", status.HTTP_400_BAD_REQUEST)
+        super().__init__(
+            f"Parameters missing for model {model_name}", status.HTTP_400_BAD_REQUEST
+        )

--- a/mlserver/errors.py
+++ b/mlserver/errors.py
@@ -1,6 +1,10 @@
+from fastapi import status
+
+
 class MLServerError(Exception):
-    def __init__(self, msg: str):
+    def __init__(self, msg: str, status_code: int = status.HTTP_400_BAD_REQUEST):
         super().__init__(msg)
+        self.status_code = status_code
 
 
 class InvalidModelURI(MLServerError):
@@ -9,7 +13,7 @@ class InvalidModelURI(MLServerError):
         if model_uri:
             msg += f" ({model_uri})"
 
-        super().__init__(msg)
+        super().__init__(msg, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
 
 class ModelNotFound(MLServerError):
@@ -18,14 +22,14 @@ class ModelNotFound(MLServerError):
         if version is not None:
             msg = f"Model {name} with version {version} not found"
 
-        super().__init__(msg)
+        super().__init__(msg, status.HTTP_404_NOT_FOUND)
 
 
 class InferenceError(MLServerError):
     def __init__(self, msg: str):
-        super().__init__(msg)
+        super().__init__(msg, status.HTTP_400_BAD_REQUEST)
 
 
 class ModelParametersMissing(MLServerError):
     def __init__(self, model_name: str):
-        super().__init__(f"Parameters missing for model {model_name}")
+        super().__init__(f"Parameters missing for model {model_name}", status.HTTP_400_BAD_REQUEST)

--- a/mlserver/rest/errors.py
+++ b/mlserver/rest/errors.py
@@ -12,7 +12,7 @@ class APIErrorResponse(BaseModel):
 
 async def handle_mlserver_error(request: Request, exc: MLServerError) -> Response:
     err_res = APIErrorResponse(error=str(exc))
-    return Response(status_code=status.HTTP_400_BAD_REQUEST, content=err_res.dict())
+    return Response(status_code=exc.status_code, content=err_res.dict())
 
 
 _EXCEPTION_HANDLERS = {MLServerError: handle_mlserver_error}

--- a/mlserver/rest/errors.py
+++ b/mlserver/rest/errors.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from fastapi import Request, status
+from fastapi import Request
 from pydantic import BaseModel
 
 from .responses import Response

--- a/tests/grpc/test_servicers.py
+++ b/tests/grpc/test_servicers.py
@@ -89,7 +89,7 @@ async def test_model_infer_error(inference_service_stub, model_infer_request):
         model_infer_request.model_name = "my-model"
         await inference_service_stub.ModelInfer(model_infer_request)
 
-    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert err.value.code() == grpc.StatusCode.NOT_FOUND
     assert err.value.details() == "Model my-model with version v1.2.3 not found"
 
 
@@ -141,5 +141,5 @@ async def test_model_repository_load_error(
         load_request = mr_pb.RepositoryModelLoadRequest(model_name="my-model")
         await model_repository_service_stub.RepositoryModelLoad(load_request)
 
-    assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert err.value.code() == grpc.StatusCode.NOT_FOUND
     assert err.value.details() == "Model my-model not found"

--- a/tests/rest/test_endpoints.py
+++ b/tests/rest/test_endpoints.py
@@ -78,7 +78,7 @@ def test_infer_error(rest_client, inference_request):
     endpoint = "/v2/models/my-model/versions/v0/infer"
     response = rest_client.post(endpoint, json=inference_request.dict())
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.json()["error"] == "Model my-model with version v0 not found"
 
 
@@ -99,7 +99,7 @@ def test_model_repository_unload(rest_client, sum_model_settings):
     assert response.status_code == 200
 
     model_metadata = rest_client.get(f"/v2/models/{sum_model_settings.name}")
-    assert model_metadata.status_code == 400
+    assert model_metadata.status_code == 404
 
 
 def test_model_repository_load(rest_client, sum_model_settings):
@@ -118,5 +118,5 @@ def test_model_repository_load_error(rest_client, sum_model_settings):
     endpoint = "/v2/repository/models/my-model/load"
     response = rest_client.post(endpoint)
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.json()["error"] == "Model my-model not found"


### PR DESCRIPTION
Currently MLServer returns a 400 HTTP response or `INVALID_ARGUMENT` gRPC response in all error cases. It would be useful to distinguish between different classes of error, in particular indicating the model-not-found case with a 404 or gRPC `NOT_FOUND` status. Model-mesh uses `NOT_FOUND` to take corrective action i.e. re-load the model in question if necessary.

I kept the default value as 400 for `MLServerError` subclasses that don't provide a specific code, but maybe something else like 500 would be more appropriate?

Note that this is affected by https://github.com/SeldonIO/MLServer/pull/487 but I can fix this one up after that's merged.