### PR TITLE
Fix flakiness in Alibi's end-to-end 

### DIFF
--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from alibi.saving import load_explainer
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose
 
 from helpers.tf_model import get_tf_mnist_model_uri
 from mlserver import MLModel
@@ -80,7 +80,7 @@ async def test_predict_impl(
         expected_result.outputs[0]
     )
 
-    assert_array_equal(actual_result, expected_result_numpy)
+    assert_allclose(actual_result, expected_result_numpy)
 
 
 @pytest.fixture()
@@ -108,7 +108,7 @@ async def test_end_2_end(
         # we remove it for alibi
     )
 
-    assert_array_equal(
+    assert_allclose(
         np.array(decoded_runtime_results["data"]["anchor"]), alibi_result.data["anchor"]
     )
 


### PR DESCRIPTION
## Changelog
- Use `assert_allclose` instead of `assert_array_equal` to allow an error tolerance