### PR TITLE
Ability to pass extra parameters to the models in huggingface

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -13,6 +13,7 @@ from transformers.models.auto.tokenization_auto import AutoTokenizer
 import transformers
 from mlserver.logging import logger
 
+
 from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
 
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -43,6 +43,7 @@ class HuggingFaceSettings(BaseSettings):
     # related issue: https://github.com/SeldonIO/MLServer/issues/947
     task_suffix: str = ""
     pretrained_model: Optional[str] = None
+    model_parameters: Optional[Dict] = None
     pretrained_tokenizer: Optional[str] = None
     optimum_model: bool = False
     device: int = -1
@@ -128,6 +129,7 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         model=model,
         tokenizer=tokenizer,
         device=device,
+        model_kwargs=hf_settings.model_parameters,
         batch_size=hf_settings.batch_size,
     )
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -118,6 +118,7 @@ def load_pipeline_from_settings(hf_settings: HuggingFaceSettings) -> Pipeline:
         model = optimum_class.from_pretrained(
             hf_settings.pretrained_model,
             from_transformers=True,
+            **hf_settings.model_parameters,
         )
         tokenizer = AutoTokenizer.from_pretrained(tokenizer)
         # Device needs to be set to -1 due to known issue

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -22,6 +22,7 @@ class HuggingFaceRuntime(MLModel):
     """Runtime class for specific Huggingface models"""
 
     def __init__(self, settings: ModelSettings):
+        logger.debug("INFORMATION --- DELETE UPON MERGE --- THIS IS A FORK")
         env_params = parse_parameters_from_env()
         if not env_params and (
             not settings.parameters or not settings.parameters.extra


### PR DESCRIPTION
I want to pass extra parameters like `device_map` and `load_in_8bit`. So I thought this is the lightest way to get that done

settings file is now

```
{
    "name": "opt-125m",
    "implementation": "mlserver_huggingface.HuggingFaceRuntime",
    "parameters": {
        "extra": {
            "model_parameters": {
                "device_map": "auto",
                "load_in_8bit": true
            },
            "task": "text-generation",
            "device": "0",
            "pretrained_model": "facebook/opt-125m"
        }
    }
}
```

thoughts? 