### PR TITLE
Update default config for pytest-asyncio

### DIFF
--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -33,15 +33,6 @@ TESTS_PATH = Path(os.path.dirname(__file__))
 _ANCHOR_IMAGE_DIR = TESTS_PATH / ".data" / "mnist_anchor_image"
 
 
-# TODO: how to make this in utils?
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def custom_runtime_tf_settings() -> ModelSettings:
     return ModelSettings(

--- a/runtimes/lightgbm/tests/conftest.py
+++ b/runtimes/lightgbm/tests/conftest.py
@@ -12,14 +12,6 @@ TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def model_uri(tmp_path) -> str:
     n = 4

--- a/runtimes/mlflow/tests/conftest.py
+++ b/runtimes/mlflow/tests/conftest.py
@@ -19,14 +19,6 @@ TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 TESTDATA_CACHE_PATH = os.path.join(TESTDATA_PATH, ".cache")
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def dataset() -> tuple:
     n = 4

--- a/runtimes/sklearn/tests/conftest.py
+++ b/runtimes/sklearn/tests/conftest.py
@@ -19,14 +19,6 @@ TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def model_uri(tmp_path) -> str:
     n = 4

--- a/runtimes/xgboost/tests/conftest.py
+++ b/runtimes/xgboost/tests/conftest.py
@@ -12,14 +12,6 @@ TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def model_uri(tmp_path) -> str:
     n = 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ exclude =
 ignore_missing_imports = True
 plugins = pydantic.mypy
 
+[tool:pytest]
+asyncio_mode = auto
+
 [tox:tox]
 basepython = py3
 envlist =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,6 @@ TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Add pytest.mark.asyncio marker to every test.
-    """
-    for item in items:
-        item.add_marker("asyncio")
-
-
 @pytest.fixture
 def sum_model_settings() -> ModelSettings:
     model_settings_path = os.path.join(TESTDATA_PATH, "model-settings.json")


### PR DESCRIPTION
Update `pytest-asyncio`'s config so that it uses the new [auto mode](https://github.com/pytest-dev/pytest-asyncio#auto-mode), which also removes a warning from the tests.