### PR TITLE
Move metrics endpoint into its own server

### DIFF
--- a/mlserver/grpc/server.py
+++ b/mlserver/grpc/server.py
@@ -80,6 +80,8 @@ class GRPCServer:
         )
         await self._server.wait_for_termination()
 
-    async def stop(self):
+    async def stop(self, sig: int):
+        logger.info("Waiting for gRPC server shutdown")
         # TODO: Read from config
         await self._server.stop(grace=5)
+        logger.info("gRPC server shutdown complete")

--- a/mlserver/grpc/server.py
+++ b/mlserver/grpc/server.py
@@ -80,7 +80,7 @@ class GRPCServer:
         )
         await self._server.wait_for_termination()
 
-    async def stop(self, sig: int):
+    async def stop(self, sig: int = None):
         logger.info("Waiting for gRPC server shutdown")
         # TODO: Read from config
         await self._server.stop(grace=5)

--- a/mlserver/metrics/__init__.py
+++ b/mlserver/metrics/__init__.py
@@ -1,0 +1,3 @@
+from .server import MetricsServer
+
+__all__ = [MetricsServer]

--- a/mlserver/metrics/__init__.py
+++ b/mlserver/metrics/__init__.py
@@ -1,3 +1,3 @@
 from .server import MetricsServer
 
-__all__ = [MetricsServer]
+__all__ = ["MetricsServer"]

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -47,5 +47,5 @@ class MetricsServer:
         # prom reqs can be spammy)
         return uvicorn.Config(self._app, **kwargs)
 
-    async def stop(self, sig: int):
+    async def stop(self, sig: int = None):
         self._server.handle_exit(sig=sig, frame=None)

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -1,0 +1,39 @@
+import uvicorn
+
+from fastapi import FastAPI
+from starlette_exporter import handle_metrics
+
+from ..settings import Settings
+
+class _NoSignalServer(uvicorn.Server):
+    def install_signal_handlers(self):
+        pass
+
+
+class MetricsServer:
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        self._app = self._get_app()
+
+    def _get_app(self):
+        app = FastAPI(debug=self._settings.debug)
+        app.add_route(self._settings.metrics_endpoint, handle_metrics)
+        return app
+
+    async def start(self):
+        cfg = self._get_config()
+        self._server = _NoSignalServer(cfg)
+        await self._server.serve()
+
+    def _get_config(self):
+        kwargs = {
+            "host": self._settings.host,
+            "port": self._settings.metrics_port
+        }
+
+        # TODO: we want to disable logger unless debug is enabled (otherwise,
+        # prom reqs can be spammy)
+        return uvicorn.Config(self._app, **kwargs)
+
+    async def stop(self):
+        self._server.handle_exit(sig=None, frame=None)

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -1,9 +1,13 @@
 import uvicorn
+import logging
 
 from fastapi import FastAPI
 from starlette_exporter import handle_metrics
 
 from ..settings import Settings
+
+logger = logging.getLogger("mlserver.metrics")
+
 
 class _NoSignalServer(uvicorn.Server):
     def install_signal_handlers(self):
@@ -23,17 +27,25 @@ class MetricsServer:
     async def start(self):
         cfg = self._get_config()
         self._server = _NoSignalServer(cfg)
+
+        metrics_server = f"http://{self._settings.host}:{self._settings.metrics_port}"
+        logger.info(f"Metrics server running on {metrics_server}")
+        logger.info(
+            "Prometheus scraping endpoint can be accessed on "
+            f"{metrics_server}{self._settings.metrics_endpoint}"
+        )
         await self._server.serve()
 
     def _get_config(self):
         kwargs = {
             "host": self._settings.host,
-            "port": self._settings.metrics_port
+            "port": self._settings.metrics_port,
+            "access_log": self._settings.debug,
         }
 
         # TODO: we want to disable logger unless debug is enabled (otherwise,
         # prom reqs can be spammy)
         return uvicorn.Config(self._app, **kwargs)
 
-    async def stop(self):
-        self._server.handle_exit(sig=None, frame=None)
+    async def stop(self, sig: int):
+        self._server.handle_exit(sig=sig, frame=None)

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -204,8 +204,10 @@ class InferencePool:
         return True
 
     async def close(self):
+        logger.info("Waiting for inference pool shutdown")
         await self._close_workers()
         await self._close_responses()
+        logger.info("Inference pool shutdown complete")
 
     async def _close_responses(self):
         await terminate_queue(self._responses)

--- a/mlserver/rest/app.py
+++ b/mlserver/rest/app.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.responses import Response as FastAPIResponse
 from fastapi.routing import APIRoute as FastAPIRoute
 from fastapi.middleware.cors import CORSMiddleware
