### PR TITLE
Add support to configurable metrics_rest_server_prefix

### DIFF
--- a/mlserver/rest/app.py
+++ b/mlserver/rest/app.py
@@ -120,7 +120,7 @@ def create_app(
         app.add_middleware(
             PrometheusMiddleware,
             app_name="mlserver",
-            prefix="rest_server",
+            prefix=settings.metrics_rest_server_prefix,
             # TODO: Should we also exclude model's health endpoints?
             skip_paths=[
                 settings.metrics_endpoint,

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -106,6 +106,11 @@ class Settings(BaseSettings):
     Port used to expose metrics endpoint.
     """
 
+    metrics_rest_server_prefix: str = "rest_server"
+    """
+    Metrics rest server string prefix to be exported.
+    """
+
     # Logging settings
     logging_settings: Optional[str] = None
     """Path to logging config file."""


### PR DESCRIPTION
This PR moves the string prefix "_rest_server_", currently hardcoded to settings, keeping its default value as _rest_server_.

Because we currently set up our application prefixes as "_http_application_" this can be achieved with MLServer by removing the hardcoded string.

cc @adriangonz 