### PR TITLE
Bump FastAPI to 0.89.1 (keeping the ceiling)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "click",
-        "fastapi<=0.88.0",
+        # 0.89.0: https://github.com/tiangolo/fastapi/issues/5861
+        "fastapi<=0.89.1, !=0.89.0",
         "python-dotenv",
         "grpcio",
         "importlib-metadata;python_version<'3.8'",


### PR DESCRIPTION
Fixes #935

FastAPI `0.89.0` introduced a breaking issue, which is now fixed in `0.89.1` (see https://github.com/tiangolo/fastapi/issues/5861). 

This PR bumps the ceiling to `0.89.1`, skipping the `0.89.0` release. 