### PR TITLE
Support batch accumulation within Detect runtime

### DIFF
--- a/mlserver/batching/__init__.py
+++ b/mlserver/batching/__init__.py
@@ -1,4 +1,5 @@
+from .requests import BatchedRequests
 from .adaptive import AdaptiveBatcher
 from .hooks import load_batching
 
-__all__ = ["AdaptiveBatcher", "load_batching"]
+__all__ = ["AdaptiveBatcher", "load_batching", "BatchedRequests"]

--- a/runtimes/alibi-detect/README.md
+++ b/runtimes/alibi-detect/README.md
@@ -1,10 +1,12 @@
 # Alibi-Detect runtime for MLServer
 
-This package provides a MLServer runtime compatible with [alibi-detect](https://docs.seldon.io/projects/alibi-detect/en/latest/index.html) models.
+This package provides a MLServer runtime compatible with
+[alibi-detect](https://docs.seldon.io/projects/alibi-detect/en/latest/index.html)
+models.
 
 ## Usage
 
-You can install the runtime, alongside `mlserver`, as:
+You can install the `mlserver-alibi-detect` runtime, alongside `mlserver`, as:
 
 ```bash
 pip install mlserver mlserver-alibi-detect
@@ -21,3 +23,36 @@ as a [NumPy Array](../../docs/user-guide/content-type).
 To avoid this, either send a different content type explicitly, or define the
 correct one as part of your [model's
 metadata](../../docs/reference/model-settings).
+
+## Settings
+
+The Alibi Detect runtime exposes a couple setting flags which can be used to
+customise how the runtime behaves.
+These settings can be added under the `parameters.extra` section of your
+`model-settings.json` file, e.g.
+
+```{code-block} json
+---
+emphasize-lines: 6-8
+---
+{
+  "name": "drift-detector",
+  "implementation": "mlserver_alibi_detect.AlibiDetectRuntime",
+  "parameters": {
+    "uri": "./alibi-detect-artifact/",
+    "extra": {
+      "batch_size": 5
+    }
+  }
+}
+```
+
+### Reference
+
+You can find the full reference of the accepted extra settings for the Alibi
+Detect runtime below:
+
+```{eval-rst}
+
+.. autopydantic_settings:: mlserver_alibi_detect.runtime.AlibiDetectSettings
+```

--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -5,7 +5,7 @@ from typing import Optional
 from pydantic import BaseSettings
 from functools import cached_property
 
-from alibi_detect.utils.saving import load_detector
+from alibi_detect.saving import load_detector
 
 from mlserver.types import InferenceRequest, InferenceResponse
 from mlserver.settings import ModelSettings

--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -1,14 +1,18 @@
-from mlserver import types
+import numpy as np
+
+from pydantic.error_wrappers import ValidationError
+from typing import Optional
+from pydantic import BaseSettings
+from functools import cached_property
+
+from alibi_detect.utils.saving import load_detector
+
+from mlserver.types import InferenceRequest, InferenceResponse
 from mlserver.settings import ModelSettings
 from mlserver.model import MLModel
 from mlserver.codecs import NumpyCodec, NumpyRequestCodec
 from mlserver.utils import get_model_uri
-from alibi_detect.utils.saving import load_detector
 from mlserver.errors import MLServerError, InferenceError
-from pydantic.error_wrappers import ValidationError
-from typing import Optional
-from pydantic import BaseSettings
-import numpy as np
 
 ENV_PREFIX_ALIBI_DETECT_SETTINGS = "MLSERVER_MODEL_ALIBI_DETECT_"
 
@@ -23,7 +27,18 @@ class AlibiDetectSettings(BaseSettings):
     class Config:
         env_prefix = ENV_PREFIX_ALIBI_DETECT_SETTINGS
 
-    predict_parameters: Optional[dict] = {}
+    predict_parameters: dict = {}
+    """
+    Keyword parameters to pass to the detector's `predict` method.
+    """
+
+    batch_size: Optional[int] = None
+    """
+    Run the detector after accumulating a batch of size `batch_size`.
+    Note that this is different to MLServer's adaptive batching, since the rest
+    of requests will just return empty (i.e. instead of being hold until
+    inference runs for all of them).
+    """
 
 
 class AlibiDetectRuntime(MLModel):
@@ -33,10 +48,10 @@ class AlibiDetectRuntime(MLModel):
 
     def __init__(self, settings: ModelSettings):
         if settings.parameters is None:
-            self.alibi_detect_settings = AlibiDetectSettings()
+            self._ad_settings = AlibiDetectSettings()
         else:
             extra = settings.parameters.extra
-            self.alibi_detect_settings = AlibiDetectSettings(**extra)  # type: ignore
+            self._ad_settings = AlibiDetectSettings(**extra)  # type: ignore
         super().__init__(settings)
 
     async def load(self) -> bool:
@@ -57,41 +72,47 @@ class AlibiDetectRuntime(MLModel):
         self.ready = True
         return self.ready
 
-    async def predict(self, payload: types.InferenceRequest) -> types.InferenceResponse:
+    async def predict(self, payload: InferenceRequest) -> InferenceResponse:
+        return self._detect(payload)
+
+    def _detect(self, payload: InferenceRequest) -> InferenceResponse:
         input_data = self.decode_request(payload, default_codec=NumpyRequestCodec)
-        predict_kwargs = {}
-        if self.alibi_detect_settings.predict_parameters is not None:
-            predict_kwargs = self.alibi_detect_settings.predict_parameters
+        predict_kwargs = self._ad_settings.predict_parameters
 
         try:
             y = self._model.predict(np.array(input_data), **predict_kwargs)
+            return self._encode_response(y)
         except (ValueError, IndexError) as e:
             raise InferenceError(
                 f"Invalid predict parameters for model {self._settings.name}: {e}"
             ) from e
 
+    def _encode_response(self, y: dict) -> InferenceResponse:
         outputs = []
         for key in y["data"]:
             outputs.append(
                 NumpyCodec.encode_output(name=key, payload=np.array([y["data"][key]]))
             )
+
         # Add headers
         y["meta"]["headers"] = {
-            "x-seldon-alibi-type": self.get_alibi_type(),
-            "x-seldon-alibi-method": self.get_alibi_method(),
+            "x-seldon-alibi-type": self.alibi_type,
+            "x-seldon-alibi-method": self.alibi_method,
         }
-        return types.InferenceResponse(
+        return InferenceResponse(
             model_name=self.name,
             model_version=self.version,
             parameters=y["meta"],
             outputs=outputs,
         )
 
-    def get_alibi_method(self) -> str:
+    @cached_property
+    def alibi_method(self) -> str:
         module: str = type(self._model).__module__
         return module.split(".")[-1]
 
-    def get_alibi_type(self) -> str:
+    @cached_property
+    def alibi_type(self) -> str:
         module: str = type(self._model).__module__
         method = module.split(".")[-2]
         if method in ALIBI_MODULE_NAMES:

--- a/runtimes/alibi-detect/tests/conftest.py
+++ b/runtimes/alibi-detect/tests/conftest.py
@@ -1,9 +1,23 @@
 import pytest
 import os
 import asyncio
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.keras.layers import Dense, InputLayer
+from alibi_detect.cd import TabularDrift
+from alibi_detect.od import OutlierVAE
+from alibi_detect.saving import save_detector
+
+from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import InferenceRequest
 from mlserver.utils import install_uvloop_event_loop
 
+from mlserver_alibi_detect import AlibiDetectRuntime
+
+tf.keras.backend.clear_session()
+
+P_VAL_THRESHOLD = 0.05
 
 TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
@@ -22,3 +36,110 @@ def event_loop():
 def inference_request() -> InferenceRequest:
     payload_path = os.path.join(TESTDATA_PATH, "inference-request.json")
     return InferenceRequest.parse_file(payload_path)
+
+
+@pytest.fixture
+def outlier_detector_settings(
+    outlier_detector_uri: str,
+) -> ModelSettings:
+    return ModelSettings(
+        name="alibi-detect-model",
+        implementation=AlibiDetectRuntime,
+        parameters=ModelParameters(
+            uri=outlier_detector_uri,
+            version="v1.2.3",
+            extra={
+                "predict_parameters": {
+                    "outlier_type": "instance",
+                    "return_feature_score": False,
+                    "return_instance_score": True,
+                }
+            },
+        ),
+    )
+
+
+@pytest.fixture
+def outlier_detector_uri(tmp_path: str) -> str:
+    X_ref = np.array([[1, 2, 3]])
+    n_features = X_ref.shape[1]
+    latent_dim = 2
+    encoder_net = tf.keras.Sequential(
+        [
+            InputLayer(input_shape=(n_features,)),
+            Dense(25, activation=tf.nn.relu),
+            Dense(10, activation=tf.nn.relu),
+            Dense(5, activation=tf.nn.relu),
+        ]
+    )
+
+    decoder_net = tf.keras.Sequential(
+        [
+            InputLayer(input_shape=(latent_dim,)),
+            Dense(5, activation=tf.nn.relu),
+            Dense(10, activation=tf.nn.relu),
+            Dense(25, activation=tf.nn.relu),
+            Dense(n_features, activation=None),
+        ]
+    )
+
+    od = OutlierVAE(
+        threshold=0.05,
+        score_type="mse",
+        encoder_net=encoder_net,
+        decoder_net=decoder_net,
+        latent_dim=latent_dim,
+        samples=5,
+    )
+
+    od.fit(X_ref, loss_fn=tf.keras.losses.mse, epochs=5, verbose=True)
+
+    detector_uri = os.path.join(tmp_path, "alibi-detector-artifacts")
+    save_detector(od, detector_uri)
+
+    return detector_uri
+
+
+@pytest.fixture
+async def outlier_detector(
+    outlier_detector_settings: ModelSettings,
+) -> AlibiDetectRuntime:
+    model = AlibiDetectRuntime(outlier_detector_settings)
+    await model.load()
+
+    return model
+
+
+@pytest.fixture
+def drift_detector_settings(
+    drift_detector_uri: str,
+) -> ModelSettings:
+    return ModelSettings(
+        name="alibi-detect-model",
+        implementation=AlibiDetectRuntime,
+        parameters=ModelParameters(
+            uri=drift_detector_uri,
+            version="v1.2.3",
+            extra={"predict_parameters": {"drift_type": "feature"}},
+        ),
+    )
+
+
+@pytest.fixture
+def drift_detector_uri(tmp_path: str) -> str:
+    X_ref = np.array([[1, 2, 3]])
+
+    cd = TabularDrift(X_ref, p_val=P_VAL_THRESHOLD)
+
+    detector_uri = os.path.join(tmp_path, "alibi-detector-artifacts")
+    save_detector(cd, detector_uri)
+
+    return detector_uri
+
+
+@pytest.fixture
+async def drift_detector(drift_detector_settings: ModelSettings) -> AlibiDetectRuntime:
+    model = AlibiDetectRuntime(drift_detector_settings)
+    await model.load()
+
+    return model

--- a/runtimes/alibi-detect/tests/conftest.py
+++ b/runtimes/alibi-detect/tests/conftest.py
@@ -120,7 +120,7 @@ def drift_detector_settings(
         parameters=ModelParameters(
             uri=drift_detector_uri,
             version="v1.2.3",
-            extra={"predict_parameters": {"drift_type": "feature"}},
+            extra={"predict_parameters": {"drift_type": "feature"}, "batch_size": 5},
         ),
     )
 

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -1,12 +1,15 @@
 import pytest
+import os
+import numpy as np
+
+from alibi_detect.cd import TabularDrift
+from alibi_detect.utils.saving import save_detector
+
 from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import RequestInput, InferenceRequest
 from mlserver.codecs import CodecError
+
 from mlserver_alibi_detect import AlibiDetectRuntime
-from alibi_detect.cd import TabularDrift
-from alibi_detect.utils.saving import save_detector
-import os
-import numpy as np
 
 P_VAL_THRESHOLD = 0.05
 

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -1,5 +1,3 @@
-import pytest
-
 from alibi_detect.cd import TabularDrift
 
 from mlserver.types import RequestInput, InferenceRequest
@@ -30,15 +28,3 @@ async def test_predict(
     assert response.outputs[2].name == "p_val"
     assert response.outputs[3].name == "threshold"
     assert response.outputs[3].data[0] == P_VAL_THRESHOLD
-
-
-async def test_multiple_inputs_error(
-    drift_detector: AlibiDetectRuntime,
-    inference_request: InferenceRequest,
-):
-    inference_request.inputs.append(
-        RequestInput(name="input-1", shape=[1, 3], data=[[0, 1, 6]], datatype="FP32")
-    )
-
-    with pytest.raises(CodecError):
-        await drift_detector.predict(inference_request)

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -1,76 +1,27 @@
 import pytest
-import os
-import numpy as np
 
 from alibi_detect.cd import TabularDrift
-from alibi_detect.utils.saving import save_detector
 
-from mlserver.settings import ModelSettings, ModelParameters
 from mlserver.types import RequestInput, InferenceRequest
 from mlserver.codecs import CodecError
 
 from mlserver_alibi_detect import AlibiDetectRuntime
 
-P_VAL_THRESHOLD = 0.05
-
-
-@pytest.fixture
-def alibi_detect_tabular_drift_model_settings(
-    alibi_detect_tabular_drift_model_uri: str,
-) -> ModelSettings:
-    return ModelSettings(
-        name="alibi-detect-model",
-        implementation=AlibiDetectRuntime,
-        parameters=ModelParameters(
-            uri=alibi_detect_tabular_drift_model_uri,
-            version="v1.2.3",
-            extra={"predict_parameters": {"drift_type": "feature"}},
-        ),
-    )
-
-
-@pytest.fixture
-def alibi_detect_tabular_drift_model_uri(tmp_path) -> str:
-    X_ref = np.array([[1, 2, 3]])
-
-    cd = TabularDrift(X_ref, p_val=P_VAL_THRESHOLD)
-
-    detector_uri = os.path.join(tmp_path, "alibi-detector-artifacts")
-    save_detector(cd, detector_uri)
-
-    return detector_uri
-
-
-@pytest.fixture
-async def alibi_detect_tabular_drift_model(
-    alibi_detect_tabular_drift_model_settings: ModelSettings,
-) -> AlibiDetectRuntime:
-    model = AlibiDetectRuntime(alibi_detect_tabular_drift_model_settings)
-    await model.load()
-
-    return model
+from .conftest import P_VAL_THRESHOLD
 
 
 async def test_load_folder(
-    alibi_detect_tabular_drift_model_uri: str,
-    alibi_detect_tabular_drift_model_settings: ModelSettings,
+    drift_detector: AlibiDetectRuntime,
 ):
-    alibi_detect_tabular_drift_model_settings.parameters.uri = (  # type: ignore
-        alibi_detect_tabular_drift_model_uri
-    )
-
-    model = AlibiDetectRuntime(alibi_detect_tabular_drift_model_settings)
-    await model.load()
-
-    assert model.ready
-    assert type(model._model) == TabularDrift
+    assert drift_detector.ready
+    assert type(drift_detector._model) == TabularDrift
 
 
 async def test_predict(
-    alibi_detect_tabular_drift_model: AlibiDetectRuntime,
+    drift_detector: AlibiDetectRuntime,
     inference_request: InferenceRequest,
 ):
-    response = await alibi_detect_tabular_drift_model.predict(inference_request)
+    response = await drift_detector.predict(inference_request)
 
     assert len(response.outputs) == 4
     assert response.outputs[0].name == "is_drift"
@@ -82,7 +33,7 @@ async def test_predict(
 
 
 async def test_multiple_inputs_error(
-    alibi_detect_tabular_drift_model: AlibiDetectRuntime,
+    drift_detector: AlibiDetectRuntime,
     inference_request: InferenceRequest,
 ):
     inference_request.inputs.append(
@@ -90,4 +41,4 @@ async def test_multiple_inputs_error(
     )
 
     with pytest.raises(CodecError):
-        await alibi_detect_tabular_drift_model.predict(inference_request)
+        await drift_detector.predict(inference_request)

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -1,8 +1,6 @@
 from alibi_detect.cd import TabularDrift
 
-from mlserver.types import RequestInput, InferenceRequest
-from mlserver.settings import ModelSettings
-from mlserver.codecs import CodecError
+from mlserver.types import InferenceRequest
 
 from mlserver_alibi_detect import AlibiDetectRuntime
 
@@ -18,12 +16,11 @@ async def test_load_folder(
 
 async def test_predict_batch(
     drift_detector: AlibiDetectRuntime,
-    drift_detector_settings: ModelSettings,
     inference_request: InferenceRequest,
 ):
     # For #(batch - 1) requests, outputs should be empty
-    batch_size = drift_detector_settings.parameters.extra["batch_size"]
-    for _ in range(batch_size - 1):
+    batch_size = drift_detector._ad_settings.batch_size
+    for _ in range(batch_size - 1):  # type: ignore
         response = await drift_detector.predict(inference_request)
         assert len(response.outputs) == 0
 

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -44,7 +44,7 @@ async def test_predict_batch(drift_detector: AlibiDetectRuntime, mocker):
 
     # For #(batch - 1) requests, outputs should be empty
     batch_size = drift_detector._ad_settings.batch_size
-    expected = np.random.randint(10, size=(batch_size, 3))
+    expected = np.random.randint(10, size=(batch_size, 3))  # type: ignore
     for idx in range(batch_size - 1):  # type: ignore
         inference_request = NumpyRequestCodec.encode_request(expected[idx : idx + 1])
         response = await drift_detector.predict(inference_request)
@@ -53,7 +53,7 @@ async def test_predict_batch(drift_detector: AlibiDetectRuntime, mocker):
         mocked_predict.assert_not_called()
 
     inference_request = NumpyRequestCodec.encode_request(
-        expected[batch_size - 1 : batch_size]
+        expected[batch_size - 1 : batch_size]  # type: ignore
     )
     await drift_detector.predict(inference_request)
 

--- a/runtimes/alibi-detect/tests/test_outlier_detector.py
+++ b/runtimes/alibi-detect/tests/test_outlier_detector.py
@@ -1,10 +1,6 @@
-import pytest
-
 from alibi_detect.od import OutlierVAE
 
-from mlserver.settings import ModelSettings
-from mlserver.types import RequestInput, InferenceRequest
-from mlserver.codecs import CodecError
+from mlserver.types import InferenceRequest
 
 from mlserver_alibi_detect import AlibiDetectRuntime
 
@@ -25,15 +21,3 @@ async def test_predict(
     assert response.outputs[1].name == "feature_score"
     assert response.outputs[2].name == "is_outlier"
     assert response.outputs[2].shape == [1, 1]
-
-
-async def test_multiple_inputs_error(
-    outlier_detector: AlibiDetectRuntime,
-    inference_request: InferenceRequest,
-):
-    inference_request.inputs.append(
-        RequestInput(name="input-1", shape=[1, 3], data=[[0, 1, 6]], datatype="FP32")
-    )
-
-    with pytest.raises(CodecError):
-        await outlier_detector.predict(inference_request)

--- a/runtimes/alibi-detect/tests/test_outlier_detector.py
+++ b/runtimes/alibi-detect/tests/test_outlier_detector.py
@@ -1,14 +1,17 @@
 import pytest
-from mlserver.settings import ModelSettings, ModelParameters
-from mlserver.types import RequestInput, InferenceRequest
-from mlserver.codecs import CodecError
-from mlserver_alibi_detect import AlibiDetectRuntime
-from alibi_detect.od import OutlierVAE
-from alibi_detect.utils.saving import save_detector
 import os
 import numpy as np
 import tensorflow as tf
+
 from tensorflow.keras.layers import Dense, InputLayer
+from alibi_detect.od import OutlierVAE
+from alibi_detect.utils.saving import save_detector
+
+from mlserver.settings import ModelSettings, ModelParameters
+from mlserver.types import RequestInput, InferenceRequest
+from mlserver.codecs import CodecError
+
+from mlserver_alibi_detect import AlibiDetectRuntime
 
 tf.keras.backend.clear_session()
 

--- a/runtimes/alibi-detect/tests/test_outlier_detector.py
+++ b/runtimes/alibi-detect/tests/test_outlier_detector.py
@@ -1,116 +1,24 @@
 import pytest
-import os
-import numpy as np
-import tensorflow as tf
 
-from tensorflow.keras.layers import Dense, InputLayer
 from alibi_detect.od import OutlierVAE
-from alibi_detect.utils.saving import save_detector
 
-from mlserver.settings import ModelSettings, ModelParameters
+from mlserver.settings import ModelSettings
 from mlserver.types import RequestInput, InferenceRequest
 from mlserver.codecs import CodecError
 
 from mlserver_alibi_detect import AlibiDetectRuntime
 
-tf.keras.backend.clear_session()
 
-X_REF_THRESHOLD = 0.05
-
-
-@pytest.fixture
-def alibi_detect_tabular_outlier_model_settings(
-    alibi_detect_tabular_outlier_model_uri: str,
-) -> ModelSettings:
-    return ModelSettings(
-        name="alibi-detect-model",
-        implementation=AlibiDetectRuntime,
-        parameters=ModelParameters(
-            uri=alibi_detect_tabular_outlier_model_uri,
-            version="v1.2.3",
-            extra={
-                "predict_parameters": {
-                    "outlier_type": "instance",
-                    "return_feature_score": False,
-                    "return_instance_score": True,
-                }
-            },
-        ),
-    )
-
-
-@pytest.fixture
-def alibi_detect_tabular_outlier_model_uri(tmp_path) -> str:
-    X_ref = np.array([[1, 2, 3]])
-    n_features = X_ref.shape[1]
-    latent_dim = 2
-    encoder_net = tf.keras.Sequential(
-        [
-            InputLayer(input_shape=(n_features,)),
-            Dense(25, activation=tf.nn.relu),
-            Dense(10, activation=tf.nn.relu),
-            Dense(5, activation=tf.nn.relu),
-        ]
-    )
-
-    decoder_net = tf.keras.Sequential(
-        [
-            InputLayer(input_shape=(latent_dim,)),
-            Dense(5, activation=tf.nn.relu),
-            Dense(10, activation=tf.nn.relu),
-            Dense(25, activation=tf.nn.relu),
-            Dense(n_features, activation=None),
-        ]
-    )
-
-    od = OutlierVAE(
-        threshold=X_REF_THRESHOLD,
-        score_type="mse",
-        encoder_net=encoder_net,
-        decoder_net=decoder_net,
-        latent_dim=latent_dim,
-        samples=5,
-    )
-
-    od.fit(X_ref, loss_fn=tf.keras.losses.mse, epochs=5, verbose=True)
-
-    detector_uri = os.path.join(tmp_path, "alibi-detector-artifacts")
-    save_detector(od, detector_uri)
-
-    return detector_uri
-
-
-@pytest.fixture
-async def alibi_detect_tabular_outlier_model(
-    alibi_detect_tabular_outlier_model_settings: ModelSettings,
-) -> AlibiDetectRuntime:
-    model = AlibiDetectRuntime(alibi_detect_tabular_outlier_model_settings)
-    await model.load()
-
-    return model
-
-
-async def test_load_folder(
-    alibi_detect_tabular_outlier_model_uri: str,
-    alibi_detect_tabular_outlier_model_settings: ModelSettings,
-):
-    alibi_detect_tabular_outlier_model_settings.parameters.uri = (  # type: ignore
-        alibi_detect_tabular_outlier_model_uri
-    )
-
-    model = AlibiDetectRuntime(alibi_detect_tabular_outlier_model_settings)
-    await model.load()
-
-    assert model.ready
-    assert type(model._model) == OutlierVAE
+async def test_load_folder(outlier_detector: AlibiDetectRuntime):
+    assert outlier_detector.ready
+    assert type(outlier_detector._model) == OutlierVAE
 
 
 async def test_predict(
-    alibi_detect_tabular_outlier_model: AlibiDetectRuntime,
+    outlier_detector: AlibiDetectRuntime,
     inference_request: InferenceRequest,
-    alibi_detect_tabular_outlier_model_settings: ModelSettings,
 ):
-    response = await alibi_detect_tabular_outlier_model.predict(inference_request)
+    response = await outlier_detector.predict(inference_request)
 
     assert len(response.outputs) == 3
     assert response.outputs[0].name == "instance_score"
@@ -120,13 +28,12 @@ async def test_predict(
 
 
 async def test_multiple_inputs_error(
-    alibi_detect_tabular_outlier_model: AlibiDetectRuntime,
+    outlier_detector: AlibiDetectRuntime,
     inference_request: InferenceRequest,
-    alibi_detect_tabular_outlier_model_settings: ModelSettings,
 ):
     inference_request.inputs.append(
         RequestInput(name="input-1", shape=[1, 3], data=[[0, 1, 6]], datatype="FP32")
     )
 
     with pytest.raises(CodecError):
-        await alibi_detect_tabular_outlier_model.predict(inference_request)
+        await outlier_detector.predict(inference_request)

--- a/runtimes/alibi-detect/tests/test_runtime.py
+++ b/runtimes/alibi-detect/tests/test_runtime.py
@@ -1,0 +1,18 @@
+import pytest
+
+from mlserver.codecs import CodecError
+from mlserver.types import RequestInput, InferenceRequest
+
+from mlserver_alibi_detect import AlibiDetectRuntime
+
+
+async def test_multiple_inputs_error(
+    outlier_detector: AlibiDetectRuntime,
+    inference_request: InferenceRequest,
+):
+    inference_request.inputs.append(
+        RequestInput(name="input-1", shape=[1, 3], data=[[0, 1, 6]], datatype="FP32")
+    )
+
+    with pytest.raises(CodecError):
+        await outlier_detector.predict(inference_request)


### PR DESCRIPTION
Fixes #1019

## Changelog

- Add the `batch_size` flag to the Detect settings.
- Use the `BatchedRequests` utility class within the Detect runtime to accumulate batches.