### PR TITLE
fix: Correct return MLModel setting for outputs

### DIFF
--- a/mlserver/model.py
+++ b/mlserver/model.py
@@ -81,7 +81,7 @@ class MLModel:
 
     @property
     def outputs(self) -> Optional[List[MetadataTensor]]:
-        return self._settings.inputs
+        return self._settings.outputs
 
     @outputs.setter
     def outputs(self, value: List[MetadataTensor]):


### PR DESCRIPTION
With current setting, the return meta data for `outputs` is taken from `inputs` one.