### PR TITLE
Alibi Explain Update to work with Hugging face runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV MLSERVER_MODELS_DIR=/mnt/models \
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
         unattended-upgrades \
-        libgomp1 libgl1-mesa-dev libglib2.0-0 build-essential && \
+        libgomp1 libgl1-mesa-dev libglib2.0-0 build-essential ffmpeg && \
     unattended-upgrades
 
 RUN mkdir /opt/mlserver

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -58,12 +58,12 @@ def remote_predict(
     verify: Union[str, bool] = True
     if ssl_verify_path != "":
         verify = ssl_verify_path
-    response_raw = requests.post(predictor_url, json=v2_payload.dict(exclude_unset=True), verify=verify)
+    response_raw = requests.post(
+        predictor_url, json=v2_payload.dict(exclude_unset=True), verify=verify
+    )
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return InferenceResponse.parse_raw(response_raw.text)
-
-
 
 
 def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
@@ -153,7 +153,9 @@ def to_v2_inference_request(
         # or even whether it is a probability of classes or targets etc
         inputs=[
             input_payload_codec.encode_input(  # type: ignore
-                name=input_name, payload=input_data, use_bytes=False,
+                name=input_name,
+                payload=input_data,
+                use_bytes=False,
             )
         ],
         outputs=outputs,

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -58,10 +58,12 @@ def remote_predict(
     verify: Union[str, bool] = True
     if ssl_verify_path != "":
         verify = ssl_verify_path
-    response_raw = requests.post(predictor_url, json=v2_payload.dict(), verify=verify)
+    response_raw = requests.post(predictor_url, json=v2_payload.dict(exclude_unset=True), verify=verify)
     if response_raw.status_code != 200:
         raise RemoteInferenceError(response_raw.status_code, response_raw.reason)
     return InferenceResponse.parse_raw(response_raw.text)
+
+
 
 
 def remote_metadata(url: str, ssl_verify_path: str) -> MetadataModelResponse:
@@ -151,7 +153,7 @@ def to_v2_inference_request(
         # or even whether it is a probability of classes or targets etc
         inputs=[
             input_payload_codec.encode_input(  # type: ignore
-                name=input_name, payload=input_data
+                name=input_name, payload=input_data, use_bytes=False,
             )
         ],
         outputs=outputs,

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -15,7 +15,6 @@ from mlserver_alibi_explain.common import (
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntimeBase
 
-
 class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
     """
     Runtime for black box explainer runtime, i.e. explainer that would just need access
@@ -68,8 +67,7 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
         # The contract is that alibi-explain would input/output ndarray
         # in the case of AnchorText, we have a list of strings instead though.
         # TODO: for now we only support v2 protocol, do we need more support?
-
-        if self.infer_metadata is None:
+        if self.infer_metadata is None and self.infer_uri.find("/v2/pipelines/") == -1:
             meta_url = construct_metadata_url(self.infer_uri)
             # get the metadata of the underlying inference model via v2
             # metadata endpoint
@@ -83,6 +81,5 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             predictor_url=self.infer_uri,
             ssl_verify_path=self.ssl_verify_path,
         )
-
         # TODO: do we care about more than one output?
         return NumpyCodec.decode_output(v2_response.outputs[0])

--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -15,6 +15,7 @@ from mlserver_alibi_explain.common import (
 )
 from mlserver_alibi_explain.runtime import AlibiExplainRuntimeBase
 
+
 class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
     """
     Runtime for black box explainer runtime, i.e. explainer that would just need access

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -196,7 +196,7 @@ async def test_end_2_end_explain_v1_output(
                     RequestInput(
                         parameters=Parameters(content_type=StringCodec.ContentType),
                         name=_DEFAULT_INPUT_NAME,
-                        data=[b"dummy", b"dummy text"],
+                        data=["dummy", "dummy text"],
                         shape=[2],
                         datatype="BYTES",
                     )

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -90,11 +90,17 @@ class HuggingFaceRuntime(MLModel):
         # TODO: convert and validate?
         kwargs = self.decode_request(payload, default_codec=MultiStringRequestCodec)
 
-        args = kwargs.pop("args", [])
+        args = kwargs.pop("args", None)
+
         X = kwargs.pop("array_inputs", None)
         if X is not None:
             args = [list(X)] + args
-        prediction = self._model(args, **kwargs)
+        if args is None:
+            prediction = self._model(**kwargs)
+        else:
+            prediction = self._model(args, **kwargs)
+
+        logger.debug("Prediction %s", prediction)
 
         # TODO: Convert hf output to v2 protocol, for now we use to_json
         if isinstance(prediction, dict):

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -84,6 +84,9 @@ class HuggingFaceRuntime(MLModel):
         TODO
         """
 
+        # Adding some logging as hard to debug given the many types of input accepted
+        logger.debug("Payload %s",payload)
+
         # TODO: convert and validate?
         kwargs = self.decode_request(payload, default_codec=MultiStringRequestCodec)
 
@@ -91,7 +94,7 @@ class HuggingFaceRuntime(MLModel):
         X = kwargs.pop("array_inputs", None)
         if X is not None:
             args = [list(X)] + args
-        prediction = self._model(*args, **kwargs)
+        prediction = self._model(args, **kwargs)
 
         # TODO: Convert hf output to v2 protocol, for now we use to_json
         if isinstance(prediction, dict):

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -94,7 +94,10 @@ class HuggingFaceRuntime(MLModel):
         prediction = self._model(*args, **kwargs)
 
         # TODO: Convert hf output to v2 protocol, for now we use to_json
-        str_out = [json.dumps(pred, cls=NumpyEncoder) for pred in prediction]
+        if isinstance(prediction, dict):
+            str_out = [json.dumps(prediction, cls=NumpyEncoder)]
+        else:
+            str_out = [json.dumps(pred, cls=NumpyEncoder) for pred in prediction]
         prediction_encoded = StringCodec.encode_output(payload=str_out, name="output")
 
         return InferenceResponse(

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -85,7 +85,7 @@ class HuggingFaceRuntime(MLModel):
         """
 
         # Adding some logging as hard to debug given the many types of input accepted
-        logger.debug("Payload %s",payload)
+        logger.debug("Payload %s", payload)
 
         # TODO: convert and validate?
         kwargs = self.decode_request(payload, default_codec=MultiStringRequestCodec)


### PR DESCRIPTION
1. Exclude unset fields when sending inference requests to limit issues on deserialization on the server end
2. Set use_bytes when creating input to send to ensure it can be JSON serialized
3. Exclude SCV2 pipelines when asking for metadata as this is not presently possible with Pipelines
4. Use `args` not `*args` in Huggingface runtime as `args` is always a single argument or list. Allows batch inputs to work.