### PR TITLE
Use explicit executor in Alibi runtime

### DIFF
--- a/mlserver/parallel/utils.py
+++ b/mlserver/parallel/utils.py
@@ -4,7 +4,8 @@ import multiprocessing
 from asyncio import Task
 from multiprocessing import Queue
 
-from mlserver.settings import Settings
+from ..settings import Settings
+from .logging import logger
 
 END_OF_QUEUE = None
 
@@ -19,7 +20,11 @@ def configure_inference_pool(settings: Settings):
         multiprocessing.set_start_method("spawn", force=True)
     except RuntimeError:
         # TODO: Log warning saying that mp start method couldn't be set
-        pass
+        method = multiprocessing.get_start_method()
+        logger.exception(
+            "Failed to set multiprocessing's start method. "
+            f"Current method is '{method}'"
+        )
 
 
 async def terminate_queue(queue: Queue):

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -1,10 +1,6 @@
-import asyncio
-import contextvars
-import functools
 import re
-from asyncio import AbstractEventLoop
 from importlib import import_module
-from typing import Any, Optional, Type, Callable, Awaitable, Union, List
+from typing import Any, Optional, Type, Union, List
 
 import numpy as np
 import requests

--- a/runtimes/alibi-explain/mlserver_alibi_explain/common.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/common.py
@@ -80,18 +80,6 @@ def construct_metadata_url(infer_url: str) -> str:
     return re.sub(r"/infer$", "", infer_url)
 
 
-# TODO: this is very similar to `asyncio.to_thread` (python 3.9+),
-# so lets use it at some point.
-def execute_async(
-    loop: Optional[AbstractEventLoop], fn: Callable, *args, **kwargs
-) -> Awaitable:
-    if loop is None:
-        loop = asyncio.get_running_loop()
-    ctx = contextvars.copy_context()
-    func_call = functools.partial(ctx.run, fn, *args, **kwargs)
-    return loop.run_in_executor(None, func_call)
-
-
 class AlibiExplainSettings(BaseSettings):
     """
     Parameters that apply only to alibi explain models

--- a/runtimes/alibi-explain/tests/helpers/run_async.py
+++ b/runtimes/alibi-explain/tests/helpers/run_async.py
@@ -1,6 +1,16 @@
 import asyncio
 import concurrent.futures
 
+from typing import Any
+
+# TODO: this is very similar to `asyncio.to_thread` (python 3.9+),
+# so lets use it at some point.
+async def run_sync_as_async(fn: Callable, *args, **kwargs) -> Any:
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, fn, *args, **kwargs)
+    return loop.run_in_executor(None, func_call)
+
 
 def run_async_as_sync(func, *args, **kwargs):
     def thread_func(*args, **kwargs):

--- a/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
+++ b/runtimes/alibi-explain/tests/test_alibi_runtime_base.py
@@ -20,7 +20,6 @@ from mlserver.types import (
     MetadataTensor,
 )
 from mlserver_alibi_explain.common import (
-    execute_async,
     convert_from_bytes,
     remote_predict,
     AlibiExplainSettings,
@@ -28,7 +27,7 @@ from mlserver_alibi_explain.common import (
 from mlserver_alibi_explain.runtime import AlibiExplainRuntime, AlibiExplainRuntimeBase
 from mlserver_alibi_explain.errors import InvalidExplanationShape
 
-from .helpers.run_async import run_async_as_sync
+from .helpers.run_async import run_async_as_sync, run_sync_as_async
 
 """
 Smoke tests for runtimes
@@ -117,8 +116,7 @@ async def test_remote_predict__smoke(custom_runtime_tf, rest_client):
 
         endpoint = f"v2/models/{custom_runtime_tf.settings.name}/infer"
 
-        res = await execute_async(
-            None,
+        res = await run_sync_as_async(
             remote_predict,
             inference_request,
             predictor_url=endpoint,

--- a/runtimes/alibi-explain/tests/test_black_box.py
+++ b/runtimes/alibi-explain/tests/test_black_box.py
@@ -21,12 +21,12 @@ from mlserver.types import (
 )
 from mlserver_alibi_explain import AlibiExplainRuntime
 from mlserver_alibi_explain.common import (
-    execute_async,
     convert_from_bytes,
     to_v2_inference_request,
     _DEFAULT_INPUT_NAME,
 )
 
+from .helpers.run_async import run_sync_as_async
 from .helpers.tf_model import get_tf_mnist_model_uri
 
 TESTS_PATH = Path(os.path.dirname(__file__))
@@ -63,8 +63,8 @@ async def test_predict_impl(
 
     # [batch, image_x, image_y, channel]
     data = np.random.randn(10, 28, 28, 1) * 255
-    actual_result = await execute_async(
-        None, anchor_image_runtime_with_remote_predict_patch._rt._infer_impl, data
+    actual_result = await run_sync_as_async(
+        anchor_image_runtime_with_remote_predict_patch._rt._infer_impl, data
     )
 
     # now we go via the inference model and see if we get the same results


### PR DESCRIPTION
It seems that using the default executor when calling `loop.run_in_executor` can lead to strange issues in some cases. This PR ensures that we explicitly create an executor for the Alibi runtime, which gets used instead of the default one. 