### PR TITLE
Fix deepspeed_reinit error

### DIFF
--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "mlserver",
-        "optimum[onnxruntime]==1.2.1",
+        "optimum[onnxruntime]==1.2.3",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",

--- a/runtimes/huggingface/tests/conftest.py
+++ b/runtimes/huggingface/tests/conftest.py
@@ -1,0 +1,54 @@
+import pytest
+import asyncio
+
+from mlserver.utils import install_uvloop_event_loop
+from mlserver.types import InferenceRequest, RequestInput
+from mlserver.settings import ModelSettings, ModelParameters
+
+from mlserver_huggingface import HuggingFaceRuntime
+
+@pytest.fixture(scope="module")
+def event_loop():
+    # NOTE: We need to override the `event_loop` fixture to change its scope to
+    # `module`, so that it can be used downstream on other `module`-scoped
+    # fixtures
+    install_uvloop_event_loop()
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture(scope='module')
+def model_settings() -> ModelSettings:
+    return ModelSettings(
+        name="foo",
+        parameters=ModelParameters(
+            extra={
+                "task": "question-answering",
+            }
+        )
+    )
+
+@pytest.fixture(scope='module')
+async def runtime(model_settings: ModelSettings) -> HuggingFaceRuntime:
+    runtime = HuggingFaceRuntime(model_settings)
+    await runtime.load()
+    return runtime
+
+@pytest.fixture
+def inference_request() -> InferenceRequest:
+    return InferenceRequest(
+        inputs=[
+            RequestInput(
+                name="question",
+                shape=[1],
+                datatype="BYTES",
+                data=["what is your name?"]
+            ),
+            RequestInput(
+                name="context",
+                shape=[1],
+                datatype="BYTES",
+                data=["Hello, I am Seldon, how is it going"]
+            ),
+        ]
+    )

--- a/runtimes/huggingface/tests/conftest.py
+++ b/runtimes/huggingface/tests/conftest.py
@@ -7,6 +7,7 @@ from mlserver.settings import ModelSettings, ModelParameters
 
 from mlserver_huggingface import HuggingFaceRuntime
 
+
 @pytest.fixture(scope="module")
 def event_loop():
     # NOTE: We need to override the `event_loop` fixture to change its scope to
@@ -17,7 +18,8 @@ def event_loop():
     yield loop
     loop.close()
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def model_settings() -> ModelSettings:
     return ModelSettings(
         name="foo",
@@ -25,14 +27,16 @@ def model_settings() -> ModelSettings:
             extra={
                 "task": "question-answering",
             }
-        )
+        ),
     )
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 async def runtime(model_settings: ModelSettings) -> HuggingFaceRuntime:
     runtime = HuggingFaceRuntime(model_settings)
     await runtime.load()
     return runtime
+
 
 @pytest.fixture
 def inference_request() -> InferenceRequest:
@@ -42,13 +46,13 @@ def inference_request() -> InferenceRequest:
                 name="question",
                 shape=[1],
                 datatype="BYTES",
-                data=["what is your name?"]
+                data=["what is your name?"],
             ),
             RequestInput(
                 name="context",
                 shape=[1],
                 datatype="BYTES",
-                data=["Hello, I am Seldon, how is it going"]
+                data=["Hello, I am Seldon, how is it going"],
             ),
         ]
     )

--- a/runtimes/huggingface/tests/test_runtime.py
+++ b/runtimes/huggingface/tests/test_runtime.py
@@ -11,7 +11,8 @@ def test_load(runtime: HuggingFaceRuntime):
     assert runtime.ready
     assert isinstance(runtime._model, QuestionAnsweringPipeline)
 
+
 async def test_infer(runtime: HuggingFaceRuntime, inference_request: InferenceRequest):
     res = await runtime.predict(inference_request)
     pred = json.loads(res.outputs[0].data[0])
-    assert pred['answer'] == 'Seldon'
+    assert pred["answer"] == "Seldon"

--- a/runtimes/huggingface/tests/test_runtime.py
+++ b/runtimes/huggingface/tests/test_runtime.py
@@ -1,0 +1,17 @@
+import json
+
+from transformers.pipelines.question_answering import QuestionAnsweringPipeline
+
+from mlserver.types import InferenceRequest
+
+from mlserver_huggingface import HuggingFaceRuntime
+
+
+def test_load(runtime: HuggingFaceRuntime):
+    assert runtime.ready
+    assert isinstance(runtime._model, QuestionAnsweringPipeline)
+
+async def test_infer(runtime: HuggingFaceRuntime, inference_request: InferenceRequest):
+    res = await runtime.predict(inference_request)
+    pred = json.loads(res.outputs[0].data[0])
+    assert pred['answer'] == 'Seldon'


### PR DESCRIPTION
Following this PR from Optimum https://github.com/huggingface/optimum/pull/210, the Huggingface runtime will raise an error complaining about a missing `deepspeed_reinit` import. 

This PR bumps the version of the `optimum` package to the latest version, which includes a fix for the above.. 