### PR TITLE
Template creation with cookiecutter for base project initialisation

### DIFF
--- a/mlserver/cli/init_project.py
+++ b/mlserver/cli/init_project.py
@@ -1,0 +1,13 @@
+import subprocess
+from ..logging import logger
+
+
+def init_cookiecutter_project(template: str):
+    rc = subprocess.call(["which", "cookiecutter"])
+    if rc == 0:
+        cmd = f"cookiecutter {template}"
+        subprocess.run(cmd, check=True, shell=True)
+    else:
+        logger.error("The cookiecutter command is not found. \n\n"
+                     "Please install with 'pip install cookiecutter' and retry")
+

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -61,6 +61,7 @@ async def build(folder: str, tag: str, no_cache: bool = False):
 
 
 @root.command("init")
+# TODO: Update to have template(s) in the SeldonIO org
 @click.option("-t", "--template", default="https://github.com/EthicalML/sml-security/")
 @click_async
 async def init_project(template: str):

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -6,6 +6,8 @@ import asyncio
 
 from functools import wraps
 
+from .init_project import init_cookiecutter_project
+
 from ..server import MLServer
 from ..logging import logger, configure_logger
 from ..utils import install_uvloop_event_loop
@@ -56,6 +58,16 @@ async def build(folder: str, tag: str, no_cache: bool = False):
     dockerfile = generate_dockerfile()
     build_image(folder, dockerfile, tag, no_cache=no_cache)
     logger.info(f"Successfully built custom Docker image with tag {tag}")
+
+
+@root.command("init")
+@click.option("-t", "--template", default="https://github.com/EthicalML/sml-security/")
+@click_async
+async def init_project(template: str):
+    """
+    Generate a base project template
+    """
+    init_cookiecutter_project(template)
 
 
 @root.command("dockerfile")


### PR DESCRIPTION
Initial work to create a basic template for mlserver thourgh the "Secure Production ML Engineering Project Base" https://github.com/EthicalML/sml-security/. Currently making the template variable configurable in case people may want to create their own org templae, as well as if we want to create different templates as well that cover potentially different usecases.