### PR TITLE
Add ssl_verify_path to explainers

### DIFF
--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -53,7 +53,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
 
 # TODO: add retry and better exceptions handling
 def remote_predict(
-    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: str
+    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: Optional[str]
 ) -> InferenceResponse:
     verify: Union[str, bool] = True
     if ssl_verify_path != "":
@@ -64,7 +64,7 @@ def remote_predict(
     return InferenceResponse.parse_raw(response_raw.text)
 
 
-def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
+def remote_metadata(url: str, ssl_verify_path: Optional[str]) -> MetadataModelResponse:
     """Get metadata from v2 endpoint"""
     verify: Union[str, bool] = True
     if ssl_verify_path != "":

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -53,9 +53,9 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
 
 # TODO: add retry and better exceptions handling
 def remote_predict(
-    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: Union[str, bool]
+    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: str
 ) -> InferenceResponse:
-    verify = True
+    verify: Union[str, bool] = True
     if ssl_verify_path != "":
         verify = ssl_verify_path
     response_raw = requests.post(predictor_url, json=v2_payload.dict(), verify=verify)
@@ -64,11 +64,9 @@ def remote_predict(
     return InferenceResponse.parse_raw(response_raw.text)
 
 
-def remote_metadata(
-    url: str, ssl_verify_path: Union[str, bool]
-) -> MetadataModelResponse:
+def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
     """Get metadata from v2 endpoint"""
-    verify = True
+    verify: Union[str, bool] = True
     if ssl_verify_path != "":
         verify = ssl_verify_path
     response_raw = requests.get(url, verify=verify)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -53,7 +53,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
 
 # TODO: add retry and better exceptions handling
 def remote_predict(
-    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: Optional[str]
+    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: str
 ) -> InferenceResponse:
     verify: Union[str, bool] = True
     if ssl_verify_path != "":
@@ -64,7 +64,7 @@ def remote_predict(
     return InferenceResponse.parse_raw(response_raw.text)
 
 
-def remote_metadata(url: str, ssl_verify_path: Optional[str]) -> MetadataModelResponse:
+def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
     """Get metadata from v2 endpoint"""
     verify: Union[str, bool] = True
     if ssl_verify_path != "":

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -53,17 +53,23 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
 
 # TODO: add retry and better exceptions handling
 def remote_predict(
-    v2_payload: InferenceRequest, predictor_url: str
+    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: str
 ) -> InferenceResponse:
-    response_raw = requests.post(predictor_url, json=v2_payload.dict())
+    verify = True
+    if ssl_verify_path != "":
+        verify = ssl_verify_path
+    response_raw = requests.post(predictor_url, json=v2_payload.dict(), verify=verify)
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return InferenceResponse.parse_raw(response_raw.text)
 
 
-def remote_metadata(url: str) -> MetadataModelResponse:
+def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
     """Get metadata from v2 endpoint"""
-    response_raw = requests.get(url)
+    verify = True
+    if ssl_verify_path != "":
+        verify = ssl_verify_path
+    response_raw = requests.get(url, verify=verify)
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return MetadataModelResponse.parse_raw(response_raw.text)
@@ -97,6 +103,7 @@ class AlibiExplainSettings(BaseSettings):
     infer_uri: str
     explainer_type: str
     init_parameters: Optional[dict]
+    ssl_verify_path: str
 
 
 def import_and_get_class(class_path: str) -> type:

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -53,7 +53,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
 
 # TODO: add retry and better exceptions handling
 def remote_predict(
-    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: str
+    v2_payload: InferenceRequest, predictor_url: str, ssl_verify_path: Union[str, bool]
 ) -> InferenceResponse:
     verify = True
     if ssl_verify_path != "":
@@ -64,7 +64,9 @@ def remote_predict(
     return InferenceResponse.parse_raw(response_raw.text)
 
 
-def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
+def remote_metadata(
+    url: str, ssl_verify_path: Union[str, bool]
+) -> MetadataModelResponse:
     """Get metadata from v2 endpoint"""
     verify = True
     if ssl_verify_path != "":

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -103,7 +103,7 @@ class AlibiExplainSettings(BaseSettings):
     infer_uri: str
     explainer_type: str
     init_parameters: Optional[dict]
-    ssl_verify_path: str
+    ssl_verify_path: Optional[str]
 
 
 def import_and_get_class(class_path: str) -> type:

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -33,7 +33,9 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
 
         self.infer_uri = explainer_settings.infer_uri
         self.infer_metadata: Optional[MetadataModelResponse] = None
-        self.ssl_verify_path = explainer_settings.ssl_verify_path
+        self.ssl_verify_path = ""
+        if explainer_settings.ssl_verify_path is not None:
+            self.ssl_verify_path = explainer_settings.ssl_verify_path
 
         # TODO: validate the settings are ok with this specific explainer
         super().__init__(settings, explainer_settings)

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -33,6 +33,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
 
         self.infer_uri = explainer_settings.infer_uri
         self.infer_metadata: Optional[MetadataModelResponse] = None
+        self.ssl_verify_path = explainer_settings.ssl_verify_path
 
         # TODO: validate the settings are ok with this specific explainer
         super().__init__(settings, explainer_settings)
@@ -70,11 +71,15 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             meta_url = construct_metadata_url(self.infer_uri)
             # get the metadata of the underlying inference model via v2
             # metadata endpoint
-            self.infer_metadata = remote_metadata(meta_url)
+            self.infer_metadata = remote_metadata(
+                meta_url, ssl_verify_path=self.ssl_verify_path
+            )
 
         v2_request = to_v2_inference_request(input_data, self.infer_metadata)
         v2_response = remote_predict(
-            v2_payload=v2_request, predictor_url=self.infer_uri
+            v2_payload=v2_request,
+            predictor_url=self.infer_uri,
+            ssl_verify_path=self.ssl_verify_path,
         )
 
         # TODO: do we care about more than one output?

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -96,6 +96,7 @@ async def test_anchors__smoke(
 
 async def test_remote_predict__smoke(custom_runtime_tf, rest_client):
     def _sync_request(*args, **kwargs):
+        kwargs.pop("verify", None)
         return run_async_as_sync(rest_client.post, *args, **kwargs)
 
     with patch("mlserver_alibi_explain.common.requests") as mock_requests:

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -121,6 +121,7 @@ async def test_remote_predict__smoke(custom_runtime_tf, rest_client):
             remote_predict,
             inference_request,
             predictor_url=endpoint,
+            ssl_verify_path="",
         )
         assert isinstance(res, InferenceResponse)
 

--- a/runtimes/alibi-explain/tests/test_utils.py
+++ b/runtimes/alibi-explain/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_remote_metadata__smoke(data, expected_input_name, expected_name):
         test_client = _TestClientWrapper(data)
 
         mock_requests.get = test_client.get_test_client().get
-        result = remote_metadata("/")
+        result = remote_metadata("/", ssl_verify_path="")
 
         if result.inputs:
             assert result.inputs[0].name == expected_input_name


### PR DESCRIPTION
 This allows server certificates to be verified in `requests` calls when MLServer might need to custom ca.crt file. The path to this ca.crt file can now be specified in the model-settings.json.

This is needed for correct TLS usage where black box explainers may call an endpoint whose certificate chain MLServer needs