### PR TITLE
Ensure HuggingFace runtime doesn't block asyncio when loading model

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -19,6 +19,9 @@ ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
 HUGGINGFACE_PARAMETERS_TAG = "huggingface_parameters"
 PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
 
+# Required as workaround until solved https://github.com/huggingface/optimum/issues/186
+TRANSFORMER_CACHE_DIR = os.environ.get("TRANSFORMERS_CACHE", None)
+
 
 class InvalidTranformerInitialisation(MLServerError):
     def __init__(self, code: int, reason: str):
@@ -99,9 +102,12 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         tokenizer = model
 
     if hf_settings.optimum_model:
+        print(f"optimum cache {TRANSFORMER_CACHE_DIR}")
         optimum_class = SUPPORTED_OPTIMUM_TASKS[hf_settings.task]["class"][0]
         model = optimum_class.from_pretrained(
-            hf_settings.pretrained_model, from_transformers=True
+            hf_settings.pretrained_model,
+            from_transformers=True,
+            cache_dir=TRANSFORMER_CACHE_DIR,
         )
         tokenizer = AutoTokenizer.from_pretrained(tokenizer)
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -10,6 +10,8 @@ from transformers.pipelines import pipeline
 from transformers.pipelines.base import Pipeline
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
+from optimum.pipelines import pipeline as pipeline_optimum
+from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
 from optimum.onnxruntime import (
     ORTModelForCausalLM,
     ORTModelForFeatureExtraction,
@@ -24,14 +26,6 @@ HUGGINGFACE_TASK_TAG = "task"
 ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
 HUGGINGFACE_PARAMETERS_TAG = "huggingface_parameters"
 PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
-
-SUPPORTED_OPTIMIZED_TASKS = {
-    "feature-extraction": ORTModelForFeatureExtraction,
-    "sentiment-analysis": ORTModelForSequenceClassification,
-    "ner": ORTModelForTokenClassification,
-    "question-answering": ORTModelForQuestionAnswering,
-    "text-generation": ORTModelForCausalLM,
-}
 
 
 class InvalidTranformerInitialisation(MLServerError):
@@ -113,7 +107,7 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         tokenizer = model
 
     if hf_settings.optimum_model:
-        optimum_class = SUPPORTED_OPTIMIZED_TASKS[hf_settings.task]
+        optimum_class = SUPPORTED_OPTIMUM_TASKS[hf_settings.task]["class"][0]
         model = optimum_class.from_pretrained(
             hf_settings.pretrained_model, from_transformers=True
         )

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -10,15 +10,7 @@ from transformers.pipelines import pipeline
 from transformers.pipelines.base import Pipeline
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
-from optimum.pipelines import pipeline as pipeline_optimum
 from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
-from optimum.onnxruntime import (
-    ORTModelForCausalLM,
-    ORTModelForFeatureExtraction,
-    ORTModelForQuestionAnswering,
-    ORTModelForSequenceClassification,
-    ORTModelForTokenClassification,
-)
 
 
 HUGGINGFACE_TASK_TAG = "task"

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -102,7 +102,6 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         tokenizer = model
 
     if hf_settings.optimum_model:
-        print(f"optimum cache {TRANSFORMER_CACHE_DIR}")
         optimum_class = SUPPORTED_OPTIMUM_TASKS[hf_settings.task]["class"][0]
         model = optimum_class.from_pretrained(
             hf_settings.pretrained_model,

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -15,10 +15,10 @@ from mlserver_huggingface.common import (
     HUGGINGFACE_PARAMETERS_TAG,
     parse_parameters_from_env,
     InvalidTranformerInitialisation,
-    SUPPORTED_OPTIMIZED_TASKS,
     load_pipeline_from_settings,
 )
 from transformers.pipelines import SUPPORTED_TASKS
+from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
 
 
 class HuggingFaceRuntime(MLModel):
@@ -47,13 +47,13 @@ class HuggingFaceRuntime(MLModel):
             )
 
         if self.hf_settings.optimum_model:
-            if self.hf_settings.task not in SUPPORTED_OPTIMIZED_TASKS:
+            if self.hf_settings.task not in SUPPORTED_OPTIMUM_TASKS:
                 raise InvalidTranformerInitialisation(
                     500,
                     (
                         f"Invalid transformer task for "
                         f"OPTIMUM model: {self.hf_settings.task}. "
-                        f"Supported Optimum tasks: {SUPPORTED_OPTIMIZED_TASKS.keys()}"
+                        f"Supported Optimum tasks: {SUPPORTED_OPTIMUM_TASKS.keys()}"
                     ),
                 )
 

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -62,7 +62,8 @@ class HuggingFaceRuntime(MLModel):
     async def load(self) -> bool:
         # Loading & caching pipeline in asyncio loop to avoid blocking
         await asyncio.get_running_loop().run_in_executor(
-            None, load_pipeline_from_settings, self.hf_settings)
+            None, load_pipeline_from_settings, self.hf_settings
+        )
         # Now we load the cached model which should not block asyncio
         self._model = load_pipeline_from_settings(self.hf_settings)
         self.ready = True


### PR DESCRIPTION
Fixes part of #576 

* Ensuring the transformer model is downloaded async and cached
* Model then gets loaded without affecting liveness/readiness probes
* Allows for very large transformers to be loaded
* Uses the Optimum SUPPORTED_TASKS object