### PR TITLE
Ensure HF runtime encodes batches separately 

### DIFF
--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "mlserver",
-        "optimum[onnxruntime]==1.2.3",
+        "optimum[onnxruntime]>=1.2.3",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",

--- a/runtimes/huggingface/tests/test_runtime.py
+++ b/runtimes/huggingface/tests/test_runtime.py
@@ -16,3 +16,23 @@ async def test_infer(runtime: HuggingFaceRuntime, inference_request: InferenceRe
     res = await runtime.predict(inference_request)
     pred = json.loads(res.outputs[0].data[0])
     assert pred["answer"] == "Seldon"
+
+
+async def test_infer_multiple(
+    runtime: HuggingFaceRuntime, inference_request: InferenceRequest
+):
+    # Send request with two elements
+    for request_input in inference_request.inputs:
+        input_data = request_input.data[0]
+        request_input.data.__root__ = [input_data, input_data]
+        request_input.shape = [2]
+
+    res = await runtime.predict(inference_request)
+
+    assert len(res.outputs) == 1
+
+    response_output = res.outputs[0]
+    assert len(response_output.data) == 2
+    for d in response_output.data:
+        pred = json.loads(d)
+        assert pred["answer"] == "Seldon"


### PR DESCRIPTION
Fixes issue discussed in [community Slack](https://seldondev.slack.com/archives/C03DQFTFXMX/p1663522460764359), where the HF runtime was aggregating all the batch outputs into a single entry. 