### PR TITLE
Allow MLflow URI with scheme

### DIFF
--- a/mlserver/utils.py
+++ b/mlserver/utils.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import asyncio
+import urllib.parse
 
 from asyncio import Task
 from typing import Callable, Dict, Optional, List, Type
@@ -12,7 +13,9 @@ from .errors import InvalidModelURI
 
 
 async def get_model_uri(
-    settings: ModelSettings, wellknown_filenames: List[str] = []
+    settings: ModelSettings,
+    wellknown_filenames: List[str] = [],
+    allowed_schemes: List[str] = [],
 ) -> str:
     if not settings.parameters:
         raise InvalidModelURI(settings.name)
@@ -20,6 +23,12 @@ async def get_model_uri(
     model_uri = settings.parameters.uri
     if not model_uri:
         raise InvalidModelURI(settings.name)
+
+    scheme = urllib.parse.urlparse(model_uri).scheme
+    if scheme != "":
+        if scheme in allowed_schemes:
+            return model_uri
+        raise InvalidModelURI(settings.name, model_uri)
 
     full_model_uri = _to_absolute_path(settings._source, model_uri)
     if os.path.isfile(full_model_uri):

--- a/runtimes/mlflow/mlserver_mlflow/runtime.py
+++ b/runtimes/mlflow/mlserver_mlflow/runtime.py
@@ -151,7 +151,10 @@ class MLflowRuntime(MLModel):
 
     async def load(self) -> bool:
         # TODO: Log info message
-        model_uri = await get_model_uri(self._settings)
+        model_uri = await get_model_uri(
+            self._settings,
+            allowed_schemes=mlflow.store.artifact.artifact_repository_registry._artifact_repository_registry._registry,
+        )
         self._model = mlflow.pyfunc.load_model(model_uri)
 
         self._input_schema = self._model.metadata.get_input_schema()

--- a/runtimes/mlflow/tests/conftest.py
+++ b/runtimes/mlflow/tests/conftest.py
@@ -97,6 +97,15 @@ def model_settings(model_uri: str) -> ModelSettings:
 
 
 @pytest.fixture
+def model_settings_scheme(model_uri: str) -> ModelSettings:
+    return ModelSettings(
+        name="mlflow-model",
+        implementation=MLflowRuntime,
+        parameters=ModelParameters(uri="file:" + model_uri),
+    )
+
+
+@pytest.fixture
 def model_settings_pytorch_fixed(pytorch_model_uri) -> ModelSettings:
     return ModelSettings(
         name="mlflow-model",
@@ -108,6 +117,14 @@ def model_settings_pytorch_fixed(pytorch_model_uri) -> ModelSettings:
 @pytest.fixture
 async def runtime(model_settings: ModelSettings) -> MLflowRuntime:
     model = MLflowRuntime(model_settings)
+    await model.load()
+
+    return model
+
+
+@pytest.fixture
+async def runtime_scheme(model_settings_scheme: ModelSettings) -> MLflowRuntime:
+    model = MLflowRuntime(model_settings_scheme)
     await model.load()
 
     return model

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -24,6 +24,12 @@ def test_load(runtime: MLflowRuntime):
     assert type(runtime._model) == PyFuncModel
 
 
+def test_load_scheme(runtime_scheme: MLflowRuntime):
+    assert runtime_scheme.ready
+
+    assert type(runtime_scheme._model) == PyFuncModel
+
+
 async def test_predict(runtime: MLflowRuntime, inference_request: InferenceRequest):
     response = await runtime.predict(inference_request)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 import platform
 
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 from unittest.mock import patch
 
 from mlserver.utils import (
@@ -18,33 +18,39 @@ from mlserver.settings import ModelSettings, ModelParameters
 
 
 @pytest.mark.parametrize(
-    "uri, source, expected",
+    "uri, source, expected, schemes",
     [
-        ("my-model.bin", None, "my-model.bin"),
+        ("my-model.bin", None, "my-model.bin", []),
         (
             "my-model.bin",
             "./my-model-folder/model-settings.json",
             "my-model-folder/my-model.bin",
+            [],
         ),
         (
             "my-model.bin",
             "./my-model-folder/../model-settings.json",
             "my-model.bin",
+            [],
         ),
         (
             "/an/absolute/path/my-model.bin",
             "/mnt/models/model-settings.json",
             "/an/absolute/path/my-model.bin",
+            [],
         ),
+        ("file:my-model.bin", None, "file:my-model.bin", ["file"]),
     ],
 )
-async def test_get_model_uri(uri: str, source: Optional[str], expected: str):
+async def test_get_model_uri(
+    uri: str, source: Optional[str], expected: str, schemes: List[str]
+):
     model_settings = ModelSettings(
         implementation=MLModel, parameters=ModelParameters(uri=uri)
     )
     model_settings._source = source
     with patch("os.path.isfile", return_value=True):
-        model_uri = await get_model_uri(model_settings)
+        model_uri = await get_model_uri(model_settings, allowed_schemes=schemes)
 
     assert model_uri == expected
 


### PR DESCRIPTION
MLflow can load [many schemes](https://github.com/mlflow/mlflow/blob/aa9366483e5e5f2fd933fe479a837d219958a1bc/mlflow/store/artifact/artifact_repository_registry.py#L78-L94). However, `get_model_uri` accepts only local file paths.

This PR enables `MLflowRuntime` to load models by URIs such as `s3://...` and `file:...`.