### PR TITLE
Pin setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,10 @@ COPY --from=wheel-builder /opt/mlserver/dist ./dist
 # NOTE: Temporarily excluding mllib from the main image due to:
 #   CVE-2022-25168
 #   CVE-2022-42889
+# NOTE: Pin setuptools due to breaking issue in 65.6.0
+#   https://github.com/pypa/setuptools/issues/3693
 RUN . $CONDA_PATH/etc/profile.d/conda.sh && \
-    pip install --upgrade pip wheel setuptools && \
+    pip install --upgrade pip wheel 'setuptools<65.6.0' && \
     if [[ $RUNTIMES == "all" ]]; then \
         for _wheel in "./dist/mlserver_"*.whl; do \
             if [[ ! $_wheel == *"mllib"* ]]; then \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,3 +36,7 @@ twine==4.0.1
 
 # Fetch licenses
 pip-licenses==4.0.1
+
+# Use same deps as Docker image
+setuptools<65.6.0
+


### PR DESCRIPTION
Pin setuptools in `Dockerfile` and tests to work around a breaking change in `setuptools==65.6.0` (https://github.com/pypa/setuptools/issues/3693).