### PR TITLE
bugfix, set a default image format when Pillow image has no format

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/codecs/base.py
+++ b/runtimes/huggingface/mlserver_huggingface/codecs/base.py
@@ -66,9 +66,10 @@ class MultiInputRequestCodec(RequestCodec):
     ) -> Dict[str, Union[Type[InputCodecTy], InputCodecTy, None]]:
         field_codec = {}
         fields = []  # type: ignore
-        if data.parameters:
+        default_codec = None
+        if data.parameters and data.parameters.content_type:
             default_codec = find_input_codec(data.parameters.content_type)
-        else:
+        if default_codec is None:
             default_codec = cls.DefaultCodec
         if isinstance(data, InferenceRequest):
             fields = data.inputs

--- a/runtimes/huggingface/mlserver_huggingface/codecs/base.py
+++ b/runtimes/huggingface/mlserver_huggingface/codecs/base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, Any, Dict, List, Union
+from typing import Optional, Type, Any, Dict, List, Union, Sequence
 from mlserver.codecs.utils import (
     has_decoded,
     _save_decoded,
@@ -19,6 +19,7 @@ from mlserver.types import (
     InferenceRequest,
     InferenceResponse,
     RequestInput,
+    ResponseOutput,
 )
 from .image import PILImageCodec
 from .json import HuggingfaceSingleJSONCodec
@@ -64,9 +65,9 @@ class MultiInputRequestCodec(RequestCodec):
     def _find_decode_codecs(
         cls, data: Union[InferenceResponse, InferenceRequest]
     ) -> Dict[str, Union[Type[InputCodecTy], InputCodecTy, None]]:
-        field_codec = {}
-        fields = []  # type: ignore
-        default_codec = None
+        field_codec: Dict[str, Union[Type[InputCodecTy], InputCodecTy, None]] = {}
+        default_codec: Union[Type[InputCodecTy], InputCodecTy, None] = None
+        fields: Sequence[Union[RequestInput, ResponseOutput]] = []
         if data.parameters and data.parameters.content_type:
             default_codec = find_input_codec(data.parameters.content_type)
         if default_codec is None:

--- a/runtimes/huggingface/mlserver_huggingface/codecs/utils.py
+++ b/runtimes/huggingface/mlserver_huggingface/codecs/utils.py
@@ -7,6 +7,7 @@ from PIL import Image, ImageChops
 from transformers.pipelines import Conversation
 
 IMAGE_PREFIX = "data:image/"
+DEFAULT_IMAGE_FORMAT = "PNG"
 
 
 class HuggingfaceJSONEncoder(json.JSONEncoder):
@@ -19,10 +20,12 @@ class HuggingfaceJSONEncoder(json.JSONEncoder):
             return int(obj)
         elif isinstance(obj, Image.Image):
             buf = io.BytesIO()
+            if not obj.format:
+                obj.format = DEFAULT_IMAGE_FORMAT
             obj.save(buf, format=obj.format)
             return (
                 IMAGE_PREFIX
-                + obj.format
+                + obj.format.lower()
                 + ";base64,"
                 + base64.b64encode(buf.getvalue()).decode()
             )

--- a/runtimes/huggingface/tests/test_codecs/test_base.py
+++ b/runtimes/huggingface/tests/test_codecs/test_base.py
@@ -349,8 +349,8 @@ from ..utils import (
 )
 def test_encode_request(inputs, use_bytes, expected):
     payload = HuggingfaceRequestCodec.encode_request(inputs, use_bytes=use_bytes)
-    print(payload.inputs[0].data[0])
-    print(expected.inputs[0].data[0])
+    # print(payload.inputs[0].data[0])
+    # print(expected.inputs[0].data[0])
     assert payload == expected
 
 

--- a/runtimes/huggingface/tests/utils.py
+++ b/runtimes/huggingface/tests/utils.py
@@ -36,7 +36,7 @@ def image_base64_bytes(fname: str) -> bytes:
     buf = io.BytesIO()
     img.save(buf, format=img.format)
     v = base64.b64encode(buf.getvalue())
-    return f"data:image/{img.format};base64,".encode() + v
+    return f"data:image/{img.format.lower()};base64,".encode() + v
 
 
 def image_base64_str(fname: str) -> str:


### PR DESCRIPTION
1. Error happend when a run a `image-segmantation` task. The Pillow Image pipeline output has not format. So add a default one
2. If client give a invalid content_type, the default_codec may be None, caused runtime error