### PR TITLE
Updating HuggingFace Optimum library to v1.2.0

### DIFF
--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -35,10 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "mlserver",
-        "optimum[onnxruntime]",
-    ],
-    dependency_links=[
-        "git+https://github.com/huggingface/optimum.git#egg=optimum[onnxruntime]"
+        "optimum[onnxruntime]==1.2.0",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Addresses one of the followups from the improvements identified from the huggingface runtime, namely upgrading to the pinned 1.2.0 verison of optimum as outlined in #576