### PR TITLE
Always use to_dtype when decoding the pandas Series

### DIFF
--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -13,13 +13,17 @@ from ..types import InferenceRequest, InferenceResponse, RequestInput, ResponseO
 
 def _to_series(input_or_output: InputOrOutput) -> pd.Series:
     payload = get_decoded_or_raw(input_or_output)
+
+    if input_or_output.datatype == "BYTES":
+        # Don't convert the dtype of BYTES
+        return pd.Series(payload)
+
     if isinstance(payload, np.ndarray):
         # Necessary so that it's compatible with pd.Series
         payload = list(payload)
-        dtype = to_dtype(input_or_output)
-        return pd.Series(payload, dtype=dtype)
 
-    return pd.Series(payload)
+    dtype = to_dtype(input_or_output)
+    return pd.Series(payload, dtype=dtype)
 
 
 def _to_response_output(series: pd.Series, use_bytes: bool = True) -> ResponseOutput:

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -182,7 +182,7 @@ def test_encode_response(dataframe, use_bytes, expected):
                     ),
                 ],
             ),
-            pd.DataFrame({"a": [1, 2, 3], "b": [5, 6, 7],}).astype(
+            pd.DataFrame({"a": [1, 2, 3], "b": [5, 6, 7]}).astype(
                 {
                     "a": "int32",
                     "b": "float32",

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -170,6 +170,25 @@ def test_encode_response(dataframe, use_bytes, expected):
                 }
             ),
         ),
+        (
+            InferenceResponse(
+                model_name="my-model",
+                outputs=[
+                    ResponseOutput(
+                        name="a", shape=[3], datatype="INT32", data=[1, 2, 3]
+                    ),
+                    ResponseOutput(
+                        name="b", shape=[3], datatype="FP32", data=[5, 6, 7]
+                    ),
+                ],
+            ),
+            pd.DataFrame({"a": [1, 2, 3], "b": [5, 6, 7],}).astype(
+                {
+                    "a": "int32",
+                    "b": "float32",
+                }
+            ),
+        ),
     ],
 )
 def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
@@ -287,6 +306,65 @@ def test_encode_request(
                 ]
             ),
             pd.DataFrame({"a": np.array([1], dtype=np.int32)}),
+        ),
+        (
+            InferenceRequest(
+                inputs=[
+                    RequestInput(
+                        name="a",
+                        data=[None, None],
+                        datatype="FP64",
+                        shape=[1],
+                    ),
+                    RequestInput(
+                        name="b",
+                        data=[1, 2],
+                        datatype="FP32",
+                        shape=[2],
+                    ),
+                    RequestInput(
+                        name="c",
+                        data=[3, 4],
+                        datatype="INT32",
+                        shape=[2],
+                    ),
+                    RequestInput(
+                        name="d",
+                        data=[5, 6],
+                        datatype="UINT8",
+                        shape=[2],
+                    ),
+                    RequestInput(
+                        name="e",
+                        data=[True, False],
+                        datatype="BOOL",
+                        shape=[2],
+                    ),
+                    RequestInput(
+                        name="f",
+                        data=[0, 1],
+                        datatype="BOOL",
+                        shape=[2],
+                    ),
+                ]
+            ),
+            pd.DataFrame(
+                {
+                    "a": [np.NaN, np.NaN],
+                    "b": [1.0, 2.0],
+                    "c": [3, 4],
+                    "d": [5, 6],
+                    "e": [True, False],
+                    "f": [False, True],
+                }
+            ).astype(
+                {
+                    "b": "float32",
+                    "c": "int32",
+                    "d": "uint8",
+                    "f": "bool",
+                }
+            ),
         ),
     ],
 )


### PR DESCRIPTION
Allows decoding a `None` into `np.NaN` and correctly uses the datatype when creating each series.

