### PR TITLE
Add WorkerError wrapper to avoid issues pickling exceptions

### DIFF
--- a/mlserver/parallel/errors.py
+++ b/mlserver/parallel/errors.py
@@ -1,6 +1,4 @@
 from fastapi import status
-from asyncio import CancelledError
-from typing import Union
 
 from ..utils import get_import_path
 from ..errors import MLServerError
@@ -16,9 +14,11 @@ class WorkerError(MLServerError):
         https://github.com/SeldonIO/MLServer/issues/881
     """
 
-    def __init__(self, exc: Union[Exception, CancelledError]):
-        import_path = get_import_path(exc.__class__)
-        msg = f"{import_path}: {exc}"
+    def __init__(self, exc: BaseException):
+        msg = str(exc)
+        if isinstance(exc, BaseException):
+            import_path = get_import_path(exc.__class__)
+            msg = f"{import_path}: {exc}"
 
         status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         if isinstance(exc, MLServerError):

--- a/mlserver/parallel/errors.py
+++ b/mlserver/parallel/errors.py
@@ -1,0 +1,27 @@
+from fastapi import status
+from asyncio import CancelledError
+from typing import Union
+
+from ..utils import get_import_path
+from ..errors import MLServerError
+
+
+class WorkerError(MLServerError):
+    """
+    Class used to wrap exceptions raised from the workers.
+
+    All stacktrace details will be hidden, and the original class won't be
+    returned. This is to avoid issues with custom exceptions, like:
+
+        https://github.com/SeldonIO/MLServer/issues/881
+    """
+
+    def __init__(self, exc: Union[Exception, CancelledError]):
+        import_path = get_import_path(exc.__class__)
+        msg = f"{import_path}: {exc}"
+
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        if isinstance(exc, MLServerError):
+            status_code = exc.status_code
+
+        super().__init__(msg, status_code)

--- a/tests/parallel/test_errors.py
+++ b/tests/parallel/test_errors.py
@@ -1,0 +1,44 @@
+import pytest
+
+from fastapi import status
+from asyncio import CancelledError
+
+from mlserver.errors import MLServerError, ModelNotFound
+from mlserver.parallel.errors import WorkerError
+
+
+class CustomError(MLServerError):
+    def __init__(self):
+        super().__init__("foo")
+
+
+@pytest.mark.parametrize(
+    "exc, message, status_code",
+    [
+        (
+            CustomError(),
+            "tests.parallel.test_errors.CustomError: foo",
+            status.HTTP_400_BAD_REQUEST,
+        ),
+        (
+            ModelNotFound("sum-model"),
+            "mlserver.errors.ModelNotFound: Model sum-model not found",
+            status.HTTP_404_NOT_FOUND,
+        ),
+        (
+            Exception("bar"),
+            "builtins.Exception: bar",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+        (
+            CancelledError("bad error"),
+            "asyncio.exceptions.CancelledError: bad error",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    ],
+)
+def test_worker_error(exc, message, status_code):
+    err = WorkerError(exc)
+
+    assert str(err) == message
+    assert err.status_code == status_code

--- a/tests/parallel/test_model.py
+++ b/tests/parallel/test_model.py
@@ -28,7 +28,8 @@ async def test_predict_error(
     with pytest.raises(MLServerError) as excinfo:
         await error_model.predict(inference_request)
 
-    assert str(excinfo.value) == ErrorModel.error_message
+    expected_msg = f"mlserver.errors.MLServerError: {ErrorModel.error_message}"
+    assert str(excinfo.value) == expected_msg
 
 
 async def test_metadata(

--- a/tests/parallel/test_pool.py
+++ b/tests/parallel/test_pool.py
@@ -65,4 +65,5 @@ async def test_load_error(
     with pytest.raises(MLServerError) as excinfo:
         await inference_pool.load_model(load_error_model)
 
-    assert str(excinfo.value) == ErrorModel.error_message
+    expected_msg = f"mlserver.errors.MLServerError: {ErrorModel.error_message}"
+    assert str(excinfo.value) == expected_msg

--- a/tests/parallel/test_worker.py
+++ b/tests/parallel/test_worker.py
@@ -1,6 +1,7 @@
 from multiprocessing import Queue
 
 from mlserver.settings import ModelSettings
+from mlserver.parallel.errors import WorkerError
 from mlserver.parallel.worker import Worker
 from mlserver.parallel.messages import ModelUpdateMessage, ModelRequestMessage
 
@@ -112,4 +113,5 @@ async def test_exception(
     assert response.id == inference_request_message.id
     assert response.return_value is None
     assert response.exception is not None
-    assert str(response.exception) == error_msg
+    assert response.exception.__class__ == WorkerError
+    assert str(response.exception) == f"builtins.Exception: {error_msg}"


### PR DESCRIPTION
Fixes #881 

## Changelog
- Workers will now always return instances of `WorkerError`, which only contain the original error message. The stacktrace will still get printed as part of the worker logs.