### PR TITLE
common batch parameters stored in a list

### DIFF
--- a/mlserver/batching/requests.py
+++ b/mlserver/batching/requests.py
@@ -45,15 +45,22 @@ def _merge_input_parameters(
             "content_type",
             "headers",
         }
-        all_params = {**all_params, **obj_params}
+        uncommon_keys = set(all_params).union(set(obj_params)) - common_keys
+        new_all_params = {}
         for key in common_keys:
             if type(all_params[key]) == list:
-                all_params[key] = all_params[key].append(obj_params[key])
+                new_value = all_params[key] + [obj_params[key]]
+                new_all_params[key] = new_value
             else:
                 new_value = [all_params[key]]
                 new_value.append(obj_params[key])
-                all_params[key] = new_value
-    return all_params
+                new_all_params[key] = new_value
+        for key in uncommon_keys:
+            if key in all_params.keys():
+                new_all_params[key] = all_params[key]
+            if key in obj_params.keys():
+                new_all_params[key] = obj_params[key]
+    return new_all_params
 
 
 def _merge_data(

--- a/mlserver/batching/requests.py
+++ b/mlserver/batching/requests.py
@@ -29,6 +29,33 @@ def _merge_parameters(
     return {**all_params, **obj_params}
 
 
+def _merge_input_parameters(
+    all_params: dict,
+    parametrised_obj: Union[
+        InferenceRequest, InferenceResponse, RequestInput, RequestOutput
+    ],
+) -> dict:
+    if not parametrised_obj.parameters:
+        return all_params
+    obj_params = parametrised_obj.parameters.dict()
+    if all_params == {}:
+        return obj_params
+    else:
+        common_keys = set(all_params).intersection(set(obj_params)) - {
+            "content_type",
+            "headers",
+        }
+        all_params = {**all_params, **obj_params}
+        for key in common_keys:
+            if type(all_params[key]) == list:
+                all_params[key] = all_params[key].append(obj_params[key])
+            else:
+                new_value = [all_params[key]]
+                new_value.append(obj_params[key])
+                all_params[key] = new_value
+    return all_params
+
+
 def _merge_data(
     all_data: Union[list, List[str], List[bytes]]
 ) -> Union[list, str, bytes]:
@@ -109,7 +136,7 @@ class BatchedRequests:
         all_data = []
         all_params: dict = {}
         for internal_id, request_input in request_inputs.items():
-            all_params = _merge_parameters(all_params, request_input)
+            all_params = _merge_input_parameters(all_params, request_input)
             all_data.append(_get_data(request_input))
             minibatch_shape = Shape(request_input.shape)
             self._minibatch_sizes[internal_id] = minibatch_shape.batch_size

--- a/tests/batching/test_requests.py
+++ b/tests/batching/test_requests.py
@@ -52,6 +52,40 @@ from mlserver.batching.requests import BatchedRequests
                 "req-1": RequestInput(
                     name="foo",
                     datatype="INT32",
+                    shape=[1, 3],
+                    data=[1, 2, 3],
+                    parameters=Parameters(content_type="np", foo="bar"),
+                ),
+                "req-2": RequestInput(
+                    name="foo",
+                    datatype="INT32",
+                    shape=[1, 3],
+                    data=[4, 5, 6],
+                ),
+                "req-3": RequestInput(
+                    name="foo",
+                    datatype="INT32",
+                    shape=[1, 3],
+                    data=[7, 8, 9],
+                    parameters=Parameters(foo="bar", time="13:00"),
+                ),
+            },
+            RequestInput(
+                name="foo",
+                datatype="INT32",
+                shape=[3, 3],
+                data=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+                parameters=Parameters(
+                    content_type="np", foo=["bar", "bar"], time="13:00"
+                ),
+            ),
+            {"req-1": 1, "req-2": 1, "req-3": 1},
+        ),
+        (
+            {
+                "req-1": RequestInput(
+                    name="foo",
+                    datatype="INT32",
                     shape=[2, 3],
                     data=[1, 2, 3, 10, 11, 12],
                 ),


### PR DESCRIPTION
fixes #915

aggregate batch requests of:
```python
# request 1
payload = types.InferenceRequest(
    inputs=[
        types.RequestInput(
            name="parameters-np",
            shape=[1],
            datatype="BYTES",
            data=[],
            parameters=types.Parameters(
                custom-param='value-1,
        )
    ]
)
# request 2
payload = types.InferenceRequest(
    inputs=[
        types.RequestInput(
            name="parameters-np",
            shape=[1],
            datatype="BYTES",
            data=[],
            parameters=types.Parameters(
                custom-param='value-2',
        )
    ]
)
```
as follows:
`{custom-param=['value-1', 'value-2']`
instead of overwriting the `value-1` with `value-2`