-from starlette_exporter import PrometheusMiddleware, handle_metrics
+from starlette_exporter import PrometheusMiddleware
 
 from .endpoints import Endpoints, ModelRepositoryEndpoints
 from .requests import Request
@@ -126,6 +126,5 @@ def create_app(
                 "/v2/health/ready",
             ],
         )
-        app.add_route(settings.metrics_endpoint, handle_metrics)
 
     return app

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -70,5 +70,5 @@ class RESTServer:
 
         return uvicorn.Config(self._app, **kwargs)
 
-    async def stop(self, sig: int):
+    async def stop(self, sig: int = None):
         self._server.handle_exit(sig=sig, frame=None)

--- a/mlserver/rest/server.py
+++ b/mlserver/rest/server.py
@@ -70,5 +70,5 @@ class RESTServer:
 
         return uvicorn.Config(self._app, **kwargs)
 
-    async def stop(self):
-        self._server.handle_exit(sig=None, frame=None)
+    async def stop(self, sig: int):
+        self._server.handle_exit(sig=sig, frame=None)

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -117,7 +117,7 @@ class MLServer:
                 sig, lambda s=sig: asyncio.create_task(self.stop(sig=s))
             )
 
-    async def stop(self, sig: int):
+    async def stop(self, sig: int = None):
         if self._inference_pool:
             await self._inference_pool.close()
 

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -118,8 +118,6 @@ class MLServer:
             )
 
     async def stop(self, sig: int):
-        stop_tasks = []
-
         if self._inference_pool:
             await self._inference_pool.close()
 

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
 
     # Metrics settings
     metrics_endpoint: Optional[str] = "/metrics"
+    metrics_port: int = 8082
     """
     Endpoint used to expose Prometheus metrics. Alternatively, can be set to
     `None` to disable it

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -95,15 +95,19 @@ class Settings(BaseSettings):
 
     # Metrics settings
     metrics_endpoint: Optional[str] = "/metrics"
-    metrics_port: int = 8082
     """
     Endpoint used to expose Prometheus metrics. Alternatively, can be set to
