### PR TITLE
fix(logging): switch eventloop log to debug

### DIFF
--- a/mlserver/utils.py
+++ b/mlserver/utils.py
@@ -126,7 +126,7 @@ def install_uvloop_event_loop():
 
     policy = _check_current_event_loop_policy()
 
-    logger.info(f"Using asyncio event-loop policy: {policy}")
+    logger.debug(f"Using asyncio event-loop policy: {policy}")
 
 
 def schedule_with_callback(coro, cb) -> Task:


### PR DESCRIPTION
This log statement is executed before the logging settings are applied and can trip up systems that don't expect logs to be formatted differently.