### PR TITLE
Add model reload hooks

### DIFF
--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -38,7 +38,7 @@ class MLServer:
             ]
             on_model_unload = [
                 self.remove_custom_handlers,
-                self._inference_pool.unload_model,
+                self._inference_pool.unload_model,  # type: ignore
             ]
 
         self._model_registry = MultiModelRegistry(

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -25,6 +25,7 @@ class MLServer:
             self.add_custom_handlers,
             load_batching,
         ]
+        on_model_reload = [self.remove_custom_handlers]
         on_model_unload = [self.remove_custom_handlers]
 
         if self._settings.parallel_workers:
@@ -42,6 +43,7 @@ class MLServer:
 
         self._model_registry = MultiModelRegistry(
             on_model_load=on_model_load,  # type: ignore
+            on_model_reload=on_model_reload,  # type: ignore
             on_model_unload=on_model_unload,  # type: ignore
         )
         self._model_repository = ModelRepository(self._settings.model_repository_root)
@@ -79,7 +81,7 @@ class MLServer:
         # TODO: Add support for custom gRPC endpoints
         # self._grpc_server.add_custom_handlers(handlers)
 
-    async def remove_custom_handlers(self, model: MLModel):
+    async def remove_custom_handlers(self, model: MLModel, new_model: MLModel = None):
         await self._rest_server.delete_custom_handlers(model)
 
         # TODO: Add support for custom gRPC endpoints

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import os
 import shutil
 
+from unittest.mock import Mock
 from mlserver.handlers import DataPlane, ModelRepositoryHandlers
 from mlserver.registry import MultiModelRegistry
 from mlserver.repository import ModelRepository, DEFAULT_MODEL_SETTINGS_FILENAME
@@ -14,6 +15,23 @@ from .helpers import get_import_path
 
 TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
+
+
+def assert_not_called_with(self, *args, **kwargs):
+    """
+    From https://stackoverflow.com/a/54838760/5015573
+    """
+    try:
+        self.assert_called_with(*args, **kwargs)
+    except AssertionError:
+        return
+    raise AssertionError(
+        "Expected %s to not have been called."
+        % self._format_mock_call_signature(args, kwargs)
+    )
+
+
+Mock.assert_not_called_with = assert_not_called_with
 
 
 @pytest.fixture

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -60,7 +60,7 @@ from mlserver.rest.responses import Response
 def test_encode_output_tensor(decoded: Any, codec: InputCodec, expected: dict):
     # Serialise response into final output bytes
     payload = codec.encode(name="output-0", payload=decoded)
-    response = Response()
+    response = Response(content=None)
     rendered_as_bytes = response.render(payload.dict())
 
     # Decode response back into JSON and check if it matches the expected one


### PR DESCRIPTION
Add a new set of model reload hooks to ensure that models don't get removed from parallel workers when reloading an existing model. 