### PR TITLE
Add CHANGELOG.md and GH action to auto-generate it

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         scenario: ["inference-rest.js", "inference-grpc.js"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 # This GH Action is triggered when a release is 'published' in GitHub.
 # Once that happens, it will re-generate the Changelog (from the GH tag), and
 # update the tag so that it gets picked up by ReadTheDocs.
+name: Publish Version
 
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: false
           args: -d=false
+          header: "# Changelog\n"
       - name: Commiting & Pushing Updated Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -42,6 +43,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: false
           args: -d=false
+          header: "# Changelog\n\n"
       - name: Commiting & Pushing Updated Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,10 @@ on:
     types: [published]
 
 jobs:
-  changelog:
+  changelog-release-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: rhysd/changelog-from-release/action@v3
         with:
           file: CHANGELOG.md
@@ -21,3 +21,18 @@ jobs:
         uses: actions-ecosystem/action-push-tag@v1
         with:
           tag: ${{ github.event.release.tag_name }}
+
+  changelog-master-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_summary_template: "Update CHANGELOG.md for %s"
+          args: -d=false
+      - name: Commiting & Pushing Updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Bump version to ${{ github.event.inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
     types: [published]
 
 jobs:
+  # NOTE: We need to update the CHANGELOG on both the `release/*` and `master`
+  # branches to ensure they are in sync.
   changelog-release-branch:
     runs-on: ubuntu-latest
     steps:
@@ -15,24 +17,31 @@ jobs:
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_summary_template: "Update CHANGELOG.md for %s"
-          args: -d=false
-      - name: Bump version tag with latest changes
-        uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ github.event.release.tag_name }}
-
-  changelog-master-branch:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_summary_template: "Update CHANGELOG.md for %s"
+          commit: false
           args: -d=false
       - name: Commiting & Pushing Updated Changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Bump version to ${{ github.event.inputs.version }}
+          commit_message: Update CHANGELOG.md for ${{ github.event.release.tag_name }}
+          tagging_message: ${{ github.event.release.tag_name }}
+          # NOTE: The tag will already exist (created by the release pipeline),
+          # so we'll need to override it to ensure the tag contains the right
+          # changelog.
+          push_options: "--force"
+
+  changelog-master-branch:
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: Open a PR instead of pushing straight to `master`?
+      - uses: actions/checkout@v3
+        ref: master
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit: false
+          args: -d=false
+      - name: Commiting & Pushing Updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update CHANGELOG.md for ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,15 @@ jobs:
           # so we'll need to override it to ensure the tag contains the right
           # changelog.
           push_options: "--force"
+      - name: Tagging release as stable
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update CHANGELOG.md for ${{ github.event.release.tag_name }}
+          tagging_message: stable
+          # NOTE: The tag will already exist (created by previous releases), so
+          # we'll need to override it to ensure it points to the latest
+          # published release.
+          push_options: "--force"
 
   changelog-master-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+# This GH Action is triggered when a release is 'published' in GitHub.
+# Once that happens, it will re-generate the Changelog (from the GH tag), and
+# update the tag so that it gets picked up by ReadTheDocs.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_summary_template: "Update CHANGELOG.md for %s"
+          args: -d=false
+      - name: Bump version tag with latest changes
+        uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-sc.yml
+++ b/.github/workflows/release-sc.yml
@@ -10,7 +10,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update Version
         run: |
           ./hack/update-version.sh ${{ github.event.inputs.version }}
@@ -37,7 +37,7 @@ jobs:
           remove-haskell: "true"
           remove-android: "true"
           root-reserve-mb: "40960"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Build Docker Image
@@ -110,7 +110,7 @@ jobs:
           remove-haskell: "true"
           remove-android: "true"
           root-reserve-mb: "40960"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Build Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update Version
         run: |
           ./hack/update-version.sh ${{ github.event.inputs.version }}
@@ -37,7 +37,7 @@ jobs:
           remove-haskell: "true"
           remove-android: "true"
           root-reserve-mb: "40960"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Set up Python 3.8
@@ -152,7 +152,7 @@ jobs:
           - sklearn
           - xgboost
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Set up Python 3.8

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -39,7 +39,7 @@ jobs:
           - alibi-explain
           - alibi-detect
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -62,7 +62,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,170 @@
+<a name="1.2.4"></a>
+# [1.2.4](https://github.com/SeldonIO/MLServer/releases/tag/1.2.4) - 10 Mar 2023
+
+<!-- Release notes generated using configuration in .github/release.yml at 1.2.4 -->
+
+
+
+**Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.3...1.2.4
+
+[Changes][1.2.4]
+
+
+<a name="1.2.3"></a>
+# [1.2.3](https://github.com/SeldonIO/MLServer/releases/tag/1.2.3) - 16 Jan 2023
+
+<!-- Release notes generated using configuration in .github/release.yml at 1.2.3 -->
+
+
+
+**Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.2...1.2.3
+
+[Changes][1.2.3]
+
+
+<a name="1.2.2"></a>
+# [1.2.2](https://github.com/SeldonIO/MLServer/releases/tag/1.2.2) - 16 Jan 2023
+
+<!-- Release notes generated using configuration in .github/release.yml at 1.2.2 -->
+
+
+
+**Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.1...1.2.2
+
+[Changes][1.2.2]
+
+
+<a name="1.2.1"></a>
+# [1.2.1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.1) - 19 Dec 2022
+
+<!-- Release notes generated using configuration in .github/release.yml at 1.2.1 -->
+
+
+
+**Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.0...1.2.1
+
+[Changes][1.2.1]
+
+
+<a name="1.2.0"></a>
+# [1.2.0](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0) - 25 Nov 2022
+
+<!-- Release notes generated using configuration in .github/release.yml at 1.2.0 -->
+
+## What's Changed
+
+### Simplified Interface for Custom Runtimes
+
+MLServer now exposes an alternative [_“simplified”_ interface](https://mlserver.readthedocs.io/en/latest/user-guide/custom.html#simplified-interface) which can be used to write custom runtimes. This interface can be enabled by decorating your predict() method with the `mlserver.codecs.decode_args` decorator, and it lets you specify in the method signature both how you want your request payload to be decoded and how to encode the response back.
+
+Based on the information provided in the method signature, MLServer will automatically decode the request payload into the different inputs specified as keyword arguments. Under the hood, this is implemented through [MLServer’s codecs and content types system](https://mlserver.readthedocs.io/en/latest/user-guide/content-type.html).
+
+```python
+from mlserver import MLModel
+from mlserver.codecs import decode_args
+
+class MyCustomRuntime(MLModel):
+
+  async def load(self) -> bool:
+    # TODO: Replace for custom logic to load a model artifact
+    self._model = load_my_custom_model()
+    self.ready = True
+    return self.ready
+
+  @decode_args
+  async def predict(self, questions: List[str], context: List[str]) -> np.ndarray:
+    # TODO: Replace for custom logic to run inference
+    return self._model.predict(questions, context)
+```
+
+### Built-in Templates for Custom Runtimes
+
+To make it easier to write your own custom runtimes, MLServer now ships with a `mlserver init` command that will generate a templated project. This project will include a skeleton with folders, unit tests, Dockerfiles, etc. for you to fill.
+
+![image1](https://user-images.githubusercontent.com/1577620/203810614-f4daa32e-8b1d-4bea-9b02-959b1d054596.gif)
+
+### Dynamic Loading of Custom Runtimes
+
+MLServer now lets you [load custom runtimes dynamically](https://mlserver.readthedocs.io/en/latest/user-guide/custom.html#loading-a-custom-mlserver-runtime) into a running instance of MLServer. Once you have your custom runtime ready, all you need to do is to move it to your model folder, next to your `model-settings.json` configuration file.
+
+For example, if we assume a flat model repository where each folder represents a model, you would end up with a folder structure like the one below:
+
+```
+.
+├── models
+│   └── sum-model
+│       ├── model-settings.json
+│       ├── models.py
+```
+
+### Batch Inference Client
+
+This release of MLServer introduces a new [`mlserver infer`](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-infer) command, which will let you run inference over a large batch of input data on the client side. Under the hood, this command will stream a large set of inference requests from specified input file, arrange them in microbatches, orchestrate the request / response lifecycle, and will finally write back the obtained responses into output file.
+
+### Parallel Inference Improvements
+
+The `1.2.0` release of MLServer, includes a number of fixes around the parallel inference pool focused on improving the architecture to optimise memory usage and reduce latency. These changes include (but are not limited to):
+
+- The main MLServer process won’t load an extra replica of the model anymore. Instead, all computing will occur on the parallel inference pool.
+- The worker pool will now ensure that all requests are executed on each worker’s AsyncIO loop, thus optimising compute time vs IO time.
+- Several improvements around logging from the inference workers. 
+
+### Dropped support for Python 3.7
+
+MLServer has now dropped support for Python `3.7`. Going forward, only `3.8`, `3.9` and `3.10` will be supported (with `3.8` being used in our official set of images).
+
+### Move to UBI Base Images
+
+The official set of MLServer images has now moved to use [UBI 9](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as a base image. This ensures support to run MLServer in OpenShift clusters, as well as a well-maintained baseline for our images. 
+
+### Support for MLflow 2.0
+
+In line with MLServer’s close relationship with the MLflow team, this release of MLServer introduces support for the recently released MLflow 2.0. This introduces changes to the drop-in MLflow “scoring protocol” support, in the MLflow runtime for MLServer, to ensure it’s aligned with MLflow 2.0.  
+
+MLServer is also shipped as a dependency of MLflow, therefore you can try it out today by installing MLflow as:
+
+```bash
+$ pip install mlflow[extras]
+```
+
+To learn more about how to use MLServer directly from the MLflow CLI, check out the [MLflow docs](https://www.mlflow.org/docs/latest/models.html#serving-with-mlserver).
+
+
+## New Contributors
+* [@johnpaulett](https://github.com/johnpaulett) made their first contribution in https://github.com/SeldonIO/MLServer/pull/633
+* [@saeid93](https://github.com/saeid93) made their first contribution in https://github.com/SeldonIO/MLServer/pull/711
+* [@RafalSkolasinski](https://github.com/RafalSkolasinski) made their first contribution in https://github.com/SeldonIO/MLServer/pull/720
+* [@dumaas](https://github.com/dumaas) made their first contribution in https://github.com/SeldonIO/MLServer/pull/742
+* [@Salehbigdeli](https://github.com/Salehbigdeli) made their first contribution in https://github.com/SeldonIO/MLServer/pull/776
+* [@regen100](https://github.com/regen100) made their first contribution in https://github.com/SeldonIO/MLServer/pull/839
+
+**Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.1.0...1.2.0
+
+[Changes][1.2.0]
+
+
+<a name="1.2.0.dev1"></a>
+# [v1.2.0.dev1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0.dev1) - 01 Aug 2022
+
+
+
+[Changes][1.2.0.dev1]
+
+
+<a name="1.1.0"></a>
+# [v1.1.0](https://github.com/SeldonIO/MLServer/releases/tag/1.1.0) - 01 Aug 2022
+
+
+
+[Changes][1.1.0]
+
+
+[1.2.4]: https://github.com/SeldonIO/MLServer/compare/1.2.3...1.2.4
+[1.2.3]: https://github.com/SeldonIO/MLServer/compare/1.2.2...1.2.3
+[1.2.2]: https://github.com/SeldonIO/MLServer/compare/1.2.1...1.2.2
+[1.2.1]: https://github.com/SeldonIO/MLServer/compare/1.2.0...1.2.1
+[1.2.0]: https://github.com/SeldonIO/MLServer/compare/1.2.0.dev1...1.2.0
+[1.2.0.dev1]: https://github.com/SeldonIO/MLServer/compare/1.1.0...1.2.0.dev1
+[1.1.0]: https://github.com/SeldonIO/MLServer/tree/1.1.0
+
+<!-- Generated by https://github.com/rhysd/changelog-from-release v3.7.0 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,59 +1,54 @@
+# Changelog
+
 <a name="1.2.4"></a>
-# [1.2.4](https://github.com/SeldonIO/MLServer/releases/tag/1.2.4) - 10 Mar 2023
+
+## [1.2.4](https://github.com/SeldonIO/MLServer/releases/tag/1.2.4) - 10 Mar 2023
 
 <!-- Release notes generated using configuration in .github/release.yml at 1.2.4 -->
-
-
 
 **Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.3...1.2.4
 
 [Changes][1.2.4]
 
-
 <a name="1.2.3"></a>
-# [1.2.3](https://github.com/SeldonIO/MLServer/releases/tag/1.2.3) - 16 Jan 2023
+
+## [1.2.3](https://github.com/SeldonIO/MLServer/releases/tag/1.2.3) - 16 Jan 2023
 
 <!-- Release notes generated using configuration in .github/release.yml at 1.2.3 -->
-
-
 
 **Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.2...1.2.3
 
 [Changes][1.2.3]
 
-
 <a name="1.2.2"></a>
-# [1.2.2](https://github.com/SeldonIO/MLServer/releases/tag/1.2.2) - 16 Jan 2023
+
+## [1.2.2](https://github.com/SeldonIO/MLServer/releases/tag/1.2.2) - 16 Jan 2023
 
 <!-- Release notes generated using configuration in .github/release.yml at 1.2.2 -->
-
-
 
 **Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.1...1.2.2
 
 [Changes][1.2.2]
 
-
 <a name="1.2.1"></a>
-# [1.2.1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.1) - 19 Dec 2022
+
+## [1.2.1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.1) - 19 Dec 2022
 
 <!-- Release notes generated using configuration in .github/release.yml at 1.2.1 -->
-
-
 
 **Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.2.0...1.2.1
 
 [Changes][1.2.1]
 
-
 <a name="1.2.0"></a>
-# [1.2.0](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0) - 25 Nov 2022
+
+## [1.2.0](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0) - 25 Nov 2022
 
 <!-- Release notes generated using configuration in .github/release.yml at 1.2.0 -->
 
-## What's Changed
+### What's Changed
 
-### Simplified Interface for Custom Runtimes
+#### Simplified Interface for Custom Runtimes
 
 MLServer now exposes an alternative [_“simplified”_ interface](https://mlserver.readthedocs.io/en/latest/user-guide/custom.html#simplified-interface) which can be used to write custom runtimes. This interface can be enabled by decorating your predict() method with the `mlserver.codecs.decode_args` decorator, and it lets you specify in the method signature both how you want your request payload to be decoded and how to encode the response back.
 
@@ -77,13 +72,13 @@ class MyCustomRuntime(MLModel):
     return self._model.predict(questions, context)
 ```
 
-### Built-in Templates for Custom Runtimes
+#### Built-in Templates for Custom Runtimes
 
 To make it easier to write your own custom runtimes, MLServer now ships with a `mlserver init` command that will generate a templated project. This project will include a skeleton with folders, unit tests, Dockerfiles, etc. for you to fill.
 
 ![image1](https://user-images.githubusercontent.com/1577620/203810614-f4daa32e-8b1d-4bea-9b02-959b1d054596.gif)
 
-### Dynamic Loading of Custom Runtimes
+#### Dynamic Loading of Custom Runtimes
 
 MLServer now lets you [load custom runtimes dynamically](https://mlserver.readthedocs.io/en/latest/user-guide/custom.html#loading-a-custom-mlserver-runtime) into a running instance of MLServer. Once you have your custom runtime ready, all you need to do is to move it to your model folder, next to your `model-settings.json` configuration file.
 
@@ -97,29 +92,29 @@ For example, if we assume a flat model repository where each folder represents a
 │       ├── models.py
 ```
 
-### Batch Inference Client
+#### Batch Inference Client
 
 This release of MLServer introduces a new [`mlserver infer`](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-infer) command, which will let you run inference over a large batch of input data on the client side. Under the hood, this command will stream a large set of inference requests from specified input file, arrange them in microbatches, orchestrate the request / response lifecycle, and will finally write back the obtained responses into output file.
 
-### Parallel Inference Improvements
+#### Parallel Inference Improvements
 
 The `1.2.0` release of MLServer, includes a number of fixes around the parallel inference pool focused on improving the architecture to optimise memory usage and reduce latency. These changes include (but are not limited to):
 
 - The main MLServer process won’t load an extra replica of the model anymore. Instead, all computing will occur on the parallel inference pool.
 - The worker pool will now ensure that all requests are executed on each worker’s AsyncIO loop, thus optimising compute time vs IO time.
-- Several improvements around logging from the inference workers. 
+- Several improvements around logging from the inference workers.
 
-### Dropped support for Python 3.7
+#### Dropped support for Python 3.7
 
 MLServer has now dropped support for Python `3.7`. Going forward, only `3.8`, `3.9` and `3.10` will be supported (with `3.8` being used in our official set of images).
 
 ### Move to UBI Base Images
 
-The official set of MLServer images has now moved to use [UBI 9](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as a base image. This ensures support to run MLServer in OpenShift clusters, as well as a well-maintained baseline for our images. 
+The official set of MLServer images has now moved to use [UBI 9](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as a base image. This ensures support to run MLServer in OpenShift clusters, as well as a well-maintained baseline for our images.
 
-### Support for MLflow 2.0
+#### Support for MLflow 2.0
 
-In line with MLServer’s close relationship with the MLflow team, this release of MLServer introduces support for the recently released MLflow 2.0. This introduces changes to the drop-in MLflow “scoring protocol” support, in the MLflow runtime for MLServer, to ensure it’s aligned with MLflow 2.0.  
+In line with MLServer’s close relationship with the MLflow team, this release of MLServer introduces support for the recently released MLflow 2.0. This introduces changes to the drop-in MLflow “scoring protocol” support, in the MLflow runtime for MLServer, to ensure it’s aligned with MLflow 2.0.
 
 MLServer is also shipped as a dependency of MLflow, therefore you can try it out today by installing MLflow as:
 
@@ -129,35 +124,30 @@ $ pip install mlflow[extras]
 
 To learn more about how to use MLServer directly from the MLflow CLI, check out the [MLflow docs](https://www.mlflow.org/docs/latest/models.html#serving-with-mlserver).
 
+### New Contributors
 
-## New Contributors
-* [@johnpaulett](https://github.com/johnpaulett) made their first contribution in https://github.com/SeldonIO/MLServer/pull/633
-* [@saeid93](https://github.com/saeid93) made their first contribution in https://github.com/SeldonIO/MLServer/pull/711
-* [@RafalSkolasinski](https://github.com/RafalSkolasinski) made their first contribution in https://github.com/SeldonIO/MLServer/pull/720
-* [@dumaas](https://github.com/dumaas) made their first contribution in https://github.com/SeldonIO/MLServer/pull/742
-* [@Salehbigdeli](https://github.com/Salehbigdeli) made their first contribution in https://github.com/SeldonIO/MLServer/pull/776
-* [@regen100](https://github.com/regen100) made their first contribution in https://github.com/SeldonIO/MLServer/pull/839
+- [@johnpaulett](https://github.com/johnpaulett) made their first contribution in https://github.com/SeldonIO/MLServer/pull/633
+- [@saeid93](https://github.com/saeid93) made their first contribution in https://github.com/SeldonIO/MLServer/pull/711
+- [@RafalSkolasinski](https://github.com/RafalSkolasinski) made their first contribution in https://github.com/SeldonIO/MLServer/pull/720
+- [@dumaas](https://github.com/dumaas) made their first contribution in https://github.com/SeldonIO/MLServer/pull/742
+- [@Salehbigdeli](https://github.com/Salehbigdeli) made their first contribution in https://github.com/SeldonIO/MLServer/pull/776
+- [@regen100](https://github.com/regen100) made their first contribution in https://github.com/SeldonIO/MLServer/pull/839
 
 **Full Changelog**: https://github.com/SeldonIO/MLServer/compare/1.1.0...1.2.0
 
 [Changes][1.2.0]
 
-
 <a name="1.2.0.dev1"></a>
-# [v1.2.0.dev1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0.dev1) - 01 Aug 2022
 
-
+## [v1.2.0.dev1](https://github.com/SeldonIO/MLServer/releases/tag/1.2.0.dev1) - 01 Aug 2022
 
 [Changes][1.2.0.dev1]
 
-
 <a name="1.1.0"></a>
-# [v1.1.0](https://github.com/SeldonIO/MLServer/releases/tag/1.1.0) - 01 Aug 2022
 
-
+## [v1.1.0](https://github.com/SeldonIO/MLServer/releases/tag/1.1.0) - 01 Aug 2022
 
 [Changes][1.1.0]
-
 
 [1.2.4]: https://github.com/SeldonIO/MLServer/compare/1.2.3...1.2.4
 [1.2.3]: https://github.com/SeldonIO/MLServer/compare/1.2.2...1.2.3

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,19 +7,54 @@ This document discusses the release process for MLServer.
 > The process may change. Please, always check this document before conducting
 > a release and verify if everything goes as expected.
 
+**Before releasing a new version of MLServer, please read this page
+carefully and make sure you understand the different parts of the process.**
+
 ## Process Summary
 
-1. Trigger a `MLServer Release` from Github Actions.
+1. If this is a new **major or minor official release**, create a [release
+   branch](#release-branches) from `master`.
+   Alternatively, if this is a **patch official release**, checkout the
+   existing [release branch](#release-branches) and cherry-pick any relevant
+   commits into it.
+
+   Note that, for **dev releases**, the above is not needed and you can trigger
+   the `MLServer Release` action straight from `master`.
+
+2. Trigger a `MLServer Release` from Github Actions.
 
    1. Provide the [version tag](versioning-scheme) that you want to release.
       ![MLServer Release](./docs/assets/mlserver-release.png)
 
-2. Monitor the triggered workflow, until it's finished.
+3. Monitor the triggered workflow, until it's finished.
 
    1. Once it's done, all the [release artifacts](release-artifacts) will be
       pushed to Docker Hub and PyPI.
    2. Additionally, a release draft will get created in the repository
       [Releases section](https://github.com/SeldonIO/MLServer/releases).
+
+4. For **official releases**, update the release draft (created in step `3.2`)
+   in the [Releases section](https://github.com/SeldonIO/MLServer/releases) of
+   the repository.
+
+   1. Once you are happy with the draft, click `Publish`.
+
+## Release Branches
+
+For official releases, MLServer uses long-lived release branches.
+These branches will always follow the `release/<major>.<minor>.x` pattern (e.g.
+`release/1.2.x`) and will be used for every `<major>.<minor>.x` [official
+release](#versioning-scheme) (e.g. the `release/1.2.x` will be used for
+`1.2.0`, `1.2.1`, etc.).
+Note that these branches will always be pushed straight to the main
+`github.com/SeldonIO/MLServer` and not to a fork and will never get merged with
+`master`.
+
+Therefore, when starting a new **major or minor official release** please
+create a `release/<major>.<minor>.x` branch.
+Alternatively, when preparing a **patch official release**, please
+_cherry-pick_ all relevant merged PRs from `master` into the existing
+`release/<major>.<minor>.x` branch.
 
 ## Versioning Scheme
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+```{include} ../CHANGELOG.md
+:relative-docs: ./docs/
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Reference <./reference/index>
 :maxdepth: 1
 
 Examples <./examples/index>
+Changelog <./changelog>
 ```
 
 ```{include} ../README.md


### PR DESCRIPTION
Fixes #1032

## Changelog
- Add initial `CHANGELOG.md`, generated from published GH releases.
- Add GH action to update `CHANGELOG.md` everytime a new release is published.
- Add `stable` tag, which points to the latest published release in GH.
