### PR TITLE
Converting alibi detect input to numpy array format before prediction

### DIFF
--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -63,7 +63,7 @@ class AlibiDetectRuntime(MLModel):
             predict_kwargs = self.alibi_detect_settings.predict_parameters
 
         try:
-            y = self._model.predict(input_data, **predict_kwargs)
+            y = self._model.predict(np.array(input_data), **predict_kwargs)
         except (ValueError, IndexError) as e:
             raise InferenceError(
                 f"Invalid predict parameters for model {self._settings.name}: {e}"


### PR DESCRIPTION
The [example inference request in the alibi-detect docs notebook](https://github.com/SeldonIO/MLServer/tree/master/docs/examples/alibi-detect#send-test-inference-request) uses `numpy` content-type as the parameter(default).
The same example should be working with a `pd` content-type using the example request below. The main reason for failure is that the alibi-detect library expects a numpy array as input for prediction. This PR adds that conversion logic in the runtime.

```
{
  "parameters": { "content_type": "pd" },
  "inputs": [
    {
      "name": "Age",
      "shape": [1, 1],
      "datatype": "FP32",
      "data": [53]
    },
    {
      "name": "Workclass",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [4]
    },
    {
      "name": "Education",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [0]
    },
    {
      "name": "Marital Status",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [2]
    },
    {
      "name": "Occupation",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [8]
    },
    {
      "name": "Relationship",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [4]
    },
    {
      "name": "Race",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [2]
    },
    {
      "name": "Sex",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [0]
    },
    {
      "name": "Capital Gain",
      "shape": [1, 1],
      "datatype": "FP32",
      "data": [1100]
    },
    {
      "name": "Capital Loss",
      "shape": [1, 1],
      "datatype": "FP32",
      "data": [500]
    },
    {
      "name": "Hours per week",
      "shape": [1, 1],
      "datatype": "FP32",
      "data": [60]
    },
    {
      "name": "Country",
      "shape": [1, 1],
      "datatype": "INT64",
      "data": [9]
    }
  ]
}
```