### PR TITLE
Fix issue with empty dimensions

### DIFF
--- a/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/explainers/black_box_runtime.py
@@ -83,4 +83,12 @@ class AlibiExplainBlackBoxRuntime(AlibiExplainRuntimeBase):
             ssl_verify_path=self.ssl_verify_path,
         )
         # TODO: do we care about more than one output?
-        return NumpyCodec.decode_output(v2_response.outputs[0])
+        decoded = NumpyCodec.decode_output(v2_response.outputs[0])
+
+        if decoded.ndim > 1 and decoded.shape[-1] == 1:
+            # Assume the response tensor is shaped as `[N, 1]` and remove the
+            # explicit dimensionality shape (which Alibi doesn't seem to like)
+            last_dim = decoded.ndim - 1
+            return decoded.squeeze(axis=last_dim)
+
+        return decoded


### PR DESCRIPTION
As a follow up to #818, Alibi doesn't seem to like model response tensors shaped as `[N, 1]` (i.e. with an explicit dimensionality shape). To work around these, process response tensors within the Alibi runtime to detect and remove these explicit empty shapes.