### PR TITLE
Removed cache folder for Hugging Face Runtime as no longer required

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -19,9 +19,6 @@ ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
 HUGGINGFACE_PARAMETERS_TAG = "huggingface_parameters"
 PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
 
-# Required as workaround until solved https://github.com/huggingface/optimum/issues/186
-TRANSFORMER_CACHE_DIR = os.environ.get("TRANSFORMERS_CACHE", None)
-
 
 class InvalidTranformerInitialisation(MLServerError):
     def __init__(self, code: int, reason: str):
@@ -106,7 +103,6 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         model = optimum_class.from_pretrained(
             hf_settings.pretrained_model,
             from_transformers=True,
-            cache_dir=TRANSFORMER_CACHE_DIR,
         )
         tokenizer = AutoTokenizer.from_pretrained(tokenizer)
 


### PR DESCRIPTION
Part of #576

As per discussion in https://github.com/huggingface/optimum/issues/186 it is no longer necessary to pass an env manually as the XDG env var would be enough to cover the cache folder case.