-    `None` to disable it
+    `None` to disable it.
+    """
+
+    metrics_port: int = 8082
+    """
+    Port used to expose metrics endpoint.
     """
 
     # Logging settings
     logging_settings: Optional[str] = None
-    """Path to logging config file"""
+    """Path to logging config file."""
 
 
 class ModelParameters(BaseSettings):

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -16,4 +16,5 @@ def docker_client() -> DockerClient:
 def free_ports() -> Tuple[int, int]:
     http_port = get_available_port()
     grpc_port = get_available_port()
-    return http_port, grpc_port
+    metrics_port = get_available_port()
+    return http_port, grpc_port, metrics_port

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -42,13 +42,14 @@ def custom_runtime_server(
     free_ports: Tuple[int, int],
     random_user_id: int,
 ) -> str:
-    host_http_port, host_grpc_port = free_ports
+    host_http_port, host_grpc_port, host_metrics_port = free_ports
 
     container = docker_client.containers.run(
         custom_image,
         ports={
             f"{settings.http_port}/tcp": str(host_http_port),
             f"{settings.grpc_port}/tcp": str(host_grpc_port),
+            f"{settings.metrics_port}/tcp": str(host_metrics_port),
         },
         detach=True,
         user=random_user_id,

--- a/tests/cli/test_start.py
+++ b/tests/cli/test_start.py
@@ -19,10 +19,11 @@ from ..utils import RESTClient
 
 @pytest.fixture
 def settings(settings: Settings, free_ports: Tuple[int, int]) -> Settings:
-    http_port, grpc_port = free_ports
+    http_port, grpc_port, metrics_port = free_ports
 
     settings.http_port = http_port
     settings.grpc_port = grpc_port
+    settings.metrics_port = metrics_port
 
     return settings
 

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -6,7 +6,6 @@ from starlette_exporter import PrometheusMiddleware
 
 from mlserver.server import MLServer
 from mlserver.settings import Settings, ModelSettings
-from mlserver.metrics.server import MetricsServer
 
 from ..utils import RESTClient, get_available_port
 from .utils import MetricsClient
@@ -45,6 +44,7 @@ def settings(settings: Settings) -> Settings:
 
     return settings
 
+
 @pytest.fixture
 async def mlserver(
     settings: Settings,
@@ -73,6 +73,7 @@ async def metrics_client(mlserver: MLServer, settings: Settings):
     yield client
 
     await client.close()
+
 
 @pytest.fixture
 async def rest_client(mlserver: MLServer, settings: Settings):

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -6,8 +6,9 @@ from starlette_exporter import PrometheusMiddleware
 
 from mlserver.server import MLServer
 from mlserver.settings import Settings, ModelSettings
+from mlserver.metrics.server import MetricsServer
 
-from ..utils import get_available_port
+from ..utils import RESTClient, get_available_port
 from .utils import MetricsClient
 
 
@@ -40,9 +41,9 @@ def prometheus_registry() -> CollectorRegistry:
 def settings(settings: Settings) -> Settings:
     settings.http_port = get_available_port()
     settings.grpc_port = get_available_port()
+    settings.metrics_port = get_available_port()
 
     return settings
-
 
 @pytest.fixture
 async def mlserver(
@@ -66,8 +67,17 @@ async def mlserver(
 
 @pytest.fixture
 async def metrics_client(mlserver: MLServer, settings: Settings):
-    http_server = f"{settings.host}:{settings.http_port}"
+    http_server = f"{settings.host}:{settings.metrics_port}"
     client = MetricsClient(http_server, metrics_endpoint=settings.metrics_endpoint)
+
+    yield client
+
+    await client.close()
+
+@pytest.fixture
+async def rest_client(mlserver: MLServer, settings: Settings):
+    http_server = f"{settings.host}:{settings.http_port}"
+    client = RESTClient(http_server)
 
     yield client
 

--- a/tests/metrics/test_endpoint.py
+++ b/tests/metrics/test_endpoint.py
@@ -2,8 +2,9 @@ import pytest
 
 from pytest_cases import parametrize_with_cases, fixture
 from mlserver import Settings
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_exceptions import ClientConnectorError
 
+from ..utils import RESTClient
 from .utils import MetricsClient
 
 
@@ -14,15 +15,14 @@ def settings(settings: Settings, metrics_endpoint: str) -> Settings:
     return settings
 
 
-async def test_metrics(metrics_client: MetricsClient):
-    await metrics_client.wait_until_ready()
+async def test_metrics(rest_client: RESTClient, metrics_client: MetricsClient):
+    await rest_client.wait_until_ready()
 
     if metrics_client._metrics_endpoint is None:
         # Assert metrics are disabled
         metrics_client._metrics_endpoint = "/metrics"
-        with pytest.raises(ClientResponseError) as err:
+        with pytest.raises(ClientConnectorError) as err:
             await metrics_client.metrics()
-        assert err.value.status == 404
     else:
         # Otherwise, assert all metrics are present
         metrics = await metrics_client.metrics()

--- a/tests/metrics/test_endpoint.py
+++ b/tests/metrics/test_endpoint.py
@@ -21,7 +21,7 @@ async def test_metrics(rest_client: RESTClient, metrics_client: MetricsClient):
     if metrics_client._metrics_endpoint is None:
         # Assert metrics are disabled
         metrics_client._metrics_endpoint = "/metrics"
-        with pytest.raises(ClientConnectorError) as err:
+        with pytest.raises(ClientConnectorError):
             await metrics_client.metrics()
     else:
         # Otherwise, assert all metrics are present

--- a/tests/metrics/test_rest.py
+++ b/tests/metrics/test_rest.py
@@ -22,7 +22,7 @@ async def test_rest_metrics(
     inference_request: InferenceRequest,
     sum_model: MLModel,
 ):
-    await metrics_client.wait_until_ready()
+    await rest_client.wait_until_ready()
     metric_name = "rest_server_requests"
 
     # Get metrics for gRPC server before sending any requests

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -12,7 +12,7 @@ class MetricsClient(RESTClient):
         self._metrics_endpoint = metrics_endpoint
 
     async def wait_until_ready(self) -> None:
-        endpoint = f"http://{self._http_server}/{self._metrics_endpoint}"
+        endpoint = f"http://{self._http_server}{self._metrics_endpoint}"
         await self._retry_get(endpoint)
 
     async def metrics(self) -> List[Metric]:

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -11,6 +11,10 @@ class MetricsClient(RESTClient):
         super().__init__(*args, **kwargs)
         self._metrics_endpoint = metrics_endpoint
 
+    async def wait_until_ready(self) -> None:
+        endpoint = f"http://{self._http_server}/{self._metrics_endpoint}"
+        await self._retry_get(endpoint)
+
     async def metrics(self) -> List[Metric]:
         endpoint = f"http://{self._http_server}{self._metrics_endpoint}"
         response = await self._session.get(endpoint)


### PR DESCRIPTION
Fixes #458 

## Changelog

- Move metrics endpoint into its own FastAPI server
- Add new `metrics_port` field to set the port for the new metrics server 
- Minor fixes to ensure workers get shut down correctly