### PR TITLE
Tag Prometheus metrics with model name and version

### DIFF
--- a/mlserver/handlers/dataplane.py
+++ b/mlserver/handlers/dataplane.py
@@ -8,17 +8,21 @@ from ..types import (
 )
 from ..middleware import inference_middlewares
 from ..utils import generate_uuid
-from ..middleware import inference_middlewares
-from ..utils import generate_uuid
 from prometheus_client import (
-    Counter, 
+    Counter,
     Summary,
 )
 
 
-_ModelInferRequestSuccess =  Counter('model_infer_request_success', 'Model infer request success count', ['model', 'version'])
-_ModelInferRequestFailure =  Counter('model_infer_request_failure', 'Model infer request failure count', ['model', 'version'])
-_ModelInferRequestDuration =  Summary('model_infer_request_duration', 'Model infer request duration', ['model', 'version'])
+_ModelInferRequestSuccess = Counter('model_infer_request_success',
+                                    'Model infer request success count',
+                                    ['model', 'version'])
+_ModelInferRequestFailure = Counter('model_infer_request_failure',
+                                    'Model infer request failure count',
+                                    ['model', 'version'])
+_ModelInferRequestDuration = Summary('model_infer_request_duration',
+                                     'Model infer request duration',
+                                     ['model', 'version'])
 
 
 class DataPlane:
@@ -60,15 +64,16 @@ class DataPlane:
         self, payload: InferenceRequest, name: str, version: str = None
     ) -> InferenceResponse:
 
-         with _ModelInferRequestDuration.labels(model=name, version=version).time(), \
-             _ModelInferRequestFailure.labels(model=name, version=version).count_exceptions():
-        
+        with _ModelInferRequestDuration.labels(model=name, version=version).time(), \
+            _ModelInferRequestFailure.labels(model=name,
+                                             version=version).count_exceptions():
+
             if payload.id is None:
                 payload.id = generate_uuid()
 
             model = await self._model_registry.get_model(name, version)
 
-                # Run middlewares
+            # Run middlewares
             inference_middlewares(payload, model.settings)
 
             # TODO: Make await optional for sync methods

--- a/mlserver/handlers/dataplane.py
+++ b/mlserver/handlers/dataplane.py
@@ -14,15 +14,19 @@ from prometheus_client import (
 )
 
 
-_ModelInferRequestSuccess = Counter('model_infer_request_success',
-                                    'Model infer request success count',
-                                    ['model', 'version'])
-_ModelInferRequestFailure = Counter('model_infer_request_failure',
-                                    'Model infer request failure count',
-                                    ['model', 'version'])
-_ModelInferRequestDuration = Summary('model_infer_request_duration',
-                                     'Model infer request duration',
-                                     ['model', 'version'])
+_ModelInferRequestSuccess = Counter(
+    "model_infer_request_success",
+    "Model infer request success count",
+    ["model", "version"],
+)
+_ModelInferRequestFailure = Counter(
+    "model_infer_request_failure",
+    "Model infer request failure count",
+    ["model", "version"],
+)
+_ModelInferRequestDuration = Summary(
+    "model_infer_request_duration", "Model infer request duration", ["model", "version"]
+)
 
 
 class DataPlane:
@@ -64,9 +68,11 @@ class DataPlane:
         self, payload: InferenceRequest, name: str, version: str = None
     ) -> InferenceResponse:
 
-        with _ModelInferRequestDuration.labels(model=name, version=version).time(), \
-            _ModelInferRequestFailure.labels(model=name,
-                                             version=version).count_exceptions():
+        with _ModelInferRequestDuration.labels(
+            model=name, version=version
+        ).time(), _ModelInferRequestFailure.labels(
+            model=name, version=version
+        ).count_exceptions():
 
             if payload.id is None:
                 payload.id = generate_uuid()

--- a/tests/metrics/test_endpoint.py
+++ b/tests/metrics/test_endpoint.py
@@ -28,7 +28,7 @@ async def test_metrics(metrics_client: MetricsClient):
         metrics = await metrics_client.metrics()
         assert metrics is not None
 
-        expected_prefixes = ("python_", "process_", "rest_server_", "grpc_server_")
+        expected_prefixes = ("python_", "process_", "rest_server_", "grpc_server_", "model_infer_")
         metrics_list = list(iter(metrics))
         assert len(metrics_list) > 0
         for metric in metrics_list:

--- a/tests/metrics/test_endpoint.py
+++ b/tests/metrics/test_endpoint.py
@@ -28,7 +28,13 @@ async def test_metrics(metrics_client: MetricsClient):
         metrics = await metrics_client.metrics()
         assert metrics is not None
 
-        expected_prefixes = ("python_", "process_", "rest_server_", "grpc_server_", "model_infer_")
+        expected_prefixes = (
+            "python_",
+            "process_",
+            "rest_server_",
+            "grpc_server_",
+            "model_infer_",
+        )
         metrics_list = list(iter(metrics))
         assert len(metrics_list) > 0
         for metric in metrics_list:


### PR DESCRIPTION
This PR relates to ticket Tag model-specific Prmoetheus metics #457 

https://github.com/SeldonIO/MLServer/issues/457

These changes create a new Prometheus metric for each model inference which is prefixed with "model_infer_request_". This metric is tagged with the model name and the model version.