### PR TITLE
fix: Adaptive Batching ignoring requested output

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Both the main `mlserver` package and the [inference runtimes
 packages](./docs/runtimes/index.md) try to follow the same versioning schema.
 To bump the version across all of them, you can use the
 [`./hack/update-version.sh`](./hack/update-version.sh) script.
+
 For example:
 
 ```bash

--- a/mlserver/batching/requests.py
+++ b/mlserver/batching/requests.py
@@ -18,7 +18,7 @@ def _get_data(payload: Union[RequestInput, ResponseOutput]):
 
 def _merge_parameters(
     all_params: dict,
-    parametrised_obj: Union[InferenceRequest, RequestInput, RequestOutput]
+    parametrised_obj: Union[InferenceRequest, RequestInput, RequestOutput],
 ) -> dict:
     if not parametrised_obj.parameters:
         return all_params
@@ -84,10 +84,14 @@ class BatchedRequests:
             for request_inputs in inputs_index.values()
         ]
 
-        outputs = [
-            self._merge_request_outputs(request_outputs)
-            for request_outputs in outputs_index.values()
-        ] if has_outputs else None
+        outputs = (
+            [
+                self._merge_request_outputs(request_outputs)
+                for request_outputs in outputs_index.values()
+            ]
+            if has_outputs
+            else None
+        )
 
         # TODO: Should we add a 'fake' request ID?
         params = Parameters(**all_params) if all_params else None

--- a/mlserver/batching/requests.py
+++ b/mlserver/batching/requests.py
@@ -6,6 +6,7 @@ from ..types import (
     InferenceResponse,
     Parameters,
     RequestInput,
+    RequestOutput,
     ResponseOutput,
 )
 from .shape import Shape
@@ -16,7 +17,8 @@ def _get_data(payload: Union[RequestInput, ResponseOutput]):
 
 
 def _merge_parameters(
-    all_params: dict, parametrised_obj: Union[InferenceRequest, RequestInput]
+    all_params: dict,
+    parametrised_obj: Union[InferenceRequest, RequestInput, RequestOutput]
 ) -> dict:
     if not parametrised_obj.parameters:
         return all_params
@@ -62,7 +64,9 @@ class BatchedRequests:
 
     def _merge_requests(self) -> InferenceRequest:
         inputs_index: Dict[str, Dict[str, RequestInput]] = defaultdict(OrderedDict)
+        outputs_index: Dict[str, Dict[str, RequestOutput]] = defaultdict(OrderedDict)
         all_params: dict = {}
+        has_outputs = False  # if no outputs are defined, then outputs=None
 
         for internal_id, inference_request in self.inference_requests.items():
             self._ids_mapping[internal_id] = inference_request.id
@@ -70,15 +74,24 @@ class BatchedRequests:
             for request_input in inference_request.inputs:
                 inputs_index[request_input.name][internal_id] = request_input
 
+            if inference_request.outputs is not None:
+                has_outputs = True
+                for request_output in inference_request.outputs:
+                    outputs_index[request_output.name][internal_id] = request_output
+
         inputs = [
             self._merge_request_inputs(request_inputs)
             for request_inputs in inputs_index.values()
         ]
 
-        # TODO: Add outputs
+        outputs = [
+            self._merge_request_outputs(request_outputs)
+            for request_outputs in outputs_index.values()
+        ] if has_outputs else None
+
         # TODO: Should we add a 'fake' request ID?
         params = Parameters(**all_params) if all_params else None
-        return InferenceRequest(inputs=inputs, parameters=params)
+        return InferenceRequest(inputs=inputs, outputs=outputs, parameters=params)
 
     def _merge_request_inputs(
         self, request_inputs: Dict[str, RequestInput]
@@ -111,6 +124,20 @@ class BatchedRequests:
             data=data,
             parameters=parameters,
         )
+
+    def _merge_request_outputs(
+        self, request_outputs: Dict[str, RequestOutput]
+    ) -> RequestOutput:
+        all_params: dict = {}
+        for internal_id, request_output in request_outputs.items():
+            all_params = _merge_parameters(all_params, request_output)
+
+        parameters = Parameters(**all_params) if all_params else None
+
+        # TODO: What should we do if list is empty?
+        sampled = next(iter(request_outputs.values()))
+
+        return RequestOutput(name=sampled.name, parameters=parameters)
 
     def split_response(
         self, batched_response: InferenceResponse

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,15 +40,20 @@ def metadata_model_response() -> types.MetadataModelResponse:
     return types.MetadataModelResponse.parse_file(payload_path)
 
 
-@pytest.fixture
-def inference_request() -> types.InferenceRequest:
-    payload_path = os.path.join(TESTDATA_PATH, "inference-request.json")
+@pytest.fixture(params=[
+    "inference-request.json", "inference-request-with-output.json"
+])
+def inference_request(request) -> types.InferenceRequest:
+    payload_path = os.path.join(TESTDATA_PATH, request.param)
+    print(payload_path)
     return types.InferenceRequest.parse_file(payload_path)
 
 
-@pytest.fixture
-def inference_response() -> types.InferenceResponse:
-    payload_path = os.path.join(TESTDATA_PATH, "inference-response.json")
+@pytest.fixture(params=[
+    "inference-response.json", "inference-response-with-output.json"
+])
+def inference_response(request) -> types.InferenceResponse:
+    payload_path = os.path.join(TESTDATA_PATH, request.param)
     return types.InferenceResponse.parse_file(payload_path)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,18 +40,16 @@ def metadata_model_response() -> types.MetadataModelResponse:
     return types.MetadataModelResponse.parse_file(payload_path)
 
 
-@pytest.fixture(params=[
-    "inference-request.json", "inference-request-with-output.json"
-])
+@pytest.fixture(params=["inference-request.json", "inference-request-with-output.json"])
 def inference_request(request) -> types.InferenceRequest:
     payload_path = os.path.join(TESTDATA_PATH, request.param)
     print(payload_path)
     return types.InferenceRequest.parse_file(payload_path)
 
 
-@pytest.fixture(params=[
-    "inference-response.json", "inference-response-with-output.json"
-])
+@pytest.fixture(
+    params=["inference-response.json", "inference-response-with-output.json"]
+)
 def inference_response(request) -> types.InferenceResponse:
     payload_path = os.path.join(TESTDATA_PATH, request.param)
     return types.InferenceResponse.parse_file(payload_path)

--- a/tests/grpc/test_converters.py
+++ b/tests/grpc/test_converters.py
@@ -70,7 +70,7 @@ def test_modelinferresponse_from_types(inference_response):
         id="123",
         outputs=[
             pb.ModelInferResponse.InferOutputTensor(
-                name="output-0",
+                name=inference_response.outputs[0].name,
                 datatype="FP32",
                 shape=[1],
                 contents=pb.InferTensorContents(fp32_contents=[21.0]),

--- a/tests/testdata/inference-request-with-output.json
+++ b/tests/testdata/inference-request-with-output.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {
+      "name": "input-0",
+      "shape": [1, 3],
+      "datatype": "INT32",
+      "data": [1, 2, 3]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "requested-output-0"
+    }
+  ]
+}

--- a/tests/testdata/inference-response-with-output.json
+++ b/tests/testdata/inference-response-with-output.json
@@ -1,0 +1,12 @@
+{
+  "model_name": "sum-model",
+  "id": "123",
+  "outputs": [
+    {
+      "name": "requested-output-0",
+      "shape": [1],
+      "datatype": "FP32",
+      "data": [21.0]
+    }
+  ]
+}


### PR DESCRIPTION
Address #514.

Parameterise the test fixtures `inference_request` and `inference_response` to test inference requests with outputs.