### PR TITLE
fixing FastAPI incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "click",
-        "fastapi",
+        "fastapi<=0.88.0",
         "python-dotenv",
         "grpcio",
         "importlib-metadata;python_version<'3.8'",


### PR DESCRIPTION
Fixing MLServer blocking incompatibility with the recent update of FastAPI https://github.com/tiangolo/fastapi/releases/tag/0.89.0