### PR TITLE
Adding --no-cache / -n option to mlserver build

### DIFF
--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -37,17 +37,15 @@ def write_dockerfile(
     return dockerfile_path
 
 
-def build_image(folder: str,
-                dockerfile: str,
-                image_tag: str,
-                no_cache: bool = False) -> str:
+def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) \
+        -> str:
     logger.info(f"Building Docker image with tag {image_tag}")
     _docker_command_prefix = "docker build --rm "
     with TemporaryDirectory() as tmp_dir:
         dockerfile_path = write_dockerfile(tmp_dir, dockerfile)
         _docker_command_suffix = f"{folder} -f {dockerfile_path} -t {image_tag}"
         if no_cache:
-            build_cmd = _docker_command_prefix + "--no-cache" + _docker_command_suffix
+            build_cmd = _docker_command_prefix + "--no-cache " + _docker_command_suffix
         else:
             build_cmd = _docker_command_prefix + _docker_command_suffix
         build_env = os.environ.copy()

--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -38,7 +38,7 @@ def write_dockerfile(
 
 
 def build_image(
-        folder: str, dockerfile: str, image_tag: str, no_cache: bool = False
+    folder: str, dockerfile: str, image_tag: str, no_cache: bool = False
 ) -> str:
     logger.info(f"Building Docker image with tag {image_tag}")
     _docker_command_prefix = "docker build --rm "

--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -37,14 +37,19 @@ def write_dockerfile(
     return dockerfile_path
 
 
-def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) -> str:
+def build_image(folder: str,
+                dockerfile: str,
+                image_tag: str,
+                no_cache: bool = False) -> str:
     logger.info(f"Building Docker image with tag {image_tag}")
+    _docker_command_prefix = "docker build --rm "
     with TemporaryDirectory() as tmp_dir:
         dockerfile_path = write_dockerfile(tmp_dir, dockerfile)
+        _docker_command_suffix = f"{folder} -f {dockerfile_path} -t {image_tag}"
         if no_cache:
-            build_cmd = f"docker build --rm --no-cache {folder} -f {dockerfile_path} -t {image_tag}"
+            build_cmd = _docker_command_prefix + "--no-cache" + _docker_command_suffix
         else:
-            build_cmd = f"docker build --rm {folder} -f {dockerfile_path} -t {image_tag}"
+            build_cmd = _docker_command_prefix + _docker_command_suffix
         build_env = os.environ.copy()
         build_env["DOCKER_BUILDKIT"] = "1"
         subprocess.run(build_cmd, check=True, shell=True, env=build_env)

--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -37,8 +37,7 @@ def write_dockerfile(
     return dockerfile_path
 
 
-def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) \
-        -> str:
+def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) -> str:  # noqa: E501
     logger.info(f"Building Docker image with tag {image_tag}")
     _docker_command_prefix = "docker build --rm "
     with TemporaryDirectory() as tmp_dir:

--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -37,7 +37,9 @@ def write_dockerfile(
     return dockerfile_path
 
 
-def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) -> str:  # noqa: E501
+def build_image(
+        folder: str, dockerfile: str, image_tag: str, no_cache: bool = False
+) -> str:
     logger.info(f"Building Docker image with tag {image_tag}")
     _docker_command_prefix = "docker build --rm "
     with TemporaryDirectory() as tmp_dir:

--- a/mlserver/cli/build.py
+++ b/mlserver/cli/build.py
@@ -37,12 +37,14 @@ def write_dockerfile(
     return dockerfile_path
 
 
-def build_image(folder: str, dockerfile: str, image_tag: str) -> str:
+def build_image(folder: str, dockerfile: str, image_tag: str, no_cache: bool = False) -> str:
     logger.info(f"Building Docker image with tag {image_tag}")
     with TemporaryDirectory() as tmp_dir:
         dockerfile_path = write_dockerfile(tmp_dir, dockerfile)
-
-        build_cmd = f"docker build {folder} -f {dockerfile_path} -t {image_tag}"
+        if no_cache:
+            build_cmd = f"docker build --rm --no-cache {folder} -f {dockerfile_path} -t {image_tag}"
+        else:
+            build_cmd = f"docker build --rm {folder} -f {dockerfile_path} -t {image_tag}"
         build_env = os.environ.copy()
         build_env["DOCKER_BUILDKIT"] = "1"
         subprocess.run(build_cmd, check=True, shell=True, env=build_env)

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -49,7 +49,7 @@ async def start(folder: str):
 @click.option("-t", "--tag", type=str)
 @click.option("-n", "--no-cache", type=bool)
 @click_async
-async def build(folder: str, tag: str):
+async def build(folder: str, tag: str, no_cache: bool):
     """
     Build a Docker image for a custom MLServer runtime.
     """

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -47,14 +47,17 @@ async def start(folder: str):
 @root.command("build")
 @click.argument("folder", nargs=1)
 @click.option("-t", "--tag", type=str)
-@click.option("-n", "--no-cache", type=bool)
+@click.option("--cache/--no-cache", default=False)
 @click_async
-async def build(folder: str, tag: str, no_cache: bool):
+async def build(folder: str, tag: str, cache: bool):
     """
     Build a Docker image for a custom MLServer runtime.
     """
     dockerfile = generate_dockerfile()
-    build_image(folder, dockerfile, tag, no_cache=no_cache)
+    if cache:
+        build_image(folder, dockerfile, tag)
+    else:
+        build_image(folder, dockerfile, tag, no_cache=True)
     logger.info(f"Successfully built custom Docker image with tag {tag}")
 
 

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -47,17 +47,14 @@ async def start(folder: str):
 @root.command("build")
 @click.argument("folder", nargs=1)
 @click.option("-t", "--tag", type=str)
-@click.option("--cache/--no-cache", default=False)
+@click.option("--no-cache", default=False, is_flag=True)
 @click_async
-async def build(folder: str, tag: str, cache: bool):
+async def build(folder: str, tag: str, no_cache: bool = False):
     """
     Build a Docker image for a custom MLServer runtime.
     """
     dockerfile = generate_dockerfile()
-    if cache:
-        build_image(folder, dockerfile, tag)
-    else:
-        build_image(folder, dockerfile, tag, no_cache=True)
+    build_image(folder, dockerfile, tag, no_cache=no_cache)
     logger.info(f"Successfully built custom Docker image with tag {tag}")
 
 

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -47,13 +47,14 @@ async def start(folder: str):
 @root.command("build")
 @click.argument("folder", nargs=1)
 @click.option("-t", "--tag", type=str)
+@click.option("-n", "--no-cache", type=bool)
 @click_async
 async def build(folder: str, tag: str):
     """
     Build a Docker image for a custom MLServer runtime.
     """
     dockerfile = generate_dockerfile()
-    build_image(folder, dockerfile, tag)
+    build_image(folder, dockerfile, tag, no_cache=no_cache)
     logger.info(f"Successfully built custom Docker image with tag {tag}")
 
 


### PR DESCRIPTION
Attempting to give users the option to use docker build cache or not, this is useful in development of multiple model versions but also in keeping a CI / CD environment clean.

* Added new -n / --no-cache option to mlserver build
* Added --rm option explicitly to ensure intermediate containers are deleted after successful build

Should fix #604 