### PR TITLE
Add support for Prometheus metrics across multiple processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 *.pyc
 bin
+*.db
 
 # Mac file system
 **/.DS_Store

--- a/mlserver/handlers/dataplane.py
+++ b/mlserver/handlers/dataplane.py
@@ -16,21 +16,6 @@ from prometheus_client import (
 from typing import Optional
 
 
-_ModelInferRequestSuccess = Counter(
-    "model_infer_request_success",
-    "Model infer request success count",
-    ["model", "version"],
-)
-_ModelInferRequestFailure = Counter(
-    "model_infer_request_failure",
-    "Model infer request failure count",
-    ["model", "version"],
-)
-_ModelInferRequestDuration = Summary(
-    "model_infer_request_duration", "Model infer request duration", ["model", "version"]
-)
-
-
 class DataPlane:
     """
     Internal implementation of handlers, used by both the gRPC and REST
@@ -43,6 +28,22 @@ class DataPlane:
 
         self._inference_middleware = InferenceMiddlewares(
             CloudEventsMiddleware(settings)
+        )
+
+        self._ModelInferRequestSuccess = Counter(
+            "model_infer_request_success",
+            "Model infer request success count",
+            ["model", "version"],
+        )
+        self._ModelInferRequestFailure = Counter(
+            "model_infer_request_failure",
+            "Model infer request failure count",
+            ["model", "version"],
+        )
+        self._ModelInferRequestDuration = Summary(
+            "model_infer_request_duration",
+            "Model infer request duration",
+            ["model", "version"],
         )
 
     async def live(self) -> bool:
@@ -77,12 +78,14 @@ class DataPlane:
         version: Optional[str] = None,
     ) -> InferenceResponse:
 
-        with _ModelInferRequestDuration.labels(
+        infer_duration = self._ModelInferRequestDuration.labels(
             model=name, version=version
-        ).time(), _ModelInferRequestFailure.labels(
+        ).time()
+        infer_errors = self._ModelInferRequestFailure.labels(
             model=name, version=version
-        ).count_exceptions():
+        ).count_exceptions()
 
+        with infer_duration, infer_errors:
             if payload.id is None:
                 payload.id = generate_uuid()
 
@@ -98,6 +101,6 @@ class DataPlane:
 
             self._inference_middleware.response_middleware(prediction, model.settings)
 
-            _ModelInferRequestSuccess.labels(model=name, version=version).inc()
+            self._ModelInferRequestSuccess.labels(model=name, version=version).inc()
 
             return prediction

--- a/mlserver/metrics/__init__.py
+++ b/mlserver/metrics/__init__.py
@@ -1,4 +1,4 @@
 from .server import MetricsServer
-from .prometheus import configure_metrics, stop_metrics
+from .prometheus import configure_metrics
 
-__all__ = ["MetricsServer", "configure_metrics", "stop_metrics"]
+__all__ = ["MetricsServer", "configure_metrics"]

--- a/mlserver/metrics/__init__.py
+++ b/mlserver/metrics/__init__.py
@@ -1,4 +1,4 @@
 from .server import MetricsServer
-from .prometheus import configure_metrics
+from .prometheus import configure_metrics, stop_metrics
 
-__all__ = ["MetricsServer", "configure_metrics"]
+__all__ = ["MetricsServer", "configure_metrics", "stop_metrics"]

--- a/mlserver/metrics/__init__.py
+++ b/mlserver/metrics/__init__.py
@@ -1,3 +1,4 @@
 from .server import MetricsServer
+from .prometheus import configure_metrics
 
-__all__ = ["MetricsServer"]
+__all__ = ["MetricsServer", "configure_metrics"]

--- a/mlserver/metrics/prometheus.py
+++ b/mlserver/metrics/prometheus.py
@@ -7,7 +7,7 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
     values,
 )
-from prometheus_client.multiprocess import MultiProcessCollector
+from prometheus_client.multiprocess import MultiProcessCollector, mark_process_dead
 from fastapi import Request, Response, status
 
 from ..settings import Settings
@@ -25,6 +25,10 @@ def configure_metrics(settings: Settings):
     # https://github.com/prometheus/client_python/blob/781e3e1851d80a53732bb8102d5754cf9d68b3c1/prometheus_client/values.py#L126-L134
     os.environ[PROMETHEUS_MULTIPROC_DIR] = settings.metrics_dir
     values.ValueClass = values.get_value_class()
+
+
+async def stop_metrics(worker: "mlserver.parallel.Worker"):
+    mark_process_dead(worker.pid)
 
 
 class PrometheusEndpoint:

--- a/mlserver/metrics/prometheus.py
+++ b/mlserver/metrics/prometheus.py
@@ -1,19 +1,51 @@
 import os
 
-from prometheus_client import REGISTRY, CollectorRegistry
+from prometheus_client import (
+    REGISTRY,
+    CollectorRegistry,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+    values,
+)
 from prometheus_client.multiprocess import MultiProcessCollector
+from fastapi import Request, Response, status
 
 from ..settings import Settings
 
+PROMETHEUS_MULTIPROC_DIR = "PROMETHEUS_MULTIPROC_DIR"
 
-def get_registry(settings: Settings) -> CollectorRegistry:
+
+def configure_metrics(settings: Settings):
     if not settings.parallel_workers:
-        return REGISTRY
+        return
 
-    if not settings.metrics_dir:
-        settings.metrics_dir = os.getcwd()
+    # Re-set Prometheus' Value class to use the multiproc version.
+    # Note that this workaround depends on initialising all metrics in a
+    # lazy manner (i.e. not as global values)
+    # https://github.com/prometheus/client_python/blob/781e3e1851d80a53732bb8102d5754cf9d68b3c1/prometheus_client/values.py#L126-L134
+    os.environ[PROMETHEUS_MULTIPROC_DIR] = settings.metrics_dir
+    values.ValueClass = values.get_value_class()
 
-    registry = CollectorRegistry()
-    MultiProcessCollector(registry, path=settings.metrics_dir)
 
-    return registry
+class PrometheusEndpoint:
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        configure_metrics(self._settings)
+
+    @property
+    def _registry(self) -> CollectorRegistry:
+        if not self._settings.parallel_workers:
+            return REGISTRY
+
+        registry = CollectorRegistry()
+        MultiProcessCollector(registry)
+
+        return registry
+
+    def handle_metrics(self, req: Request) -> Response:
+        headers = {"Content-Type": CONTENT_TYPE_LATEST}
+        return Response(
+            generate_latest(self._registry),
+            status_code=status.HTTP_200_OK,
+            headers=headers,
+        )

--- a/mlserver/metrics/prometheus.py
+++ b/mlserver/metrics/prometheus.py
@@ -1,0 +1,19 @@
+import os
+
+from prometheus_client import REGISTRY, CollectorRegistry
+from prometheus_client.multiprocess import MultiProcessCollector
+
+from ..settings import Settings
+
+
+def get_registry(settings: Settings) -> CollectorRegistry:
+    if not settings.parallel_workers:
+        return REGISTRY
+
+    if not settings.metrics_dir:
+        settings.metrics_dir = os.getcwd()
+
+    registry = CollectorRegistry()
+    MultiProcessCollector(registry, path=settings.metrics_dir)
+
+    return registry

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -1,4 +1,5 @@
 import uvicorn
+import os
 
 from typing import Optional
 
@@ -62,4 +63,5 @@ class MetricsServer:
         return uvicorn.Config(self._app, **kwargs)
 
     async def stop(self, sig: Optional[int] = None):
+        mark_process_dead(os.getpid())
         self._server.handle_exit(sig=sig, frame=None)

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -3,11 +3,10 @@ import uvicorn
 from typing import Optional
 
 from fastapi import FastAPI
-from starlette_exporter import handle_metrics
 
 from ..settings import Settings
 from .logging import logger
-from .prometheus import get_registry
+from .prometheus import PrometheusEndpoint
 
 
 class _NoSignalServer(uvicorn.Server):
@@ -18,12 +17,12 @@ class _NoSignalServer(uvicorn.Server):
 class MetricsServer:
     def __init__(self, settings: Settings):
         self._settings = settings
+        self._endpoint = PrometheusEndpoint(settings)
         self._app = self._get_app()
-        self._registry = get_registry(settings)
 
     def _get_app(self):
         app = FastAPI(debug=self._settings.debug)
-        app.add_route(self._settings.metrics_endpoint, handle_metrics)
+        app.add_route(self._settings.metrics_endpoint, self._endpoint.handle_metrics)
         return app
 
     async def start(self):

--- a/mlserver/metrics/server.py
+++ b/mlserver/metrics/server.py
@@ -1,11 +1,13 @@
 import uvicorn
 
+from typing import Optional
+
 from fastapi import FastAPI
 from starlette_exporter import handle_metrics
 
 from ..settings import Settings
 from .logging import logger
-from typing import Optional
+from .prometheus import get_registry
 
 
 class _NoSignalServer(uvicorn.Server):
@@ -17,6 +19,7 @@ class MetricsServer:
     def __init__(self, settings: Settings):
         self._settings = settings
         self._app = self._get_app()
+        self._registry = get_registry(settings)
 
     def _get_app(self):
         app = FastAPI(debug=self._settings.debug)

--- a/mlserver/parallel/__init__.py
+++ b/mlserver/parallel/__init__.py
@@ -1,4 +1,5 @@
 from .pool import InferencePool
 from .utils import configure_inference_pool
+from .worker import Worker
 
-__all__ = ["InferencePool", "configure_inference_pool"]
+__all__ = ["InferencePool", "configure_inference_pool", "Worker"]

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from multiprocessing import Queue
-from typing import Any, Awaitable, Coroutine, Callable, Dict, List
+from typing import Awaitable, Callable, Dict, List
 
 from ..model import MLModel
 from ..types import InferenceRequest, InferenceResponse

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -1,5 +1,7 @@
+import asyncio
+
 from multiprocessing import Queue
-from typing import Any, Coroutine, Callable, Dict
+from typing import Any, Awaitable, Coroutine, Callable, Dict, List
 
 from ..model import MLModel
 from ..types import InferenceRequest, InferenceResponse
@@ -17,7 +19,8 @@ from .logging import logger
 from .dispatcher import Dispatcher
 
 
-PredictMethod = Callable[[InferenceRequest], Coroutine[Any, Any, InferenceResponse]]
+PredictMethod = Callable[[InferenceRequest], Awaitable[InferenceResponse]]
+InferencePoolHook = Callable[[Worker], Awaitable[None]]
 
 
 class InferencePool:
@@ -31,9 +34,13 @@ class InferencePool:
     can occur in parallel across multiple models or instances of a model.
     """
 
-    def __init__(self, settings: Settings):
+    def __init__(
+        self, settings: Settings, on_worker_stop: List[InferencePoolHook] = []
+    ):
         configure_inference_pool(settings)
 
+        # TODO: Hook on_worker_stop to "worker unexpectedly died" event
+        self._on_worker_stop = on_worker_stop
         self._workers: Dict[int, Worker] = {}
         self._settings = settings
         self._responses: Queue[ModelResponseMessage] = Queue()
@@ -120,5 +127,8 @@ class InferencePool:
             worker.join(self._settings.parallel_workers_timeout)
             if worker.exitcode is None:
                 worker.kill()
+            await asyncio.gather(
+                *[callback(worker) for callback in self._on_worker_stop]
+            )
 
         self._workers.clear()

--- a/mlserver/parallel/worker.py
+++ b/mlserver/parallel/worker.py
@@ -10,6 +10,7 @@ from ..registry import MultiModelRegistry
 from ..utils import install_uvloop_event_loop, schedule_with_callback
 from ..logging import configure_logger
 from ..settings import Settings
+from ..metrics import configure_metrics
 
 from .messages import (
     ModelRequestMessage,
@@ -53,6 +54,7 @@ class Worker(Process):
     def run(self):
         install_uvloop_event_loop()
         configure_logger(self._settings)
+        configure_metrics(self._settings)
         self._ignore_signals()
         asyncio.run(self.coro_run())
 

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -83,6 +83,12 @@ class MLServer:
         self._logger = configure_logger(self._settings)
 
     def _create_servers(self):
+        # NOTE: Metrics server needs to be created first, to initialise the
+        # multiprocess collector (if needed)
+        self._metrics_server = None
+        if self._settings.metrics_endpoint:
+            self._metrics_server = MetricsServer(self._settings)
+
         self._rest_server = RESTServer(
             self._settings, self._data_plane, self._model_repository_handlers
         )
@@ -93,10 +99,6 @@ class MLServer:
         self._kafka_server = None
         if self._settings.kafka_enabled:
             self._kafka_server = KafkaServer(self._settings, self._data_plane)
-
-        self._metrics_server = None
-        if self._settings.metrics_endpoint:
-            self._metrics_server = MetricsServer(self._settings)
 
     async def start(self, models_settings: List[ModelSettings] = []):
         servers = [self._rest_server.start(), self._grpc_server.start()]

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -15,7 +15,7 @@ from .parallel import InferencePool
 from .batching import load_batching
 from .rest import RESTServer
 from .grpc import GRPCServer
-from .metrics import MetricsServer
+from .metrics import MetricsServer, stop_metrics
 from .kafka import KafkaServer
 from .utils import logger
 
@@ -30,7 +30,9 @@ class MLServer:
         self._inference_pool = None
         if self._settings.parallel_workers:
             # Only load inference pool if parallel inference has been enabled
-            self._inference_pool = InferencePool(self._settings)
+            self._inference_pool = InferencePool(
+                self._settings, on_worker_stop=[stop_metrics]
+            )
 
         self._model_registry = self._create_model_registry()
         self._model_repository = ModelRepositoryFactory.resolve_model_repository(

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -39,7 +39,7 @@ class MLServer:
                 on_worker_stop = [self._metrics_server.on_worker_stop]
 
             self._inference_pool = InferencePool(
-                self._settings, on_worker_stop=on_worker_stop
+                self._settings, on_worker_stop=on_worker_stop  # type: ignore
             )
 
         self._model_registry = self._create_model_registry()

--- a/mlserver/server.py
+++ b/mlserver/server.py
@@ -80,7 +80,7 @@ class MLServer:
         if self._settings.debug:
             logger.setLevel(logging.DEBUG)
 
-        self._logger = configure_logger(settings)
+        self._logger = configure_logger(self._settings)
 
     def _create_servers(self):
         self._rest_server = RESTServer(

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -148,6 +148,14 @@ class Settings(BaseSettings):
     Metrics rest server string prefix to be exported.
     """
 
+    metrics_dir: Optional[str] = None
+    """
+    Directory used to share metrics across parallel workers.
+    Equivalent to the `PROMETHEUS_MULTIPROC_DIR` env var in
+    `prometheus-client`.
+    Note that this won't be used if the `parallel_workers` flag is disabled.
+    """
+
     # Logging settings
     logging_settings: Optional[Union[str, Dict]] = None
     """Path to logging config file or dictionary configuration."""

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -148,7 +148,7 @@ class Settings(BaseSettings):
     Metrics rest server string prefix to be exported.
     """
 
-    metrics_dir: Optional[str] = None
+    metrics_dir: str = os.getcwd()
     """
     Directory used to share metrics across parallel workers.
     Equivalent to the `PROMETHEUS_MULTIPROC_DIR` env var in

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 import asyncio
+import glob
+import os
 
 from mlserver.server import MLServer
 from mlserver.settings import Settings, ModelSettings
@@ -42,6 +44,10 @@ async def mlserver(
 
     await server.stop()
     await server_task
+
+    pattern = os.path.join(settings.metrics_dir, "*.db")
+    prom_files = glob.glob(pattern)
+    assert not prom_files
 
 
 @pytest.fixture

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -15,11 +15,12 @@ def prometheus_endpoint(settings: Settings) -> PrometheusEndpoint:
 
 
 @pytest.fixture
-def settings(settings: Settings) -> Settings:
+def settings(settings: Settings, tmp_path: str) -> Settings:
     http_port, grpc_port, metrics_port = get_available_ports(3)
     settings.http_port = http_port
     settings.grpc_port = grpc_port
     settings.metrics_port = metrics_port
+    settings.metrics_dir = str(tmp_path)
 
     return settings
 

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -3,9 +3,15 @@ import asyncio
 
 from mlserver.server import MLServer
 from mlserver.settings import Settings, ModelSettings
+from mlserver.metrics.prometheus import PrometheusEndpoint
 
 from ..utils import RESTClient, get_available_ports
 from .utils import MetricsClient
+
+
+@pytest.fixture
+def prometheus_endpoint(settings: Settings) -> PrometheusEndpoint:
+    return PrometheusEndpoint(settings)
 
 
 @pytest.fixture

--- a/tests/metrics/test_custom.py
+++ b/tests/metrics/test_custom.py
@@ -1,7 +1,6 @@
 import pytest
 import asyncio
 import os
-import glob
 
 from aiofiles.os import path
 from prometheus_client import Counter

--- a/tests/metrics/test_custom.py
+++ b/tests/metrics/test_custom.py
@@ -1,0 +1,76 @@
+import pytest
+import asyncio
+import os
+import glob
+
+from aiofiles.os import path
+from prometheus_client import Counter
+
+from mlserver.server import MLServer
+from mlserver.model import MLModel
+from mlserver.settings import ModelSettings
+from mlserver.types import InferenceRequest, InferenceResponse
+
+from ..utils import RESTClient
+from .utils import MetricsClient, find_metric
+
+COUNTER_NAME = "my_custom_counter"
+
+
+class CustomMetricsModel(MLModel):
+    async def load(self) -> bool:
+        self.counter = Counter(COUNTER_NAME, "Test custom counter")
+        self.ready = True
+        return self.ready
+
+    async def predict(self, req: InferenceRequest) -> InferenceResponse:
+        self.counter.inc()
+        return InferenceResponse(model_name=self.name, outputs=[])
+
+
+@pytest.fixture
+async def custom_metrics_model(mlserver: MLServer) -> MLModel:
+    model_settings = ModelSettings(
+        name="custom-metrics-model", implementation=CustomMetricsModel
+    )
+    return await mlserver._model_registry.load(model_settings)
+
+
+async def test_db_files(
+    custom_metrics_model: MLModel, rest_client: RESTClient, mlserver: MLServer
+):
+    await rest_client.wait_until_ready()
+
+    assert mlserver._settings.parallel_workers > 0
+    for pid in mlserver._inference_pool._workers:
+        db_file = os.path.join(mlserver._settings.metrics_dir, f"counter_{pid}.db")
+        assert await path.isfile(db_file)
+
+
+async def test_custom_metrics(
+    custom_metrics_model: MLModel,
+    inference_request: InferenceRequest,
+    metrics_client: MetricsClient,
+    rest_client: RESTClient,
+):
+    await rest_client.wait_until_ready()
+
+    metrics = await metrics_client.metrics()
+    custom_counter = find_metric(metrics, COUNTER_NAME)
+    assert custom_counter is not None
+    assert len(custom_counter.samples) == 1
+    assert custom_counter.samples[0].value == 0
+
+    expected_value = 5
+    await asyncio.gather(
+        *[
+            rest_client.infer(custom_metrics_model.name, inference_request)
+            for _ in range(expected_value)
+        ]
+    )
+
+    metrics = await metrics_client.metrics()
+    custom_counter = find_metric(metrics, COUNTER_NAME)
+    assert custom_counter is not None
+    assert len(custom_counter.samples) == 1
+    assert custom_counter.samples[0].value == expected_value

--- a/tests/metrics/test_grpc.py
+++ b/tests/metrics/test_grpc.py
@@ -35,8 +35,7 @@ async def test_grpc_metrics(
     # Get metrics for gRPC server before sending any requests
     metrics = await metrics_client.metrics()
     grpc_server_handled = find_metric(metrics, metric_name)
-    assert grpc_server_handled is not None
-    assert len(grpc_server_handled.samples) == 0
+    assert grpc_server_handled is None
 
     expected_handled = 5
     await asyncio.gather(

--- a/tests/metrics/test_prometheus.py
+++ b/tests/metrics/test_prometheus.py
@@ -1,0 +1,22 @@
+from prometheus_client import REGISTRY
+from prometheus_client.multiprocess import MultiProcessCollector
+
+from mlserver.settings import Settings
+
+from mlserver.metrics.prometheus import get_registry
+
+
+def test_get_registry(settings: Settings):
+    registry = get_registry(settings)
+    collectors = [c for c in registry._collector_to_names.keys()]
+
+    assert len(collectors) == 1
+    assert isinstance(collectors[0], MultiProcessCollector)
+    assert collectors[0]._path == settings.metrics_dir
+
+
+def test_get_registry_no_parallel(settings: Settings):
+    settings.parallel_workers = 0
+    registry = get_registry(settings)
+
+    assert registry == REGISTRY

--- a/tests/metrics/test_prometheus.py
+++ b/tests/metrics/test_prometheus.py
@@ -3,12 +3,11 @@ from prometheus_client.multiprocess import MultiProcessCollector
 
 from mlserver.settings import Settings
 
-from mlserver.metrics.prometheus import get_registry
+from mlserver.metrics.prometheus import PrometheusEndpoint
 
 
-def test_get_registry(settings: Settings):
-    registry = get_registry(settings)
-    collectors = [c for c in registry._collector_to_names.keys()]
+def test_get_registry(prometheus_endpoint: PrometheusEndpoint, settings: Settings):
+    collectors = [c for c in prometheus_endpoint._registry._collector_to_names.keys()]
 
     assert len(collectors) == 1
     assert isinstance(collectors[0], MultiProcessCollector)
@@ -17,6 +16,6 @@ def test_get_registry(settings: Settings):
 
 def test_get_registry_no_parallel(settings: Settings):
     settings.parallel_workers = 0
-    registry = get_registry(settings)
+    endpoint = PrometheusEndpoint(settings)
 
-    assert registry == REGISTRY
+    assert endpoint._registry == REGISTRY

--- a/tests/metrics/test_rest.py
+++ b/tests/metrics/test_rest.py
@@ -1,10 +1,7 @@
-import pytest
 import asyncio
 
 from mlserver.model import MLModel
 from mlserver.types import InferenceRequest
-from mlserver.server import MLServer
-from mlserver.settings import Settings
 
 from ..utils import RESTClient
 from .utils import MetricsClient, find_metric
@@ -19,7 +16,7 @@ async def test_rest_metrics(
     await rest_client.wait_until_ready()
     metric_name = "rest_server_requests"
 
-    # Get metrics for gRPC server before sending any requests
+    # Get metrics for REST server before sending any requests
     metrics = await metrics_client.metrics()
     rest_server_requests = find_metric(metrics, metric_name)
     assert rest_server_requests is None

--- a/tests/metrics/test_rest.py
+++ b/tests/metrics/test_rest.py
@@ -10,12 +10,6 @@ from ..utils import RESTClient
 from .utils import MetricsClient, find_metric
 
 
-@pytest.fixture
-async def rest_client(mlserver: MLServer, settings: Settings):
-    http_server = f"{settings.host}:{settings.http_port}"
-    return RESTClient(http_server)
-
-
 async def test_rest_metrics(
     metrics_client: MetricsClient,
     rest_client: RESTClient,


### PR DESCRIPTION
Part of #303 

## Notes

Note that this work just enables the collection of metrics across multiple workers, which lets users define Prometheus metrics directly on their custom runtimes. However, we may still introduce a simplified way to register metrics within the MLServer package itself (e.g. `self.metrics.register('foo', 1)`) - which is why this PR doesn't close #303 (and also why there is no docs update in this PR). 

## Changelog
- Enable Prom's multiprocess mode when `parallel_workers > 0`, adding a new `metrics_dir` setting.
- Clean up `*.db` files during shutdown.
- Add tests around manual set up of custom metrics in custom runtimes.