### PR TITLE
Add Lower Bound for FastAPI Package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         "click",
         # 0.89.0: https://github.com/tiangolo/fastapi/issues/5861
-        "fastapi<=0.89.1, !=0.89.0",
+        "fastapi >=0.88.0, <=0.89.1, !=0.89.0",
         "python-dotenv",
         "grpcio",
         "importlib-metadata;python_version<'3.8'",


### PR DESCRIPTION
This add a lower bound for the fastapi package. This is needed to avoid having poetry install a very old version of FastAPI (0.1.17) from Jan 2019.

After building MLServer locally with that change, when I installed it locally, you could see that we were using a more recent version of FastAPI

```
❯ poetry install
Installing dependencies from lock file

Package operations: 0 installs, 3 updates, 0 removals

  • Updating starlette (0.25.0 -> 0.22.0)
  • Updating fastapi (0.1.17 -> 0.89.1)
  • Updating mlserver (1.2.4 -> 1.3.0.dev3 /Users/stephenbatifol/Documents/wolt/code/fork_mlserver/dist/mlserver-1.3.0.dev3.tar.gz)
```
Then with Python 

```
❯ python
Python 3.9.16 (main, Dec  7 2022, 10:02:13)
[Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastapi
>>> fastapi.__version__
'0.89.1'
```