### PR TITLE
do not run benchmark job on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    if: github.repository == 'SeldonIO/MLServer' # Do not run this on forks.
     strategy:
       matrix:
         scenario: ["inference-rest.js", "inference-grpc.js"]


### PR DESCRIPTION
This job often run on forks producing unnecessary noise 
![image](https://user-images.githubusercontent.com/10928117/208498342-8ba0c0b5-ce64-4878-8757-d7886ccf05fc.png)
