### PR TITLE
support huggingface translation task suffix

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -38,6 +38,9 @@ class HuggingFaceSettings(BaseSettings):
         env_prefix = ENV_PREFIX_HUGGINGFACE_SETTINGS
 
     task: str = ""
+    # Why need this filed?
+    # for translation task, required a suffix to specify source and target
+    # related issue: https://github.com/SeldonIO/MLServer/issues/947
     task_suffix: str = ""
     pretrained_model: Optional[str] = None
     pretrained_tokenizer: Optional[str] = None
@@ -47,7 +50,9 @@ class HuggingFaceSettings(BaseSettings):
 
     @property
     def task_name(self):
-        return f"{self.task}{self.task_suffix}"
+        if self.task == "translation":
+            return f"{self.task}{self.task_suffix}"
+        return self.task
 
 
 def parse_parameters_from_env() -> Dict:

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -38,11 +38,16 @@ class HuggingFaceSettings(BaseSettings):
         env_prefix = ENV_PREFIX_HUGGINGFACE_SETTINGS
 
     task: str = ""
+    task_suffix: str = ""
     pretrained_model: Optional[str] = None
     pretrained_tokenizer: Optional[str] = None
     optimum_model: bool = False
     device: int = -1
     batch_size: Optional[int] = None
+
+    @property
+    def task_name(self):
+        return f"{self.task}{self.task_suffix}"
 
 
 def parse_parameters_from_env() -> Dict:
@@ -114,7 +119,7 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         device = -1
 
     pp = pipeline(
-        hf_settings.task,
+        hf_settings.task_name,
         model=model,
         tokenizer=tokenizer,
         device=device,

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -65,7 +65,7 @@ class HuggingFaceRuntime(MLModel):
     async def load(self) -> bool:
         # Loading & caching pipeline in asyncio loop to avoid blocking
         print("=" * 80)
-        print(self.hf_settings.task)
+        print(self.hf_settings.task_name)
         print("loading model...")
         await asyncio.get_running_loop().run_in_executor(
             None, load_pipeline_from_settings, self.hf_settings

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -1,0 +1,18 @@
+import pytest
+from typing import Dict
+from mlserver_huggingface.common import HuggingFaceSettings
+
+
+@pytest.mark.parametrize(
+    "envs, expected",
+    [
+        ({"task": "translation", "task_suffix": "_en_to_fr"}, "translation_en_to_fr"),
+        (
+            {"task": "question-answering", "task_suffix": "_any_thing_else"},
+            "question-answering",
+        ),
+    ],
+)
+def test_settings_task_name(envs: Dict[str, str], expected: str):
+    setting = HuggingFaceSettings(**envs)
+    assert setting.task_name == expected


### PR DESCRIPTION
Fixes #947

When I run huggingface task translation, got this `raise ValueError('The task defaults can\'t be correctly selected. You probably meant "translation_XX_to_YY"')`

So, I add a new setting item in HuggingfaceSetting, to support task name suffix.

