### PR TITLE
Improve logic for health endpoints

### DIFF
--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -173,6 +173,11 @@ class InferencePool:
         # Decorate predict method
         setattr(model, "predict", self.parallel(model.predict))
 
+    async def reload_model(self, old_model: MLModel, new_model: MLModel):
+        # The model registries within each worker will take care of reloading
+        # the model internally
+        await self.load_model(new_model)
+
     async def unload_model(self, model: MLModel):
         if not self._should_load_model(model):
             # Skip unload if model has disabled parallel workers

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -147,8 +147,8 @@ class SingleModelRegistry:
         return new_model
 
     async def _load_model(self, model: MLModel):
-        await model.load()
         self._register(model)
+        await model.load()
 
         # TODO: Expose custom handlers on ParallelRuntime
         await asyncio.gather(*[callback(model) for callback in self._on_model_load])

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -73,6 +73,9 @@ class MLServer:
         servers_task = asyncio.gather(
             self._rest_server.start(), self._grpc_server.start()
         )
+        # Await for 100ms to ensure control goes back to the loop to executor
+        # the server start task immediately.
+        await asyncio.sleep(0.1)
 
         await asyncio.gather(
             *[

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -66,8 +66,8 @@ class MLServer:
             self._settings, self._data_plane, self._model_repository_handlers
         )
 
-        servers_task = asyncio.gather(
-            self._rest_server.start(), self._grpc_server.start()
+        servers_task = asyncio.create_task(
+            asyncio.gather(self._rest_server.start(), self._grpc_server.start())
         )
 
         await asyncio.gather(

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -66,6 +66,10 @@ class MLServer:
             self._settings, self._data_plane, self._model_repository_handlers
         )
 
+        servers_task = asyncio.gather(
+            self._rest_server.start(), self._grpc_server.start()
+        )
+
         await asyncio.gather(
             *[
                 self._model_registry.load(model_settings)
@@ -73,7 +77,7 @@ class MLServer:
             ]
         )
 
-        await asyncio.gather(self._rest_server.start(), self._grpc_server.start())
+        await servers_task
 
     async def add_custom_handlers(self, model: MLModel):
         await self._rest_server.add_custom_handlers(model)

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -66,8 +66,8 @@ class MLServer:
             self._settings, self._data_plane, self._model_repository_handlers
         )
 
-        servers_task = asyncio.create_task(
-            asyncio.gather(self._rest_server.start(), self._grpc_server.start())
+        servers_task = asyncio.gather(
+            self._rest_server.start(), self._grpc_server.start()
         )
 
         await asyncio.gather(

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -73,9 +73,6 @@ class MLServer:
         servers_task = asyncio.gather(
             self._rest_server.start(), self._grpc_server.start()
         )
-        # Await for 100ms to ensure control goes back to the loop to executor
-        # the server start task immediately.
-        await asyncio.sleep(0.1)
 
         await asyncio.gather(
             *[

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -25,7 +25,7 @@ class MLServer:
             self.add_custom_handlers,
             load_batching,
         ]
-        on_model_reload = [self.remove_custom_handlers]
+        on_model_reload = [self.reload_custom_handlers]
         on_model_unload = [self.remove_custom_handlers]
 
         if self._settings.parallel_workers:
@@ -35,6 +35,10 @@ class MLServer:
                 self.add_custom_handlers,
                 self._inference_pool.load_model,
                 load_batching,
+            ]
+            on_model_reload = [
+                self.reload_custom_handlers,
+                self._inference_pool.reload_model,  # type: ignore
             ]
             on_model_unload = [
                 self.remove_custom_handlers,
@@ -85,7 +89,14 @@ class MLServer:
         # TODO: Add support for custom gRPC endpoints
         # self._grpc_server.add_custom_handlers(handlers)
 
-    async def remove_custom_handlers(self, model: MLModel, new_model: MLModel = None):
+    async def reload_custom_handlers(self, old_model: MLModel, new_model: MLModel):
+        await self.add_custom_handlers(new_model)
+        await self.remove_custom_handlers(old_model)
+
+        # TODO: Add support for custom gRPC endpoints
+        # self._grpc_server.delete_custom_handlers(handlers)
+
+    async def remove_custom_handlers(self, model: MLModel):
         await self._rest_server.delete_custom_handlers(model)
 
         # TODO: Add support for custom gRPC endpoints

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,11 +1,8 @@
 import pytest
 import docker
-import os
 
 from typing import Tuple
 from docker.client import DockerClient
-
-from mlserver.settings import Settings, ModelSettings
 
 from ..utils import get_available_port
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,22 +1,13 @@
 import pytest
 import docker
 import os
-import signal
-import shutil
-import json
-
 
 from typing import Tuple
 from docker.client import DockerClient
-from subprocess import Popen
 
 from mlserver.settings import Settings, ModelSettings
-from mlserver.cli.serve import DEFAULT_SETTINGS_FILENAME
-from mlserver.cli.main import start
-from mlserver.repository import DEFAULT_MODEL_SETTINGS_FILENAME
 
-from ..utils import get_available_port, RESTClient
-from ..conftest import TESTDATA_PATH
+from ..utils import get_available_port
 
 
 @pytest.fixture
@@ -29,74 +20,3 @@ def free_ports() -> Tuple[int, int]:
     http_port = get_available_port()
     grpc_port = get_available_port()
     return http_port, grpc_port
-
-
-@pytest.fixture
-def settings(settings: Settings, free_ports: Tuple[int, int]) -> Settings:
-    http_port, grpc_port = free_ports
-
-    settings.http_port = http_port
-    settings.grpc_port = grpc_port
-
-    return settings
-
-
-@pytest.fixture
-def mlserver_folder(tmp_path: str, settings: Settings) -> str:
-    """
-    This fixture should create an MLServer folder with some base settings and
-    two models: a copy of the standard SumModel, as well as a copy of the
-    SlowModel.
-    """
-    # Write settings.json with free ports
-    settings_path = os.path.join(tmp_path, DEFAULT_SETTINGS_FILENAME)
-    with open(settings_path, "w") as settings_file:
-        settings_file.write(settings.json())
-
-    # Copy models.py module
-    src_path = os.path.join(TESTDATA_PATH, "models.py")
-    dst_path = os.path.join(tmp_path, "models.py")
-    shutil.copy(src_path, dst_path)
-
-    # Copy SumModel's model-settings.json
-    sum_model_folder = os.path.join(tmp_path, "sum-model")
-    os.makedirs(sum_model_folder)
-    old_path = os.path.join(TESTDATA_PATH, DEFAULT_MODEL_SETTINGS_FILENAME)
-    new_path = os.path.join(sum_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
-    shutil.copy(old_path, new_path)
-
-    # Write SlowModel's model-settings.json
-    slow_model_folder = os.path.join(tmp_path, "slow-model")
-    os.makedirs(slow_model_folder)
-    slow_model_settings_path = os.path.join(
-        slow_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME
-    )
-    with open(slow_model_settings_path, "w") as slow_model_file:
-        slow_model_settings = {
-            "name": "slow-model",
-            "implementation": "models.SlowModel",
-        }
-        slow_model_file.write(json.dumps(slow_model_settings))
-
-    return tmp_path
-
-
-@pytest.fixture
-def mlserver_start(mlserver_folder: str) -> Popen:
-    cmd = f"mlserver start {mlserver_folder}"
-    p = Popen(["mlserver", "start", mlserver_folder], start_new_session=True)
-
-    yield p
-
-    os.killpg(os.getpgid(p.pid), signal.SIGTERM)
-
-
-@pytest.fixture
-async def rest_client(settings: Settings, mlserver_start) -> RESTClient:
-    http_server = f"127.0.0.1:{settings.http_port}"
-    client = RESTClient(http_server)
-    await client.wait_until_live()
-
-    yield client
-
-    await client.close()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,10 +1,22 @@
 import pytest
 import docker
+import os
+import signal
+import shutil
+import json
+
 
 from typing import Tuple
 from docker.client import DockerClient
+from subprocess import Popen
 
-from ..utils import get_available_port
+from mlserver.settings import Settings, ModelSettings
+from mlserver.cli.serve import DEFAULT_SETTINGS_FILENAME
+from mlserver.cli.main import start
+from mlserver.repository import DEFAULT_MODEL_SETTINGS_FILENAME
+
+from ..utils import get_available_port, RESTClient
+from ..conftest import TESTDATA_PATH
 
 
 @pytest.fixture
@@ -17,3 +29,74 @@ def free_ports() -> Tuple[int, int]:
     http_port = get_available_port()
     grpc_port = get_available_port()
     return http_port, grpc_port
+
+
+@pytest.fixture
+def settings(settings: Settings, free_ports: Tuple[int, int]) -> Settings:
+    http_port, grpc_port = free_ports
+
+    settings.http_port = http_port
+    settings.grpc_port = grpc_port
+
+    return settings
+
+
+@pytest.fixture
+def mlserver_folder(tmp_path: str, settings: Settings) -> str:
+    """
+    This fixture should create an MLServer folder with some base settings and
+    two models: a copy of the standard SumModel, as well as a copy of the
+    SlowModel.
+    """
+    # Write settings.json with free ports
+    settings_path = os.path.join(tmp_path, DEFAULT_SETTINGS_FILENAME)
+    with open(settings_path, "w") as settings_file:
+        settings_file.write(settings.json())
+
+    # Copy models.py module
+    src_path = os.path.join(TESTDATA_PATH, "models.py")
+    dst_path = os.path.join(tmp_path, "models.py")
+    shutil.copy(src_path, dst_path)
+
+    # Copy SumModel's model-settings.json
+    sum_model_folder = os.path.join(tmp_path, "sum-model")
+    os.makedirs(sum_model_folder)
+    old_path = os.path.join(TESTDATA_PATH, DEFAULT_MODEL_SETTINGS_FILENAME)
+    new_path = os.path.join(sum_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
+    shutil.copy(old_path, new_path)
+
+    # Write SlowModel's model-settings.json
+    slow_model_folder = os.path.join(tmp_path, "slow-model")
+    os.makedirs(slow_model_folder)
+    slow_model_settings_path = os.path.join(
+        slow_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME
+    )
+    with open(slow_model_settings_path, "w") as slow_model_file:
+        slow_model_settings = {
+            "name": "slow-model",
+            "implementation": "models.SlowModel",
+        }
+        slow_model_file.write(json.dumps(slow_model_settings))
+
+    return tmp_path
+
+
+@pytest.fixture
+def mlserver_start(mlserver_folder: str) -> Popen:
+    cmd = f"mlserver start {mlserver_folder}"
+    p = Popen(["mlserver", "start", mlserver_folder], start_new_session=True)
+
+    yield p
+
+    os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+
+
+@pytest.fixture
+async def rest_client(settings: Settings, mlserver_start) -> RESTClient:
+    http_server = f"127.0.0.1:{settings.http_port}"
+    client = RESTClient(http_server)
+    await client.wait_until_live()
+
+    yield client
+
+    await client.close()

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -1,0 +1,22 @@
+from mlserver.settings import ModelSettings, Settings
+from mlserver.types import InferenceRequest
+
+from ..utils import RESTClient
+
+
+async def test_live(rest_client: RESTClient):
+    is_live = await rest_client.live()
+    is_ready = await rest_client.ready()
+
+    # Assert that the server is live, but some models are still loading
+    assert is_live
+    assert not is_ready
+
+
+async def test_infer(
+    rest_client: RESTClient,
+    sum_model_settings: ModelSettings,
+    inference_request: InferenceRequest,
+):
+    await rest_client.wait_until_model_ready(sum_model_settings.name)
+    await rest_client.infer(sum_model_settings.name, inference_request)

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -1,3 +1,7 @@
+import pytest
+
+from aiohttp.client_exceptions import ClientResponseError
+
 from mlserver.settings import ModelSettings, Settings
 from mlserver.types import InferenceRequest
 
@@ -6,11 +10,11 @@ from ..utils import RESTClient
 
 async def test_live(rest_client: RESTClient):
     is_live = await rest_client.live()
-    is_ready = await rest_client.ready()
+    assert is_live
 
     # Assert that the server is live, but some models are still loading
-    assert is_live
-    assert not is_ready
+    with pytest.raises(ClientResponseError):
+        await rest_client.ready()
 
 
 async def test_infer(

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -69,7 +69,6 @@ def mlserver_folder(tmp_path: str, settings: Settings) -> str:
 
 @pytest.fixture
 def mlserver_start(mlserver_folder: str) -> Popen:
-    cmd = f"mlserver start {mlserver_folder}"
     p = Popen(["mlserver", "start", mlserver_folder], start_new_session=True)
 
     yield p
@@ -103,4 +102,6 @@ async def test_infer(
     inference_request: InferenceRequest,
 ):
     await rest_client.wait_until_model_ready(sum_model_settings.name)
-    await rest_client.infer(sum_model_settings.name, inference_request)
+    response = await rest_client.infer(sum_model_settings.name, inference_request)
+
+    assert len(response.outputs) == 1

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -1,11 +1,91 @@
+import os
 import pytest
+import shutil
+import signal
+import json
 
 from aiohttp.client_exceptions import ClientResponseError
+from subprocess import Popen
+from typing import Tuple
 
+from mlserver.cli.serve import DEFAULT_SETTINGS_FILENAME
+from mlserver.repository import DEFAULT_MODEL_SETTINGS_FILENAME
 from mlserver.settings import ModelSettings, Settings
 from mlserver.types import InferenceRequest
 
+from ..conftest import TESTDATA_PATH
 from ..utils import RESTClient
+
+
+@pytest.fixture
+def settings(settings: Settings, free_ports: Tuple[int, int]) -> Settings:
+    http_port, grpc_port = free_ports
+
+    settings.http_port = http_port
+    settings.grpc_port = grpc_port
+
+    return settings
+
+
+@pytest.fixture
+def mlserver_folder(tmp_path: str, settings: Settings) -> str:
+    """
+    This fixture should create an MLServer folder with some base settings and
+    two models: a copy of the standard SumModel, as well as a copy of the
+    SlowModel.
+    """
+    # Write settings.json with free ports
+    settings_path = os.path.join(tmp_path, DEFAULT_SETTINGS_FILENAME)
+    with open(settings_path, "w") as settings_file:
+        settings_file.write(settings.json())
+
+    # Copy models.py module
+    src_path = os.path.join(TESTDATA_PATH, "models.py")
+    dst_path = os.path.join(tmp_path, "models.py")
+    shutil.copy(src_path, dst_path)
+
+    # Copy SumModel's model-settings.json
+    sum_model_folder = os.path.join(tmp_path, "sum-model")
+    os.makedirs(sum_model_folder)
+    old_path = os.path.join(TESTDATA_PATH, DEFAULT_MODEL_SETTINGS_FILENAME)
+    new_path = os.path.join(sum_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME)
+    shutil.copy(old_path, new_path)
+
+    # Write SlowModel's model-settings.json
+    slow_model_folder = os.path.join(tmp_path, "slow-model")
+    os.makedirs(slow_model_folder)
+    slow_model_settings_path = os.path.join(
+        slow_model_folder, DEFAULT_MODEL_SETTINGS_FILENAME
+    )
+    with open(slow_model_settings_path, "w") as slow_model_file:
+        slow_model_settings = {
+            "name": "slow-model",
+            "implementation": "models.SlowModel",
+        }
+        slow_model_file.write(json.dumps(slow_model_settings))
+
+    return tmp_path
+
+
+@pytest.fixture
+def mlserver_start(mlserver_folder: str) -> Popen:
+    cmd = f"mlserver start {mlserver_folder}"
+    p = Popen(["mlserver", "start", mlserver_folder], start_new_session=True)
+
+    yield p
+
+    os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+
+
+@pytest.fixture
+async def rest_client(settings: Settings, mlserver_start) -> RESTClient:
+    http_server = f"127.0.0.1:{settings.http_port}"
+    client = RESTClient(http_server)
+    await client.wait_until_live()
+
+    yield client
+
+    await client.close()
 
 
 async def test_live(rest_client: RESTClient):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from mlserver import MLModel
 from mlserver.types import InferenceRequest, InferenceResponse, Parameters
 from mlserver.codecs import NumpyCodec
@@ -40,3 +42,14 @@ class ErrorModel(MLModel):
 
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
         raise MLServerError(self.error_message)
+
+
+class SlowModel(MLModel):
+    async def load(self) -> bool:
+        await asyncio.sleep(10)
+        self.ready = True
+        return self.ready
+
+    async def infer(self, payload: InferenceRequest) -> InferenceResponse:
+        await asyncio.sleep(10)
+        return InferenceResponse(id=payload.id, model_name=self.name, outputs=[])

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -53,8 +53,7 @@ async def mlserver(
     server = MLServer(settings)
 
     # Start server without blocking, and cancel afterwards
-    loop = asyncio.get_event_loop()
-    server_task = loop.create_task(server.start())
+    server_task = asyncio.create_task(server.start())
 
     # Load sample model
     await server._model_registry.load(sum_model_settings)

--- a/tests/testdata/models.py
+++ b/tests/testdata/models.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from mlserver import MLModel
 
 from mlserver.codecs import NumpyCodec
@@ -11,3 +13,14 @@ class SumModel(MLModel):
 
         output = NumpyCodec().encode(name="total", payload=total)
         return InferenceResponse(id=payload.id, model_name=self.name, outputs=[output])
+
+
+class SlowModel(MLModel):
+    async def load(self) -> bool:
+        await asyncio.sleep(10)
+        self.ready = True
+        return self.ready
+
+    async def infer(self, payload: InferenceRequest) -> InferenceResponse:
+        await asyncio.sleep(10)
+        return InferenceResponse(id=payload.id, model_name=self.name, outputs=[])


### PR DESCRIPTION
Part of #576 

## Changelog
- Ensure that the server's health endpoints are exposed before starting to load the initial set of models
- Ensure that models show as "not ready" while they are getting loaded
- To refresh / reload existing models, ensure that we do a "rolling update" (i.e. keep the old version available while we load the new one)