### PR TITLE
Set explicitly a two-dimensional shape on some codecs

### DIFF
--- a/docs/user-guide/content-type.md
+++ b/docs/user-guide/content-type.md
@@ -206,13 +206,13 @@ Therefore, we can leverage this to override the model's metadata when needed.
 Out of the box, MLServer supports the following list of content types.
 However, this can be extended through the use of 3rd-party or custom runtimes.
 
-| Python Type                           | Content Type | Request Level | Request Codec                        | Input Level | Input Codec                     |
-| ------------------------------------- | ------------ | ------------- | ------------------------------------ | ----------- | ------------------------------- |
-| [NumPy Array](#numpy-array)           | `np`         | ✅            | `mlserver.codecs.NumpyRequestCodec`  | ✅          | `mlserver.codecs.NumpyCodec`    |
-| [Pandas DataFrame](#pandas-dataframe) | `pd`         | ✅            | `mlserver.codecs.PandasCodec`        | ❌          |                                 |
+| Python Type                           | Content Type | Request Level | Request Codec                               | Input Level | Input Codec                     |
+| ------------------------------------- | ------------ | ------------- | ------------------------------------------- | ----------- | ------------------------------- |
+| [NumPy Array](#numpy-array)           | `np`         | ✅            | `mlserver.codecs.NumpyRequestCodec`         | ✅          | `mlserver.codecs.NumpyCodec`    |
+| [Pandas DataFrame](#pandas-dataframe) | `pd`         | ✅            | `mlserver.codecs.PandasCodec`               | ❌          |                                 |
 | [UTF-8 String](#utf-8-string)         | `str`        | ✅            | `mlserver.codecs.string.StringRequestCodec` | ✅          | `mlserver.codecs.StringCodec`   |
-| [Base64](#base64)                     | `base64`     | ❌            |                                      | ✅          | `mlserver.codecs.Base64Codec`   |
-| [Datetime](#datetime)                 | `datetime`   | ❌            |                                      | ✅          | `mlserver.codecs.DatetimeCodec` |
+| [Base64](#base64)                     | `base64`     | ❌            |                                             | ✅          | `mlserver.codecs.Base64Codec`   |
+| [Datetime](#datetime)                 | `datetime`   | ❌            |                                             | ✅          | `mlserver.codecs.DatetimeCodec` |
 
 ```{note}
 MLServer allows you extend the supported content types by **adding custom
@@ -241,6 +241,16 @@ into account the following:
   `dtype`](https://numpy.org/doc/stable/reference/arrays.dtypes.html).
 - The `shape` field will be used to reshape the flattened array expected by the
   V2 protocol into the expected tensor shape.
+
+```{note}
+By default, MLServer will always assume that an array with a single-dimensional
+shape, e.g. `[N]`, is equivalent to `[N, 1]`.
+That is, each entry will be treated like a single one-dimensional data point
+(i.e. instead of a `[1, D]` array, where the full array is a single
+`D`-dimensional data point).
+To avoid any ambiguity, where possible, the **Numpy codec will always
+explicitly encode `[N]` arrays as `[N, 1]`**.
+```
 
 For example, if we think of the following NumPy Array:
 

--- a/mlserver/codecs/base64.py
+++ b/mlserver/codecs/base64.py
@@ -58,7 +58,7 @@ class Base64Codec(InputCodec):
     ) -> ResponseOutput:
         # Assume that payload is already in b64, so we only need to pack it
         packed = map(partial(_encode_base64, use_bytes=use_bytes), payload)
-        shape = [len(payload)]
+        shape = [len(payload), 1]
         return ResponseOutput(
             name=name,
             datatype="BYTES",

--- a/mlserver/codecs/datetime.py
+++ b/mlserver/codecs/datetime.py
@@ -56,7 +56,7 @@ class DatetimeCodec(InputCodec):
         cls, name: str, payload: List[_Datetime], use_bytes: bool = True, **kwargs
     ) -> ResponseOutput:
         packed = map(partial(_encode_datetime, use_bytes=use_bytes), payload)
-        shape = [len(payload)]
+        shape = [len(payload), 1]
         return ResponseOutput(
             name=name,
             datatype="BYTES",

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -5,7 +5,7 @@ from typing import Any
 from ..types import RequestInput, ResponseOutput, Parameters
 
 from .base import InputCodec, register_input_codec, register_request_codec
-from .utils import SingleInputRequestCodec, InputOrOutput
+from .utils import SingleInputRequestCodec, InputOrOutput, inject_batch_dimension
 from .lists import is_list_of
 from .string import encode_str
 
@@ -112,10 +112,12 @@ class NumpyCodec(InputCodec):
     def encode_output(cls, name: str, payload: np.ndarray, **kwargs) -> ResponseOutput:
         datatype = to_datatype(payload.dtype)
 
+        shape = inject_batch_dimension(list(payload.shape))
+
         return ResponseOutput(
             name=name,
             datatype=datatype,
-            shape=list(payload.shape),
+            shape=shape,
             data=_encode_data(payload, datatype),
         )
 

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -6,7 +6,7 @@ from typing import Any, List
 from .base import RequestCodec, register_request_codec
 from .numpy import to_datatype, to_dtype
 from .string import encode_str
-from .utils import get_decoded_or_raw, InputOrOutput
+from .utils import get_decoded_or_raw, InputOrOutput, inject_batch_dimension
 from .lists import ListElement
 from ..types import InferenceRequest, InferenceResponse, RequestInput, ResponseOutput
 
@@ -35,9 +35,11 @@ def _to_response_output(series: pd.Series, use_bytes: bool = True) -> ResponseOu
         # encode them as bytes
         data = list(map(_ensure_bytes, data))
 
+    shape = inject_batch_dimension(list(series.shape))
+
     return ResponseOutput(
         name=series.name,
-        shape=list(series.shape),
+        shape=shape,
         # If string, it should be encoded to bytes
         data=data,
         datatype=datatype,

--- a/mlserver/codecs/string.py
+++ b/mlserver/codecs/string.py
@@ -55,7 +55,7 @@ class StringCodec(InputCodec):
         if use_bytes:
             packed = list(map(encode_str, payload))  # type: ignore
 
-        shape = [len(payload)]
+        shape = [len(payload), 1]
         return ResponseOutput(
             name=name,
             datatype="BYTES",

--- a/mlserver/codecs/utils.py
+++ b/mlserver/codecs/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Dict, Optional
+from typing import Any, Union, Dict, Optional, List
 
 from ..types import (
     InferenceRequest,
@@ -32,6 +32,17 @@ Parametrised = Union[
 ]
 Tagged = Union[MetadataTensor, ModelSettings]
 DecodedParameterName = "_decoded_payload"
+
+
+def inject_batch_dimension(shape: List[int]) -> List[int]:
+    """
+    Utility method to ensure that 1-dimensional shapes
+    assume that `[N] == [N, D]`.
+    """
+    if len(shape) > 1:
+        return shape
+
+    return shape + [1]
 
 
 def _get_content_type(

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -38,7 +38,7 @@ def convert_from_bytes(output: ResponseOutput, ty: Optional[Type] = None) -> Any
     This utility function decodes the response from bytes string to python object dict.
     It is related to decoding StringCodec
     """
-    if output.shape != [1]:
+    if output.shape not in ([1], [1, 1]):
         raise InvalidExplanationShape(output.shape)
 
     if ty == str:

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -67,7 +67,7 @@ class AlibiExplainRuntimeBase(MLModel):
 
         output = v2_response.outputs[0]
 
-        if output.shape != [1]:
+        if output.shape not in ([1], [1, 1]):
             raise InvalidExplanationShape(output.shape)
 
         explanation = json.loads(output.data[0])

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -276,7 +276,7 @@ async def test_custom_explain_endpoint(dummy_alibi_explain_client):
         InferenceResponse(
             model_name="my-model",
             outputs=[
-                ResponseOutput(name="foo", datatype="INT32", shape=[1, 1], data=[1]),
+                ResponseOutput(name="foo", datatype="INT32", shape=[1, 1, 1], data=[1]),
             ],
         ),
         InferenceResponse(

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -197,7 +197,7 @@ async def test_end_2_end_explain_v1_output(
                         parameters=Parameters(content_type=StringCodec.ContentType),
                         name=_DEFAULT_INPUT_NAME,
                         data=["dummy", "dummy text"],
-                        shape=[2],
+                        shape=[2, 1],
                         datatype="BYTES",
                     )
                 ],

--- a/runtimes/alibi-explain/tests/test_common.py
+++ b/runtimes/alibi-explain/tests/test_common.py
@@ -9,7 +9,7 @@ from mlserver_alibi_explain.errors import InvalidExplanationShape
 @pytest.mark.parametrize(
     "output",
     [
-        ResponseOutput(name="foo", datatype="INT32", shape=[1, 1], data=[1]),
+        ResponseOutput(name="foo", datatype="INT32", shape=[1, 1, 1], data=[1]),
         ResponseOutput(name="foo", datatype="INT32", shape=[1, 2], data=[1, 2]),
     ],
 )

--- a/runtimes/mlflow/tests/test_codecs.py
+++ b/runtimes/mlflow/tests/test_codecs.py
@@ -38,7 +38,7 @@ def test_encode_response():
     assert inference_response.model_name == model_name
     assert len(inference_response.outputs) == 2
     assert inference_response.outputs[0] == ResponseOutput(
-        name="foo", datatype="INT64", shape=[3], data=[1, 2, 3]
+        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
     )
     assert inference_response.outputs[1] == ResponseOutput(
         name="bar", datatype="FP64", shape=[2, 1], data=[2.3, 4.5]
@@ -49,7 +49,7 @@ def test_decode_response():
     inference_response = InferenceResponse(
         model_name="dummy-model",
         outputs=[
-            ResponseOutput(name="foo", datatype="INT64", shape=[3], data=[1, 2, 3]),
+            ResponseOutput(name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]),
             ResponseOutput(name="bar", datatype="FP64", shape=[2, 1], data=[2.3, 4.5]),
         ],
     )
@@ -57,7 +57,7 @@ def test_decode_response():
     tensor_dict = TensorDictCodec.decode_response(inference_response)
 
     expected_dict = {
-        "foo": np.array([1, 2, 3], dtype=np.int32),
+        "foo": np.array([[1], [2], [3]], dtype=np.int32),
         "bar": np.array([[2.3], [4.5]]),
     }
 
@@ -75,7 +75,7 @@ def test_encode_request():
     assert inference_request.inputs[0] == RequestInput(
         name="foo",
         datatype="INT64",
-        shape=[3],
+        shape=[3, 1],
         data=[1, 2, 3],
         parameters=Parameters(content_type=NumpyCodec.ContentType),
     )

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -67,7 +67,7 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                     ResponseOutput(
                         name="output-1",
                         datatype="BYTES",
-                        shape=[1],
+                        shape=[1, 1],
                         data=[b"foo"],
                         parameters=Parameters(content_type="str"),
                     )
@@ -123,10 +123,13 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                 model_name="mlflow-model",
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3], data=[1, 2, 3]
+                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="bar", datatype="BYTES", shape=[3], data=[b"A", b"B", b"C"]
+                        name="bar",
+                        datatype="BYTES",
+                        shape=[3, 1],
+                        data=[b"A", b"B", b"C"],
                     ),
                 ],
             ),

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -94,9 +94,11 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                 model_name="mlflow-model",
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3], data=[1, 2, 3]
+                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
                     ),
-                    ResponseOutput(name="bar", datatype="FP64", shape=[1], data=[1.2]),
+                    ResponseOutput(
+                        name="bar", datatype="FP64", shape=[1, 1], data=[1.2]
+                    ),
                 ],
             ),
         ),
@@ -106,12 +108,12 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                 model_name="mlflow-model",
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3], data=[1, 2, 3]
+                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
                     ),
                     ResponseOutput(
                         name="bar",
                         datatype="BYTES",
-                        shape=[2],
+                        shape=[2, 1],
                         data=[b"hello", b"world"],
                     ),
                 ],

--- a/tests/codecs/test_base64.py
+++ b/tests/codecs/test_base64.py
@@ -28,7 +28,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -39,7 +39,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -50,7 +50,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -61,7 +61,7 @@ def test_can_encode(payload: Any, expected: bool):
             False,
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=["UHl0aG9uIGlzIGZ1bg==", "UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -83,7 +83,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single base64-encoded binary string
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data="UHl0aG9uIGlzIGZ1bg==",
             ),
@@ -93,7 +93,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single (non-base64-encoded) binary string
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=b"Python is fun",
             ),
@@ -103,7 +103,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single (non-base64-encoded) (non-binary) string
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data="Python is fun",
             ),
@@ -113,7 +113,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Multiple base64-encoded binary strings
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -136,7 +136,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -147,7 +147,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -158,7 +158,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -169,7 +169,7 @@ def test_decode_output(encoded, expected):
             False,
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=["UHl0aG9uIGlzIGZ1bg==", "UHl0aG9uIGlzIGZ1bg=="],
             ),
@@ -191,7 +191,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single base64-encoded binary string
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data="UHl0aG9uIGlzIGZ1bg==",
             ),
@@ -201,7 +201,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single (non-base64-encoded) binary string
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=b"Python is fun",
             ),
@@ -211,7 +211,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single (non-base64-encoded) (non-binary) string
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data="Python is fun",
             ),
@@ -221,7 +221,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Multiple base64-encoded binary strings
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
             ),

--- a/tests/codecs/test_datetime.py
+++ b/tests/codecs/test_datetime.py
@@ -36,7 +36,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
             ),
@@ -47,7 +47,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
@@ -58,7 +58,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
             ),
@@ -69,7 +69,7 @@ def test_can_encode(payload: Any, expected: bool):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIsoB],
             ),
@@ -80,7 +80,7 @@ def test_can_encode(payload: Any, expected: bool):
             False,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
             ),
@@ -102,7 +102,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single binary ISO-encoded datetime
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=TestDatetimeIsoB,
             ),
@@ -112,7 +112,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single (non-binary) ISO-encoded datetime
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIso],
             ),
@@ -122,7 +122,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Multiple binary ISO-encoded datetime
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
@@ -132,7 +132,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Multiple (non-binary) ISO-encoded datetime
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIso, TestDatetimeIso],
             ),
@@ -142,7 +142,7 @@ def test_encode_output(decoded, use_bytes, expected):
             # Single (non-binary) ISO-encoded datetime with timezone
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
             ),
@@ -165,7 +165,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
             ),
@@ -176,7 +176,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
@@ -187,7 +187,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
             ),
@@ -198,7 +198,7 @@ def test_decode_output(encoded, expected):
             True,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIsoB],
             ),
@@ -209,7 +209,7 @@ def test_decode_output(encoded, expected):
             False,
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
             ),
@@ -231,7 +231,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single binary ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=TestDatetimeIsoB,
             ),
@@ -241,7 +241,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single (non-binary) ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIso],
             ),
@@ -251,7 +251,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Multiple binary ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
             ),
@@ -261,7 +261,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Multiple (non-binary) ISO-encoded datetime
             RequestInput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIso, TestDatetimeIso],
             ),
@@ -271,7 +271,7 @@ def test_encode_input(decoded, use_bytes, expected):
             # Single (non-binary) ISO-encoded datetime with timezone
             RequestInput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
             ),

--- a/tests/codecs/test_decorator.py
+++ b/tests/codecs/test_decorator.py
@@ -162,7 +162,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-0",
                     datatype="BYTES",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[b"foo"],
                     parameters=Parameters(content_type=StringCodec.ContentType),
                 )
@@ -181,7 +181,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-1",
                     datatype="BYTES",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[b"foo"],
                     parameters=Parameters(content_type=StringCodec.ContentType),
                 ),
@@ -194,7 +194,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-0",
                     datatype="BYTES",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[b"foo"],
                     parameters=Parameters(content_type=StringCodec.ContentType),
                 ),
@@ -210,20 +210,20 @@ def test_decode_request_not_found(
             pd.DataFrame({"a": [2], "b": ["foo"]}),
             [PandasCodec],
             [
-                ResponseOutput(name="a", datatype="INT64", shape=[1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1], data=[b"foo"]),
+                ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
+                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
             ],
         ),
         (
             (pd.DataFrame({"a": [2], "b": ["foo"]}), ["bar"]),
             [PandasCodec, StringCodec],
             [
-                ResponseOutput(name="a", datatype="INT64", shape=[1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1], data=[b"foo"]),
+                ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
+                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
                 ResponseOutput(
                     name="output-1",
                     datatype="BYTES",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[b"bar"],
                     parameters=Parameters(content_type=StringCodec.ContentType),
                 ),
@@ -239,8 +239,8 @@ def test_decode_request_not_found(
                     shape=[1],
                     data=[3],
                 ),
-                ResponseOutput(name="a", datatype="INT64", shape=[1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1], data=[b"foo"]),
+                ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
+                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
             ],
         ),
     ],

--- a/tests/codecs/test_decorator.py
+++ b/tests/codecs/test_decorator.py
@@ -150,7 +150,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-0",
                     datatype="INT64",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[2],
                 )
             ],
@@ -175,7 +175,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-0",
                     datatype="INT64",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[2],
                 ),
                 ResponseOutput(
@@ -201,7 +201,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-1",
                     datatype="INT64",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[2],
                 ),
             ],
@@ -236,7 +236,7 @@ def test_decode_request_not_found(
                 ResponseOutput(
                     name="output-0",
                     datatype="INT64",
-                    shape=[1],
+                    shape=[1, 1],
                     data=[3],
                 ),
                 ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -84,10 +84,13 @@ def test_to_response_output(series, use_bytes, expected):
                 model_name="my-model",
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3], datatype="INT64", data=[1, 2, 3]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="b", shape=[3], datatype="BYTES", data=[b"A", b"B", b"C"]
+                        name="b",
+                        shape=[3, 1],
+                        datatype="BYTES",
+                        data=[b"A", b"B", b"C"],
                     ),
                 ],
             ),
@@ -104,10 +107,10 @@ def test_to_response_output(series, use_bytes, expected):
                 model_name="my-model",
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3], datatype="INT64", data=[1, 2, 3]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="b", shape=[3], datatype="BYTES", data=["A", "B", "C"]
+                        name="b", shape=[3, 1], datatype="BYTES", data=["A", "B", "C"]
                     ),
                 ],
             ),

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -32,33 +32,33 @@ def test_can_encode(payload: Any, expected: bool):
             pd.Series(data=["hey", "abc"], name="foo"),
             True,
             ResponseOutput(
-                name="foo", shape=[2], data=[b"hey", b"abc"], datatype="BYTES"
+                name="foo", shape=[2, 1], data=[b"hey", b"abc"], datatype="BYTES"
             ),
         ),
         (
             pd.Series(data=["hey", "abc"], name="foo"),
             False,
             ResponseOutput(
-                name="foo", shape=[2], data=["hey", "abc"], datatype="BYTES"
+                name="foo", shape=[2, 1], data=["hey", "abc"], datatype="BYTES"
             ),
         ),
         (
             pd.Series(data=[1, 2, 3], name="bar"),
             True,
-            ResponseOutput(name="bar", shape=[3], data=[1, 2, 3], datatype="INT64"),
+            ResponseOutput(name="bar", shape=[3, 1], data=[1, 2, 3], datatype="INT64"),
         ),
         (
             pd.Series(data=[1, 2.5, 3], name="bar"),
             True,
             ResponseOutput(
-                name="bar", shape=[3], data=[1.0, 2.5, 3.0], datatype="FP64"
+                name="bar", shape=[3, 1], data=[1.0, 2.5, 3.0], datatype="FP64"
             ),
         ),
         (
             pd.Series(data=[[1, 2, 3], [4, 5, 6]], name="bar"),
             True,
             ResponseOutput(
-                name="bar", shape=[2], data=[[1, 2, 3], [4, 5, 6]], datatype="BYTES"
+                name="bar", shape=[2, 1], data=[[1, 2, 3], [4, 5, 6]], datatype="BYTES"
             ),
         ),
     ],
@@ -133,10 +133,13 @@ def test_encode_response(dataframe, use_bytes, expected):
                 model_name="my-model",
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3], datatype="INT64", data=[1, 2, 3]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="b", shape=[3], datatype="BYTES", data=[b"A", b"B", b"C"]
+                        name="b",
+                        shape=[3, 1],
+                        datatype="BYTES",
+                        data=[b"A", b"B", b"C"],
                     ),
                 ],
             ),
@@ -152,11 +155,11 @@ def test_encode_response(dataframe, use_bytes, expected):
                 model_name="my-model",
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3], datatype="INT64", data=[1, 2, 3]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
                         name="b",
-                        shape=[3],
+                        shape=[3, 1],
                         datatype="BYTES",
                         data=[b"A", b"B", b"C"],
                         parameters=Parameters(_decoded_payload=["A", "B", "C"]),
@@ -175,10 +178,15 @@ def test_encode_response(dataframe, use_bytes, expected):
                 model_name="my-model",
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3], datatype="INT32", data=[1, 2, 3]
+                        name="a",
+                        shape=[
+                            3,
+                        ],
+                        datatype="INT32",
+                        data=[1, 2, 3],
                     ),
                     ResponseOutput(
-                        name="b", shape=[3], datatype="FP32", data=[5, 6, 7]
+                        name="b", shape=[3, 1], datatype="FP32", data=[5, 6, 7]
                     ),
                 ],
             ),
@@ -209,9 +217,14 @@ def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
             True,
             InferenceRequest(
                 inputs=[
-                    RequestInput(name="a", shape=[3], datatype="INT64", data=[1, 2, 3]),
                     RequestInput(
-                        name="b", shape=[3], datatype="BYTES", data=[b"A", b"B", b"C"]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
+                    ),
+                    RequestInput(
+                        name="b",
+                        shape=[3, 1],
+                        datatype="BYTES",
+                        data=[b"A", b"B", b"C"],
                     ),
                 ],
             ),
@@ -226,9 +239,11 @@ def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
             False,
             InferenceRequest(
                 inputs=[
-                    RequestInput(name="a", shape=[3], datatype="INT64", data=[1, 2, 3]),
                     RequestInput(
-                        name="b", shape=[3], datatype="BYTES", data=["A", "B", "C"]
+                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
+                    ),
+                    RequestInput(
+                        name="b", shape=[3, 1], datatype="BYTES", data=["A", "B", "C"]
                     ),
                 ],
             ),
@@ -259,7 +274,7 @@ def test_encode_request(
                         name="b",
                         data=b"hello world",
                         datatype="BYTES",
-                        shape=[1],
+                        shape=[1, 1],
                         parameters=Parameters(_decoded_payload=["hello world"]),
                     ),
                 ]
@@ -282,7 +297,7 @@ def test_encode_request(
                         name="b",
                         data=b"ABC",
                         datatype="BYTES",
-                        shape=[3],
+                        shape=[3, 1],
                     ),
                 ]
             ),
@@ -314,37 +329,37 @@ def test_encode_request(
                         name="a",
                         data=[None, None],
                         datatype="FP64",
-                        shape=[1],
+                        shape=[2, 1],
                     ),
                     RequestInput(
                         name="b",
                         data=[1, 2],
                         datatype="FP32",
-                        shape=[2],
+                        shape=[2, 1],
                     ),
                     RequestInput(
                         name="c",
                         data=[3, 4],
                         datatype="INT32",
-                        shape=[2],
+                        shape=[2, 1],
                     ),
                     RequestInput(
                         name="d",
                         data=[5, 6],
                         datatype="UINT8",
-                        shape=[2],
+                        shape=[2, 1],
                     ),
                     RequestInput(
                         name="e",
                         data=[True, False],
                         datatype="BOOL",
-                        shape=[2],
+                        shape=[2, 1],
                     ),
                     RequestInput(
                         name="f",
                         data=[0, 1],
                         datatype="BOOL",
-                        shape=[2],
+                        shape=[2, 1],
                     ),
                 ]
             ),

--- a/tests/codecs/test_string.py
+++ b/tests/codecs/test_string.py
@@ -23,42 +23,52 @@ def test_can_encode(payload: Any, expected: bool):
     "request_input, expected",
     [
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[], data=b"hello world"),
+            RequestInput(
+                name="foo", datatype="BYTES", shape=[1, 1], data=b"hello world"
+            ),
             ["hello world"],
         ),
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[], data="hello world"),
+            RequestInput(
+                name="foo", datatype="BYTES", shape=[1, 1], data="hello world"
+            ),
             ["hello world"],
         ),
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[], data=["hello world"]),
+            RequestInput(
+                name="foo", datatype="BYTES", shape=[1, 1], data=["hello world"]
+            ),
             ["hello world"],
         ),
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[], data=[b"hello world"]),
+            RequestInput(
+                name="foo", datatype="BYTES", shape=[1, 1], data=[b"hello world"]
+            ),
             ["hello world"],
         ),
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[1], data=b"hello world"),
+            RequestInput(
+                name="foo", datatype="BYTES", shape=[1, 1], data=b"hello world"
+            ),
             ["hello world"],
         ),
         (
             RequestInput(
                 name="foo",
                 datatype="BYTES",
-                shape=[2],
+                shape=[2, 1],
                 data=["hello world", "hello world"],
             ),
             ["hello world", "hello world"],
         ),
         (
             RequestInput(
-                name="foo", datatype="BYTES", shape=[2], data=[b"hey", b"whats"]
+                name="foo", datatype="BYTES", shape=[2, 1], data=[b"hey", b"whats"]
             ),
             ["hey", "whats"],
         ),
         (
-            RequestInput(name="foo", datatype="BYTES", shape=[2], data=[None]),
+            RequestInput(name="foo", datatype="BYTES", shape=[1, 1], data=[None]),
             [None],
         ),
     ],
@@ -77,7 +87,7 @@ def test_decode_input(request_input, expected):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[1],
+                shape=[1, 1],
                 datatype="BYTES",
                 data=[b"hello world"],
                 parameters=Parameters(content_type=StringCodec.ContentType),
@@ -88,7 +98,7 @@ def test_decode_input(request_input, expected):
             True,
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=[b"hey", b"whats"],
                 parameters=Parameters(content_type=StringCodec.ContentType),
@@ -99,7 +109,7 @@ def test_decode_input(request_input, expected):
             False,
             ResponseOutput(
                 name="foo",
-                shape=[2],
+                shape=[2, 1],
                 datatype="BYTES",
                 data=["hey", "whats"],
                 parameters=Parameters(content_type=StringCodec.ContentType),
@@ -122,21 +132,21 @@ def test_encode_output(decoded, use_bytes, expected):
             ["hello world"],
             True,
             ResponseOutput(
-                name="foo", shape=[1], datatype="BYTES", data=[b"hello world"]
+                name="foo", shape=[1, 1], datatype="BYTES", data=[b"hello world"]
             ),
         ),
         (
             ["hey", "whats"],
             True,
             ResponseOutput(
-                name="foo", shape=[2], datatype="BYTES", data=[b"hey", b"whats"]
+                name="foo", shape=[2, 1], datatype="BYTES", data=[b"hey", b"whats"]
             ),
         ),
         (
             ["hey", "whats"],
             False,
             ResponseOutput(
-                name="foo", shape=[2], datatype="BYTES", data=["hey", "whats"]
+                name="foo", shape=[2, 1], datatype="BYTES", data=["hey", "whats"]
             ),
         ),
     ],

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -41,7 +41,7 @@ from mlserver.codecs.string import StringCodec
             ResponseOutput(
                 name="bar",
                 datatype="BYTES",
-                shape=[1],
+                shape=[1, 1],
                 data=[b"asd"],
                 parameters=Parameters(content_type=StringCodec.ContentType),
             ),
@@ -50,7 +50,10 @@ from mlserver.codecs.string import StringCodec
             ["2021-02-25T12:00:00Z"],
             RequestOutput(name="bar", parameters=Parameters(content_type="datetime")),
             ResponseOutput(
-                name="bar", datatype="BYTES", shape=[1], data=[b"2021-02-25T12:00:00Z"]
+                name="bar",
+                datatype="BYTES",
+                shape=[1, 1],
+                data=[b"2021-02-25T12:00:00Z"],
             ),
         ),
         ({1, 2, 3, 4}, RequestOutput(name="bar"), None),
@@ -81,12 +84,12 @@ def test_encode_response_output(
                 model_version="v1.2.3",
                 outputs=[
                     ResponseOutput(
-                        name="a", datatype="INT64", shape=[3], data=[1, 2, 3]
+                        name="a", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
                     ),
                     ResponseOutput(
                         name="b",
                         datatype="BYTES",
-                        shape=[3],
+                        shape=[3, 1],
                         data=[b"a", b"b", b"c"],
                     ),
                 ],
@@ -113,7 +116,7 @@ def test_encode_response_output(
                     ResponseOutput(
                         name="output-1",
                         datatype="BYTES",
-                        shape=[2],
+                        shape=[2, 1],
                         data=[b"foo", b"bar"],
                         parameters=Parameters(content_type=StringCodec.ContentType),
                     ),

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -33,7 +33,9 @@ from mlserver.codecs.string import StringCodec
         (
             np.array([1, 2, 3, 4]),
             RequestOutput(name="foo"),
-            ResponseOutput(name="foo", datatype="INT64", shape=[4], data=[1, 2, 3, 4]),
+            ResponseOutput(
+                name="foo", datatype="INT64", shape=[4, 1], data=[1, 2, 3, 4]
+            ),
         ),
         (
             ["asd"],
@@ -102,7 +104,7 @@ def test_encode_response_output(
                 model_version="v1.2.3",
                 outputs=[
                     ResponseOutput(
-                        name="output-1", datatype="INT64", shape=[3], data=[1, 2, 3]
+                        name="output-1", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
                     ),
                 ],
             ),

--- a/tests/grpc/test_codecs.py
+++ b/tests/grpc/test_codecs.py
@@ -39,13 +39,13 @@ from mlserver.grpc.converters import (
                     pb.ModelInferResponse.InferOutputTensor(
                         name="a",
                         datatype="INT64",
-                        shape=[3],
+                        shape=[3, 1],
                         contents=pb.InferTensorContents(int64_contents=[1, 2, 3]),
                     ),
                     pb.ModelInferResponse.InferOutputTensor(
                         name="b",
                         datatype="BYTES",
-                        shape=[3],
+                        shape=[3, 1],
                         contents=pb.InferTensorContents(
                             bytes_contents=[b"A", b"B", b"C"]
                         ),
@@ -133,7 +133,7 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
             pb.ModelInferResponse.InferOutputTensor(
                 name="output-0",
                 datatype="BYTES",
-                shape=[3],
+                shape=[3, 1],
                 parameters={
                     "content_type": pb.InferParameter(
                         string_param=StringCodec.ContentType
@@ -150,7 +150,7 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
             pb.ModelInferResponse.InferOutputTensor(
                 name="output-0",
                 datatype="BYTES",
-                shape=[1],
+                shape=[1, 1],
                 contents=pb.InferTensorContents(
                     bytes_contents=[b"UHl0aG9uIGlzIGZ1bg=="]
                 ),

--- a/tests/grpc/test_codecs.py
+++ b/tests/grpc/test_codecs.py
@@ -113,7 +113,7 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
             pb.ModelInferResponse.InferOutputTensor(
                 name="output-0",
                 datatype="FP64",
-                shape=[1],
+                shape=[1, 1],
                 contents=pb.InferTensorContents(fp64_contents=[21.0]),
             ),
         ),

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -18,7 +18,7 @@ from mlserver.rest.responses import Response
             {
                 "name": "output-0",
                 "datatype": "FP64",
-                "shape": [1],
+                "shape": [1, 1],
                 "parameters": None,
                 "data": [21.0],
             },

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -40,7 +40,7 @@ from mlserver.rest.responses import Response
             {
                 "name": "output-0",
                 "datatype": "BYTES",
-                "shape": [3],
+                "shape": [3, 1],
                 "parameters": Parameters(content_type=StringCodec.ContentType),
                 "data": ["hey", "what's", "up"],
             },
@@ -51,7 +51,7 @@ from mlserver.rest.responses import Response
             {
                 "name": "output-0",
                 "datatype": "BYTES",
-                "shape": [1],
+                "shape": [1, 1],
                 "parameters": None,
                 "data": ["UHl0aG9uIGlzIGZ1bg=="],
             },

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -41,7 +41,7 @@ def test_pack_bytes(unpacked: List[str]):
     "tensor",
     [
         # bool
-        np.array([True, False, True]),
+        np.array([[True, False, True]]),
         # uint8
         np.array([[1, 2], [3, 4]], dtype=np.ubyte),
         # uint16


### PR DESCRIPTION
Fixes #818 

## Changelog
- To avoid room for ambiguity, where a shape is set to `[N]`, convert it to `[N, 1]` (which is MLServer's assumption). This will be switched on in some codecs (`StringCodec`, `Base64Codec`, `DatetimeCodec` and `PandasCodec`).