### PR TITLE
Add dep bounds in HF runtime

### DIFF
--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -33,13 +33,7 @@ setup(
     author_email="hello@seldon.io",
     description="HuggingFace runtime for MLServer",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=[
-        "mlserver",
-        "optimum[onnxruntime]>=1.2.3",
-        # Avoid `transformers` versions incompatible with Optimum:
-        # https://github.com/huggingface/optimum/issues/344
-        "transformers <=4.21.1, >=4.22.0",
-    ],
+    install_requires=["mlserver", "optimum[onnxruntime]>=1.4.0"],
     long_description=_load_description(),
     long_description_content_type="text/markdown",
     license="Apache 2.0",

--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -36,9 +36,9 @@ setup(
     install_requires=[
         "mlserver",
         "optimum[onnxruntime]>=1.2.3",
-        # Pin `transformers`, otherwise we risk falling into this issue:
+        # Avoid `transformers` versions incompatible with Optimum:
         # https://github.com/huggingface/optimum/issues/344
-        "transformers<=4.21.1",
+        "transformers <=4.21.1, >=4.22.0",
     ],
     long_description=_load_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
It seems like recent versions of `optimum` expect a newer version of `transformers`. Otherwise it will show the error below:

```
.tox/all-runtimes/lib/python3.9/site-packages/transformers/utils/import_utils.py:1004: in _get_module
    raise RuntimeError(
E   RuntimeError: Failed to import optimum.onnxruntime.modeling_seq2seq because of the following error (look up to see its traceback):
E   cannot import name 'TFAutoModelForSemanticSegmentation' from 'transformers.models.auto' (/home/agm/Seldon/mlserver/.tox/all-runtimes/lib/python3.9/site-packages/transformers/models/auto/__init__.py)
```