### PR TITLE
Fix some Uvloop quirks

### DIFF
--- a/mlserver/parallel/worker.py
+++ b/mlserver/parallel/worker.py
@@ -13,7 +13,7 @@ from .messages import ModelUpdateType, ModelUpdateMessage, InferenceResponseMess
 from .utils import terminate_queue, END_OF_QUEUE
 from .logging import logger
 
-NON_HANDLED_SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT]
+IGNORED_SIGNALS = [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT]
 
 
 def _noop():
@@ -56,7 +56,7 @@ class Worker(Process):
         """
         loop = asyncio.get_event_loop()
 
-        for sign in NON_HANDLED_SIGNALS:
+        for sign in IGNORED_SIGNALS:
             # Ensure that signal handlers are a no-op, to let the main process
             # take care of cleaning up workers
             loop.add_signal_handler(sign, _noop)

--- a/runtimes/alibi-explain/setup.py
+++ b/runtimes/alibi-explain/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "mlserver",
-        "alibi[shap]",
+        "alibi[shap, tensorflow]",
         "orjson",
         # numba 0.55.0 requires: numpy <1.22 (for Shap / alibi)
         "numpy<1.22",

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,8 +86,9 @@ commands = pytest {posargs} {toxinidir}/runtimes/alibi-detect
 
 [testenv:all-runtimes]
 deps =
-  -e{toxinidir}/runtimes/alibi-explain
-  -e{toxinidir}/runtimes/alibi-detect
+  # Removing from all-runtimes test, as they don't seem to fit in GH workers.
+  # -e{toxinidir}/runtimes/alibi-explain
+  # -e{toxinidir}/runtimes/alibi-detect
   -e{toxinidir}/runtimes/sklearn
   -e{toxinidir}/runtimes/xgboost
   -e{toxinidir}/runtimes/mllib
@@ -96,7 +97,7 @@ deps =
   -e{toxinidir}[all]
   -r{toxinidir}/requirements/dev.txt
   -r{toxinidir}/runtimes/mlflow/requirements-dev.txt
-  -r{toxinidir}/runtimes/alibi-explain/requirements-dev.txt
+  # -r{toxinidir}/runtimes/alibi-explain/requirements-dev.txt
 commands = pytest {posargs}
 
 [testenv:licenses]

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ commands = pytest {posargs} {toxinidir}/runtimes/alibi-detect
 
 [testenv:all-runtimes]
 deps =
+  -e{toxinidir}[all]
   # Removing from all-runtimes test, as they don't seem to fit in GH workers.
   # -e{toxinidir}/runtimes/alibi-explain
   # -e{toxinidir}/runtimes/alibi-detect
@@ -94,11 +95,16 @@ deps =
   -e{toxinidir}/runtimes/mllib
   -e{toxinidir}/runtimes/lightgbm
   -e{toxinidir}/runtimes/mlflow
-  -e{toxinidir}[all]
   -r{toxinidir}/requirements/dev.txt
   -r{toxinidir}/runtimes/mlflow/requirements-dev.txt
   # -r{toxinidir}/runtimes/alibi-explain/requirements-dev.txt
-commands = pytest {posargs}
+commands = pytest {posargs} \
+  {toxinidir}/tests \
+  {toxinidir}/runtimes/sklearn \
+  {toxinidir}/runtimes/xgboost \
+  {toxinidir}/runtimes/mllib \
+  {toxinidir}/runtimes/lightgbm \
+  {toxinidir}/runtimes/mlflow
 
 [testenv:licenses]
 deps =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,6 @@ def metadata_model_response() -> types.MetadataModelResponse:
 @pytest.fixture(params=["inference-request.json", "inference-request-with-output.json"])
 def inference_request(request) -> types.InferenceRequest:
     payload_path = os.path.join(TESTDATA_PATH, request.param)
-    print(payload_path)
     return types.InferenceRequest.parse_file(payload_path)
 
 


### PR DESCRIPTION
It looks like Uvloop tries to terminate all subprocesses by itself through signals. However, we want the main process to handle that, so that we can ensure a clean shutdown of the inference workers. To account for that, this PR ensures that the workers ignore upstream signals. 