### PR TITLE
Micro batching

### DIFF
--- a/mlserver/batching/requests.py
+++ b/mlserver/batching/requests.py
@@ -18,7 +18,9 @@ def _get_data(payload: Union[RequestInput, ResponseOutput]):
 
 def _merge_parameters(
     all_params: dict,
-    parametrised_obj: Union[InferenceRequest, RequestInput, RequestOutput],
+    parametrised_obj: Union[
+        InferenceRequest, InferenceResponse, RequestInput, RequestOutput
+    ],
 ) -> dict:
     if not parametrised_obj.parameters:
         return all_params

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -123,9 +123,16 @@ async def dockerfile(folder: str, include_dockerignore: bool):
     help="Local path to the output file for the inference responses to be  written to.",
 )
 @click.option("--workers", "-w", default=10, envvar="MLSERVER_INFER_WORKERS")
-@click.option("--batch-size", "-b", default=1, envvar="MLSERVER_INFER_BATCH_SIZE")
+@click.option(
+    "--batch-size",
+    "-s",
+    default=1,
+    envvar="MLSERVER_INFER_BATCH_SIZE",
+    help="Send inference requests grouped together as micro-batch.",
+)
 @click.option(
     "--binary-data",
+    "-b",
     is_flag=True,
     default=False,
     envvar="MLSERVER_INFER_BINARY_DATA",

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -123,10 +123,9 @@ async def dockerfile(folder: str, include_dockerignore: bool):
     help="Local path to the output file for the inference responses to be  written to.",
 )
 @click.option("--workers", "-w", default=10, envvar="MLSERVER_INFER_WORKERS")
-@click.option("--batch-size", "-s", default=1, envvar="MLSERVER_INFER_BATCH_SIZE")
+@click.option("--batch-size", "-b", default=1, envvar="MLSERVER_INFER_BATCH_SIZE")
 @click.option(
     "--binary-data",
-    "-b",
     is_flag=True,
     default=False,
     envvar="MLSERVER_INFER_BINARY_DATA",

--- a/mlserver/cli/main.py
+++ b/mlserver/cli/main.py
@@ -123,6 +123,7 @@ async def dockerfile(folder: str, include_dockerignore: bool):
     help="Local path to the output file for the inference responses to be  written to.",
 )
 @click.option("--workers", "-w", default=10, envvar="MLSERVER_INFER_WORKERS")
