### PR TITLE
Add Uvicorn root_path configuration

### DIFF
--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -60,6 +60,7 @@ class RESTServer:
         kwargs = {
             "host": self._settings.host,
             "port": self._settings.http_port,
+            "root_path": self._settings.root_path,
         }
 
         if self._settings.logging_settings:

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
     http_port: int = 8080
     """Port where to listen for HTTP / REST connections."""
 
+    root_path: str = ""
+    """Set the ASGI root_path for applications submounted below a given URL path."""
+
     grpc_port: int = 8081
     """Port where to listen for gRPC connections."""
 


### PR DESCRIPTION
As discussed in #571, this adds support for configuring the Uvicorn `root_path` parameter. I looked through the tests and saw that most settings don't have specific unit tests attached, but I've tested this setting on one of my applications and it works as expected.

Please let me know if any other info is required.