### PR TITLE
Run benchmarks every day

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,12 +1,9 @@
 name: MLServer Benchmarks
 
 on:
-  push:
-    branches:
-      - master
-      - release/*
-  pull_request:
-    branches: [master]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "23 18 * * *"
 
 jobs:
   benchmark:


### PR DESCRIPTION
To avoid getting PRs failing checks due to fluctuations in GH workers performance, instead of running benchmarks for every PR, we will run them periodically every day. 