+@click.option("--batch-size", "-s", default=1, envvar="MLSERVER_INFER_BATCH_SIZE")
 @click.option(
     "--binary-data",
     "-b",
@@ -160,7 +161,6 @@ async def dockerfile(folder: str, include_dockerignore: bool):
 )
 @click.option(
     "--use-ssl",
-    "-s",
     is_flag=True,
     default=False,
     envvar="MLSERVER_INFER_USE_SSL",
@@ -179,6 +179,7 @@ async def infer(
     model_name,
     url,
     workers,
+    batch_size,
     input_data_path,
     output_data_path,
     binary_data,
@@ -195,6 +196,7 @@ async def infer(
         model_name=model_name,
         url=url,
         workers=workers,
+        batch_size=batch_size,
         input_data_path=input_data_path,
         output_data_path=output_data_path,
         binary_data=binary_data,

--- a/tests/batch_processing/test_rest.py
+++ b/tests/batch_processing/test_rest.py
@@ -79,9 +79,7 @@ async def test_many(
         responses = [json.loads(line) for line in lines]
 
     assert len(responses) == 6
-    inference_indices = []
     for response in responses:
-        inference_indices.append(response["parameters"]["inference_id"])
         assert (
             response["outputs"][0]["data"][0]
             == response["parameters"]["batch_index"] + 1
@@ -91,7 +89,8 @@ async def test_many(
             _ = UUID(response["id"])
         except ValueError:
             raise RuntimeError(f"Response id is not a valid UUID; got {response['id']}")
-    assert len(set(inference_indices)) == 6
+
+        assert response["parameters"]["inference_id"] == response["id"]
 
 
 async def test_many_batch(

--- a/tests/batch_processing/test_rest.py
+++ b/tests/batch_processing/test_rest.py
@@ -137,7 +137,7 @@ async def test_many_batch(
         except ValueError:
             raise RuntimeError(f"Response id is not a valid UUID; got {response['id']}")
 
-    # We expect two unique inference indices as we have 6 requests and micro batch size is 3
+    # We expect two unique inference indices as we have 6 requests and batch size is 3
     assert len(set(inference_indices)) == 2
 
 

--- a/tests/batch_processing/test_rest.py
+++ b/tests/batch_processing/test_rest.py
@@ -28,6 +28,7 @@ async def test_single(
         input_data_path=single_input,
         output_data_path=output_file,
         binary_data=False,
+        batch_size=1,
         transport="rest",
         use_ssl=False,
         insecure=False,
@@ -65,6 +66,7 @@ async def test_many(
         input_data_path=many_input,
         output_data_path=output_file,
         binary_data=False,
+        batch_size=1,
         transport="rest",
         use_ssl=False,
         insecure=False,
@@ -77,7 +79,9 @@ async def test_many(
         responses = [json.loads(line) for line in lines]
 
     assert len(responses) == 6
+    inference_indices = []
     for response in responses:
+        inference_indices.append(response["parameters"]["inference_id"])
         assert (
             response["outputs"][0]["data"][0]
             == response["parameters"]["batch_index"] + 1
@@ -87,6 +91,55 @@ async def test_many(
             _ = UUID(response["id"])
         except ValueError:
             raise RuntimeError(f"Response id is not a valid UUID; got {response['id']}")
+    assert len(set(inference_indices)) == 6
+
+
+async def test_many_batch(
+    tmp_dir: TemporaryDirectory,
+    rest_client: RESTClient,
+    settings: Settings,
+    many_input: str,
+):
+    await rest_client.wait_until_ready()
+    model_name = "sum-model"
+    url = f"{settings.host}:{settings.http_port}"
+    output_file = os.path.join(tmp_dir.name, "output.txt")
+
+    await process_batch(
+        model_name=model_name,
+        url=url,
+        workers=1,
+        input_data_path=many_input,
+        output_data_path=output_file,
+        binary_data=False,
+        batch_size=3,
+        transport="rest",
+        use_ssl=False,
+        insecure=False,
+        verbose=True,
+        extra_verbose=True,
+    )
+
+    with open(output_file) as f:
+        lines = f.readlines()
+        responses = [json.loads(line) for line in lines]
+
+    assert len(responses) == 6
+    inference_indices = []
+    for response in responses:
+        inference_indices.append(response["parameters"]["inference_id"])
+        assert (
+            response["outputs"][0]["data"][0]
+            == response["parameters"]["batch_index"] + 1
+        )
+        assert response["id"] is not None and response["id"] != ""
+        try:
+            _ = UUID(response["id"])
+        except ValueError:
+            raise RuntimeError(f"Response id is not a valid UUID; got {response['id']}")
+
+    # We expect two unique inference indices as we have 6 requests and micro batch size is 3
+    assert len(set(inference_indices)) == 2
 
 
 async def test_single_with_id(
@@ -107,6 +160,7 @@ async def test_single_with_id(
         input_data_path=single_input_with_id,
         output_data_path=output_file,
         binary_data=False,
+        batch_size=1,
         transport="rest",
         use_ssl=False,
         insecure=False,

--- a/tests/batch_processing/test_rest.py
+++ b/tests/batch_processing/test_rest.py
@@ -76,6 +76,7 @@ async def test_many(
         lines = f.readlines()
         responses = [json.loads(line) for line in lines]
 
+    assert len(responses) == 6
     for response in responses:
         assert (
             response["outputs"][0]["data"][0]


### PR DESCRIPTION
Add micro-batching to `mlserver infer` in order to align with v1 batch processor.

Noticeable changes:
- input/output queues now holds `List[BatchInputItem]` and `List[BatchOutputItem]`
- added separate preprocess / postprocess functions
- added `TritonRequest` class (one step closer towards Triton codecs)