### PR TITLE
Use dtype in the request to create input DataFrame

### DIFF
--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -30,7 +30,7 @@ _NumpyToDatatype["object"] = "BYTES"
 _NumpyToDatatype["S"] = "BYTES"
 
 
-def _to_dtype(v2_data: Union[RequestInput, ResponseOutput]) -> "np.dtype":
+def to_dtype(v2_data: Union[RequestInput, ResponseOutput]) -> "np.dtype":
     dtype = _DatatypeToNumpy[v2_data.datatype]
 
     if v2_data.datatype == "BYTES":
@@ -56,7 +56,7 @@ def to_datatype(dtype: np.dtype) -> str:
 
 def _to_ndarray(v2_data: Union[RequestInput, ResponseOutput]) -> np.ndarray:
     data = getattr(v2_data.data, "__root__", v2_data.data)
-    dtype = _to_dtype(v2_data)
+    dtype = to_dtype(v2_data)
 
     if v2_data.datatype == "BYTES":
         # If the inputs is of type `BYTES`, there could be multiple "lists"

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 
 from .base import RequestCodec, register_request_codec
-from .numpy import to_datatype
+from .numpy import to_datatype, to_dtype
 from .string import encode_str
 from .utils import get_decoded_or_raw
 from .pack import PackElement
@@ -15,6 +15,8 @@ def _to_series(request_input: RequestInput) -> pd.Series:
     if isinstance(payload, np.ndarray):
         # Necessary so that it's compatible with pd.Series
         payload = list(payload)
+        dtype = to_dtype(request_input)
+        return pd.Series(payload, dtype=dtype)
 
     return pd.Series(payload)
 

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -130,20 +130,19 @@ def test_encode(dataframe, expected):
             ),
         ),
         (
-                InferenceRequest(
-                    inputs=[
-                        RequestInput(
-                            name="a",
-                            data=[1],
-                            datatype="INT32",
-                            shape=[1],
-                            parameters=Parameters(_decoded_payload=np.array([1])),
-                        ),
-                    ]
-                ),
-                pd.DataFrame({"a": np.array([1], dtype=np.int32)}),
+            InferenceRequest(
+                inputs=[
+                    RequestInput(
+                        name="a",
+                        data=[1],
+                        datatype="INT32",
+                        shape=[1],
+                        parameters=Parameters(_decoded_payload=np.array([1])),
+                    ),
+                ]
+            ),
+            pd.DataFrame({"a": np.array([1], dtype=np.int32)}),
         ),
-
     ],
 )
 def test_decode(inference_request, expected):

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -129,6 +129,21 @@ def test_encode(dataframe, expected):
                 }
             ),
         ),
+        (
+                InferenceRequest(
+                    inputs=[
+                        RequestInput(
+                            name="a",
+                            data=[1],
+                            datatype="INT32",
+                            shape=[1],
+                            parameters=Parameters(_decoded_payload=np.array([1])),
+                        ),
+                    ]
+                ),
+                pd.DataFrame({"a": np.array([1], dtype=np.int32)}),
+        ),
+
     ],
 )
 def test_decode(inference_request, expected):


### PR DESCRIPTION
While testing MLServer in Seldon Core, I discovered a bug due to which the datatype sent in the request input is not used to create the dataframe. Instead it uses the default data types in Pandas which do not include `int32`. This PR proposes a fix for this bug. 

The change has been tested using unit tests and locally by running mlserver. 

Related slack thread - https://seldondev.slack.com/archives/C8Y9A8G0Y/p1645517701847759?thread_ts=1645093614.150229&cid=C8Y9A8G0Y 