### PR TITLE
Uvicorn logging settings

### DIFF
--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -53,7 +53,7 @@ class RESTServer:
 
     async def start(self):
         cfg = uvicorn.Config(
-            self._app, host=self._settings.host, port=self._settings.http_port
+            self._app, host=self._settings.host, port=self._settings.http_port, log_config=self._settings.uvicorn_logging_settings
         )
         self._server = _NoSignalServer(cfg)
         await self._server.serve()

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
     `None` to disable it
     """
 
+    # Logging settings
+    uvicorn_logging_settings: Optional[str] = None
+    """Path to uvicorn logging config file"""
+
 
 class ModelParameters(BaseSettings):
     """


### PR DESCRIPTION
Closes #530 

add support to uvicorn logging setting:

- add a parameter to define a logging configuration file into application settings
- edit uvicorn Config initialization to add this parameter