## Summary
LightGBM will train [missing data with NaN values](https://lightgbm.readthedocs.io/en/latest/Advanced-Topics.html#missing-value-handle) by default, but if my call to infer has only None value(s) for an input that was trained as a floating point, I get the error:
```
ValueError: DataFrame.dtypes for data must be int, float or bool.
Did not expect the data types in the following fields: column
```

## Problem:
The `datatype` is not used when the PandasCodec receives a `None` value.  Tracing this down, [`mlserver.codecs.pandas._to_series()`](https://github.com/SeldonIO/MLServer/blob/24917089d0f7acd62ad84b63b3862200af03ce74/mlserver/codecs/pandas.py#L14) only calls  `mlserver.codecs.numpy.to_dtype()` when given an `ndarray`, thus for most cases the `pd.Series` is given raw data.

This problem, while not my prime motivator also seems to result in ignoring other datatypes like `INT32` / `FP32` incorrectly being inferred as the pandas default of `int64`/`float64`.

Given an example where one input is `FP32` but with `None` value, another is `FP32`, and a third is `INT32`:
```python
from mlserver.codecs import PandasCodec
from mlserver.types import InferenceRequest, Parameters, RequestInput

df = PandasCodec.decode_request(InferenceRequest(
  parameters=Parameters(content__type='pd'),
  inputs=[
    RequestInput(
      name= "colNan",
      data=[None],  # should be decoded as np.NaN
      datatype="FP32",
      shape=[1],
    ), 
    RequestInput(
      name= "colFloat",
      data=[3.14],
      datatype="FP32",  # should be decoded as dtype float32
      shape=[1],
    ),
    RequestInput(
      name= "colInt",
      data=[512],
      datatype="INT32",  # should be decoded as dtype int32
      shape=[1],
    ),
  ]
))
```

At present, the `df.dtype` is:
```
colNan       object <-- FP32 not converted to float with np.NaN
colFloat    float64  <-- not converted to float32
colInt        int64   <-- not converted to int32
dtype: object
```

With this PR the `df.dtype` is properly converted and the `colNan` correctly is a np.NaN:
```
colNan      float32
colFloat    float32
colInt        int32
dtype: object
```

## Reproduce
Using the [LightGBM example](https://mlserver.readthedocs.io/en/latest/examples/lightgbm/README.html), but converted to use the pandas content_type (this is a toy example, I discovered it in my more complex model that is trained with NaN's)

```python
import requests
endpoint = "http://localhost:8080/v2/models/iris-lgb/versions/v0.1.0/infer"

inference_request = {
  "parameters": {
    "content_type": "pd"
  },
  "inputs": [
    {
      "name": "sepal_width_(cm)",
      # "data": [3.5],
      "data": [None],
      "datatype": "FP32",
      "shape": [1],
    },
    {
      "name": "petal_length_(cm)",
      "data": [1.4],
      "datatype": "FP32",
      "shape": [1],
    },
    {
      "name": "petal_width_(cm)",
      "data": [0.2],
      "datatype": "FP32",
      "shape": [1],
    },
    {
      "name": "sepal_length_(cm)",
      "data": [5.1],
      "datatype": "FP32",
      "shape": [1],
    },
  ]
}
response = requests.post(endpoint, json=inference_request)
response.json()
```

Results in:
```
ValueError: DataFrame.dtypes for data must be int, float or bool.
Did not expect the data types in the following fields: sepal_width_(cm)
```

With the PR applied, the response is as expected:
```
{'model_name': 'iris-lgb',
 'model_version': 'v0.1.0',
 'id': '1aea9a57-e1b4-4e81-abfb-fb969ca35982',
 'parameters': {'content_type': None, 'headers': None},
 'outputs': [{'name': 'predict',
   'shape': [1, 3],
   'datatype': 'FP64',
   'parameters': None,
   'data': [0.22063813971842786, 0.001247537667425619, 0.7781143226141466]}]}
```

## Note

I had to special case the BYTES to not use to_dtype, as it seemed to break the tests by returning single-byte characters -- perhaps there is a better approach?

Happy to adjust tests or code as needed.