### PR TITLE
Force patch for CVE-2022-1941

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,10 +81,12 @@ commands =
 
 [testenv:huggingface]
 deps =
-  -e{toxinidir}
   -e{toxinidir}/runtimes/huggingface
   -r{toxinidir}/requirements/dev.txt
 commands =
+  # Avoid conflicts and ensure `protobuf==3.20.3` is used (CVE-2022-1941)
+  # https://github.com/huggingface/optimum/issues/733
+  pip install -e{toxinidir}
   pip install --upgrade setuptools pip wheel
   python -m pytest {posargs} {toxinidir}/runtimes/huggingface
 
@@ -113,7 +115,6 @@ commands =
 
 [testenv:all-runtimes]
 deps =
-  -e{toxinidir}
   -e{toxinidir}/runtimes/alibi-explain
   -e{toxinidir}/runtimes/alibi-detect
   -e{toxinidir}/runtimes/sklearn
@@ -126,6 +127,9 @@ deps =
 commands = 
   # Move other dev deps here - otherwise pip may choke trying to resolve deps
   pip install \
+    # Avoid conflicts and ensure `protobuf==3.20.3` is used (CVE-2022-1941)
+    # https://github.com/huggingface/optimum/issues/733
+    -e{toxinidir} \
     -r{toxinidir}/runtimes/mlflow/requirements/dev.txt \
     -r{toxinidir}/runtimes/alibi-explain/requirements/dev.txt
   python -m pytest {posargs} \

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ setup(
         "importlib-metadata;python_version<'3.8'",
         "numpy",
         "pandas",
-        "protobuf",
+        # Force patch for CVE-2022-1941
+        # https://github.com/huggingface/optimum/issues/733
+        "protobuf == 3.20.3",
         "uvicorn",
         "starlette_exporter",
         "py-grpc-prometheus",


### PR DESCRIPTION
Force `protobuf==3.20.3` to include patch for CVE-2022-1941. 

Related to https://github.com/huggingface/optimum/issues/733