### PR TITLE
Added _parse_dict_values method

### DIFF
--- a/hack/generate_dotenv.py
+++ b/hack/generate_dotenv.py
@@ -78,7 +78,7 @@ def save_default_env(env: dict, output: str):
 
 
 def _parse_dict_values(name: str, value: str) -> str:
-    if name == "MLSERVER_MODEL_EXTRA":
+    if "{" in value:
         value = value.replace("'", '"')
         return f"export {name}='{value}'\n"
     else:

--- a/hack/generate_dotenv.py
+++ b/hack/generate_dotenv.py
@@ -9,6 +9,7 @@ of settings that we want to source always (e.g. the default runtime to use).
 
 import click
 import json
+from json import JSONDecodeError
 import os
 
 from typing import List, Tuple, Type
@@ -78,10 +79,11 @@ def save_default_env(env: dict, output: str):
 
 
 def _parse_dict_values(name: str, value: str) -> str:
-    if "{" in value:
+    try:
         value = value.replace("'", '"')
+        json.loads(value)
         return f"export {name}='{value}'\n"
-    else:
+    except JSONDecodeError:
         return f'export {name}="{value}"\n'
 
 

--- a/hack/generate_dotenv.py
+++ b/hack/generate_dotenv.py
@@ -74,7 +74,15 @@ def _get_env_prefix(settings_class: Type[BaseSettings]) -> str:
 def save_default_env(env: dict, output: str):
     with open(output, "w") as file:
         for name, value in env.items():
-            file.write(f'export {name}="{value}"\n')
+            file.write(_parse_dict_values(name, value))
+
+
+def _parse_dict_values(name: str, value: str) -> str:
+    if name == "MLSERVER_MODEL_EXTRA":
+        value = value.replace("'", '"')
+        return f"export {name}='{value}'\n"
+    else:
+        return f'export {name}="{value}"\n'
 
 
 @click.command()


### PR DESCRIPTION
- New method to parse the only BaseSetting that might involve a JSON / dict object 
- Replaces single quotes within value with doubles
- Replaces double quotes around the environment variable with singles
- Tested outputs in a docker image with some custom extra dictionary and starts server