### PR TITLE
Revert "Bump grpcio-tools from 1.47.0 to 1.48.0"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Code generation
-grpcio-tools==1.48.0
+grpcio-tools==1.47.0
 datamodel-code-generator==0.13.0
 ## Locking `prance` (a subdep of `datamodel-code-generator`) to an older
 ## version due to issues with the latest version of `pip`:


### PR DESCRIPTION
Reverts SeldonIO/MLServer#680