### PR TITLE
Only convert pd.DataFrame to numpy array in alibi-explain

### DIFF
--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -4,6 +4,8 @@ import numpy as np
 import functools
 
 from typing import Any, Optional, List, Dict
+
+import pandas as pd
 from alibi.api.interfaces import Explanation, Explainer
 from alibi.saving import load_explainer
 from concurrent.futures import ThreadPoolExecutor
@@ -86,8 +88,10 @@ class AlibiExplainRuntimeBase(MLModel):
 
         # TODO: convert and validate?
         input_data = self.decode_request(payload, default_codec=NumpyRequestCodec)
+        if isinstance(input_data, pd.DataFrame):
+            input_data = np.array(input_data)
         output_data = await self._async_explain_impl(
-            np.array(input_data), payload.parameters
+            input_data, payload.parameters
         )
 
         return InferenceResponse(

--- a/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
+++ b/runtimes/alibi-explain/mlserver_alibi_explain/runtime.py
@@ -90,9 +90,7 @@ class AlibiExplainRuntimeBase(MLModel):
         input_data = self.decode_request(payload, default_codec=NumpyRequestCodec)
         if isinstance(input_data, pd.DataFrame):
             input_data = np.array(input_data)
-        output_data = await self._async_explain_impl(
-            input_data, payload.parameters
-        )
+        output_data = await self._async_explain_impl(input_data, payload.parameters)
 
         return InferenceResponse(
             model_name=self.name,


### PR DESCRIPTION
Currently we have been converting all inputs to numpy before passing them to alibi `explain` method. This is not true in the case of `AnchorText` as it expects an `str`, check [here](https://docs.seldon.io/projects/alibi/en/latest/api/alibi.explainers.html#alibi.explainers.AnchorText.explain).

Although we should be perhaps more strict in the way we do the conversions between types but for now we know we want to convert pd.DataFrame to numpy which we do explicitly. 