### PR TITLE
Use python-dotenv to manage default env in custom images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,5 @@ USER 1000
 
 # We need to build and activate the "hot-loaded" environment before MLServer
 # starts
-CMD source ./hack/activate-env.sh $MLSERVER_ENV_TARBALL . && \
+CMD source ./hack/activate-env.sh $MLSERVER_ENV_TARBALL && \
     mlserver start $MLSERVER_MODELS_DIR

--- a/hack/activate-env.sh
+++ b/hack/activate-env.sh
@@ -26,8 +26,9 @@ _unpackEnv() {
 
 _activateEnv() {
   local _envFolder=$1
+  local _activate="$_envFolder/bin/activate"
 
-  if ! [[ -d $_envFolder ]]; then
+  if ! [[ -f $_activate ]]; then
     echo "Environment not found at '$_envFolder'"
     return
   fi
@@ -35,7 +36,7 @@ _activateEnv() {
   echo "--> Sourcing new environment at $_envFolder..."
   # Need to disable unbound errors for activate
   set +u
-  source "$_envFolder/bin/activate"
+  source $_activate
   set -u
 
   echo "--> Calling conda-unpack..."

--- a/hack/activate-env.sh
+++ b/hack/activate-env.sh
@@ -4,9 +4,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 1 ]; then
   echo 'Invalid number of arguments'
-  echo "Usage: ./activate-env.sh <envTarball> <dstFolder>"
+  echo "Usage: ./activate-env.sh <envTarball>"
   exit 1
 fi
 
@@ -46,27 +46,13 @@ _activateEnv() {
   export PYTHONNOUSERSITE=True
 }
 
-_sourceDotenv() {
-  local _dotenv=$1
-
-  if ! [[ -f $_dotenv ]]; then
-    echo "Dotenv file not found at '$_dotenv'"
-    return
-  fi
-
-  source $_dotenv
-}
-
 _main() {
   local _envTarball=$1
-  local _dstFolder=$2
-  local _envFolder="$_dstFolder/environment"
+  local _envName=$(basename "${_envTarball%.tar.gz}")
+  local _envFolder="./envs/$_envName"
 
   _unpackEnv $_envTarball $_envFolder
   _activateEnv $_envFolder
-
-  local _dotenv="$_dstFolder/.env"
-  _sourceDotenv $_dotenv
 }
 
-_main $1 $2
+_main $1

--- a/hack/build-env.sh
+++ b/hack/build-env.sh
@@ -7,9 +7,9 @@ set -o pipefail
 # This script may be called with `source`, so we can't rely on the `$0` trick.
 PARENT_FOLDER=$(dirname "$BASH_SOURCE")
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 1 ]; then
   echo 'Invalid number of arguments'
-  echo "Usage: ./build-env.sh <srcFolder> <dstFolder>"
+  echo "Usage: ./build-env.sh <srcFolder>"
   exit 1
 fi
 
@@ -36,18 +36,15 @@ _generateDotenv() {
 
 _main() {
   local _srcFolder=$1
-  local _dstFolder=$2
-
-  mkdir -p $_dstFolder
 
   local _requirementsTxt="$_srcFolder/requirements.txt"
   _installRequirements $_requirementsTxt
 
-  local _dotenv="$_dstFolder/.env"
+  local _dotenv="./.env"
   _generateDotenv $_srcFolder $_dotenv
 
   # TODO: If MLServer is not present, should we install it from the local wheel
   # in the Docker image?
 }
 
-_main $1 $2
+_main $1

--- a/hack/generate_dotenv.py
+++ b/hack/generate_dotenv.py
@@ -82,9 +82,10 @@ def _parse_dict_values(name: str, value: str) -> str:
     try:
         value = value.replace("'", '"')
         json.loads(value)
-        return f"export {name}='{value}'\n"
+        return f"{name}='{value}'\n"
     except JSONDecodeError:
-        return f'export {name}="{value}"\n'
+        # If not JSON, then assume it's a plain string
+        return f'{name}="{value}"\n'
 
 
 @click.command()

--- a/mlserver/cli/constants.py
+++ b/mlserver/cli/constants.py
@@ -49,9 +49,7 @@ COPY \\
 USER root
 # Install dependencies system-wide, to ensure that they are available for every
 # user
-RUN ./hack/build-env.sh . ./envs/base && \
-    chown -R 1000:0 ./envs/base && \\
-    chmod -R 776 ./envs/base
+RUN ./hack/build-env.sh .
 USER 1000
 
 # Copy everything else
@@ -59,7 +57,7 @@ COPY . .
 
 # Override MLServer's own `CMD` to activate the embedded environment
 # (optionally activating the hot-loaded one as well).
-CMD source ./hack/activate-env.sh ./envs/base.tar.gz ./envs/base && \\
+CMD source ./hack/activate-env.sh ./envs/base.tar.gz && \\
     mlserver start $MLSERVER_MODELS_DIR
 """
 

--- a/mlserver/cli/constants.py
+++ b/mlserver/cli/constants.py
@@ -48,8 +48,11 @@ COPY \\
 
 USER root
 # Install dependencies system-wide, to ensure that they are available for every
-# user
-RUN ./hack/build-env.sh .
+# user and give permissions to (future) environment folder.
+RUN ./hack/build-env.sh . && \\
+    mkdir -p ./envs/base && \\
+    chown -R 1000:0 ./envs/base && \\
+    chmod -R 776 ./envs/base
 USER 1000
 
 # Copy everything else

--- a/tests/testdata/env_models.py
+++ b/tests/testdata/env_models.py
@@ -11,7 +11,7 @@ from sklearn.dummy import DummyClassifier
 
 from mlserver import MLModel
 from mlserver.types import InferenceRequest, InferenceResponse
-from mlserver.codecs import NumpyCodec
+from mlserver.codecs import NumpyRequestCodec
 
 
 class DummySKLearnModel(MLModel):
@@ -27,8 +27,9 @@ class DummySKLearnModel(MLModel):
         return self.ready
 
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
-        decoded = self.decode(payload.inputs[0])
+        decoded = self.decode_request(payload, default_codec=NumpyRequestCodec)
         prediction = self._model.predict(decoded)
 
-        output = NumpyCodec().encode(name="prediction", payload=prediction)
-        return InferenceResponse(id=payload.id, model_name=self.name, outputs=[output])
+        return NumpyRequestCodec.encode_response(
+            model_name=self.name, payload=prediction, model_version=self.version
+        )

--- a/tests/testdata/environment.yml
+++ b/tests/testdata/environment.yml
@@ -3,4 +3,4 @@ dependencies:
   - python == 3.7
   - scikit-learn
   - pip:
-      - mlserver == 1.1.0.dev6
+      - mlserver == 1.2.0.dev6


### PR DESCRIPTION
Fixes #722 

## Changelog
- Update build scripts to let `python-dotenv` do its thing. This ensures that env vars can still override the default model settings after the custom image has been created.

## Note

The build scripts are coming from the base `seldonio/mlserver:1.2.0.dev6-slim` image. Therefore, the `mlserver build` tests will fail, since they're not able to get the updated config scripts. I've tested these locally though, and seem to work OK :+1: 

Once the tests finish (with those failing ones), we'll go ahead and merge this PR, and then kick off a `1.2.0.dev7` build, which should sort out these errors.