### PR TITLE
fix(codecs): do not crash when the content type is not registered

### DIFF
--- a/mlserver/codecs/base.py
+++ b/mlserver/codecs/base.py
@@ -187,8 +187,7 @@ class _CodecRegistry:
         type_hint: Optional[Type] = None,
     ) -> Optional[InputCodecLike]:
         if content_type:
-            # TODO: Raise error if codec doesn't exist
-            return self._input_codecs[content_type]
+            return self._input_codecs.get(content_type)
         elif payload:
             return self.find_input_codec_by_payload(payload)
         elif type_hint:
@@ -219,8 +218,7 @@ class _CodecRegistry:
         type_hint: Optional[Type] = None,
     ) -> Optional[RequestCodecLike]:
         if content_type:
-            # TODO: Raise error if codec doesn't exist
-            return self._request_codecs[content_type]
+            return self._request_codecs.get(content_type)
         elif payload:
             return self.find_request_codec_by_payload(payload)
         elif type_hint:

--- a/tests/codecs/test_base.py
+++ b/tests/codecs/test_base.py
@@ -40,6 +40,7 @@ def test_deprecated_methods(caplog):
     [
         ({"content_type": NumpyCodec.ContentType}, NumpyCodec),
         ({"content_type": StringCodec.ContentType}, StringCodec),
+        ({"content_type": "application/octet-stream"}, None),
         ({"type_hint": List[str]}, StringCodec),
         ({"type_hint": dict}, None),
         ({"payload": [datetime.now()]}, DatetimeCodec),
@@ -57,6 +58,7 @@ def test_find_input_codec(
     [
         ({"content_type": NumpyRequestCodec.ContentType}, NumpyRequestCodec),
         ({"content_type": StringRequestCodec.ContentType}, StringRequestCodec),
+        ({"content_type": "application/octet-stream"}, None),
         ({"type_hint": List[str]}, StringRequestCodec),
         ({"type_hint": dict}, None),
         ({"payload": ["foo"]}, StringRequestCodec),


### PR DESCRIPTION
Any unexpected input in the content_type parameter field on either input or request will crash the server otherwise and return a 500.