### PR TITLE
handle missing model settings folders during load

### DIFF
--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -33,6 +33,7 @@ class ModelRepository:
                     model_settings = self._load_model_settings(model_settings_path)
                     all_model_settings.append(model_settings)
                 except:
+                    logger.exception(f"Failed load model settings at {model_settings_path}")
                     continue
 
         # If there were no matches, try to load model from environment

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -33,7 +33,9 @@ class ModelRepository:
                     model_settings = self._load_model_settings(model_settings_path)
                     all_model_settings.append(model_settings)
                 except Exception:
-                    logger.exception(f"Failed load model settings at {model_settings_path}")
+                    logger.exception(
+                        f"Failed load model settings at {model_settings_path}"
+                    )
                     continue
 
         # If there were no matches, try to load model from environment

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -32,7 +32,7 @@ class ModelRepository:
                 try:
                     model_settings = self._load_model_settings(model_settings_path)
                     all_model_settings.append(model_settings)
-                except:
+                except Exception:
                     logger.exception(f"Failed load model settings at {model_settings_path}")
                     continue
 

--- a/mlserver/repository.py
+++ b/mlserver/repository.py
@@ -29,8 +29,11 @@ class ModelRepository:
             matches = glob.glob(pattern, recursive=True)
 
             for model_settings_path in matches:
-                model_settings = self._load_model_settings(model_settings_path)
-                all_model_settings.append(model_settings)
+                try:
+                    model_settings = self._load_model_settings(model_settings_path)
+                    all_model_settings.append(model_settings)
+                except:
+                    continue
 
         # If there were no matches, try to load model from environment
         if not all_model_settings:


### PR DESCRIPTION
If a folder disappears during model load this can cause an exception.

https://github.com/SeldonIO/MLServer/blob/acae8a77c04b339c1346775456ab241d80a276fe/mlserver/repository.py#L28-L29

The glob returns all model-settings files. If between this time and the time of a load the file disappears this will cause an exception 

https://github.com/SeldonIO/MLServer/blob/acae8a77c04b339c1346775456ab241d80a276fe/mlserver/repository.py#L31-L33

This fix ignores these exceptions for loading model settings files.

In future, it may be better to try to find the model to load in a more directed way rather than searching the whole repository.