### PR TITLE
Fix CVEs in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ ENV MLSERVER_MODELS_DIR=/mnt/models \
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
-        libgomp1 libgl1-mesa-dev libglib2.0-0 build-essential
+        unattended-upgrades \
+        libgomp1 libgl1-mesa-dev libglib2.0-0 build-essential && \
+    unattended-upgrades
 
 RUN mkdir /opt/mlserver
 WORKDIR /opt/mlserver

--- a/mlserver/cli/constants.py
+++ b/mlserver/cli/constants.py
@@ -1,6 +1,6 @@
 DockerfileName = "Dockerfile"
 DockerfileTemplate = """
-FROM continuumio/miniconda3:4.10.3 AS env-builder
+FROM continuumio/miniconda3:4.12.0 AS env-builder
 SHELL ["/bin/bash", "-c"]
 
 ARG MLSERVER_ENV_NAME="mlserver-custom-env" \\


### PR DESCRIPTION
## Changelog

- Use `unattended-upgrades` to apply security updates to base image
- Bump version of `miniconda3` image