### PR TITLE
Improve worker's processing loop

### DIFF
--- a/benchmarking/testserver/settings.json
+++ b/benchmarking/testserver/settings.json
@@ -1,4 +1,5 @@
 {
   "debug": false,
-  "load_models_at_startup": false
+  "load_models_at_startup": false,
+  "parallel_workers": 4
 }

--- a/mlserver/parallel/worker.py
+++ b/mlserver/parallel/worker.py
@@ -183,4 +183,5 @@ class Worker(Process):
         await terminate_queue(self._model_updates)
         await loop.run_in_executor(self._executor, self._model_updates.join)
         self._model_updates.close()
+        self._requests.close()
         self._executor.shutdown()

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -29,14 +29,6 @@ async def inference_pool(
 
 
 @pytest.fixture
-async def requests() -> Queue:
-    q = Queue()
-    yield q
-
-    q.close()
-
-
-@pytest.fixture
 async def responses() -> Queue:
     q = Queue()
     yield q
@@ -47,11 +39,10 @@ async def responses() -> Queue:
 @pytest.fixture
 async def worker(
     event_loop,
-    requests: Queue,
     responses: Queue,
     load_message: ModelUpdateMessage,
 ) -> Worker:
-    worker = Worker(requests, responses)
+    worker = Worker(responses)
 
     # Simulate the worker running on a different process, but keep it to a
     # thread to simplify debugging.

--- a/tests/parallel/test_worker.py
+++ b/tests/parallel/test_worker.py
@@ -5,11 +5,10 @@ from mlserver.parallel.messages import ModelUpdateMessage, InferenceRequestMessa
 
 async def test_predict(
     worker: Worker,
-    requests: Queue,
     inference_request_message: InferenceRequestMessage,
     responses: Queue,
 ):
-    requests.put(inference_request_message)
+    worker.send_request(inference_request_message)
     response = responses.get()
 
     assert response is not None
@@ -51,7 +50,6 @@ async def test_unload_model(
 
 async def test_exception(
     worker: Worker,
-    requests: Queue,
     inference_request_message: InferenceRequestMessage,
     responses: Queue,
     mocker,
@@ -64,7 +62,7 @@ async def test_exception(
 
     mocker.patch.object(model, "predict", _async_exception)
 
-    requests.put(inference_request_message)
+    worker.send_request(inference_request_message)
     response = responses.get()
 
     assert response is not None


### PR DESCRIPTION
Fixes #643 

## Changelog
- Create one requests queue per worker
- Ensure that the worker always schedules messages as they come, processing the responses through callbacks
- Forward messages to workers from the pool in a round-robin manner