### PR TITLE
Fix signature codec with tuple type annotations

### DIFF
--- a/mlserver/codecs/decorator.py
+++ b/mlserver/codecs/decorator.py
@@ -38,6 +38,10 @@ def _as_list(a: Optional[Union[Any, Tuple[Any]]]) -> List[Any]:
         # Split into components
         return list(a)
 
+    if get_origin(a) is tuple:
+        # Convert type arguments into list
+        return list(get_args(a))
+
     # Otherwise, assume it's a single element
     return [a]
 

--- a/tests/codecs/test_decorator.py
+++ b/tests/codecs/test_decorator.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import pandas as pd
 
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, Optional, List, Tuple
 
 from mlserver.types import (
     InferenceRequest,
@@ -13,7 +13,7 @@ from mlserver.types import (
 )
 from mlserver.codecs.base import InputCodec
 from mlserver.codecs.utils import Codec
-from mlserver.codecs.decorator import SignatureCodec
+from mlserver.codecs.decorator import SignatureCodec, _as_list
 from mlserver.codecs.errors import InputsNotFound, OutputNotFound
 from mlserver.codecs.numpy import NumpyCodec, NumpyRequestCodec
 from mlserver.codecs.string import StringCodec
@@ -287,3 +287,13 @@ async def test_decode_args(
 
     res = NumpyRequestCodec.decode_response(inference_response)
     assert res == output_value
+
+
+def test_as_list_typing_tuple():
+    signature_list = _as_list(Tuple[np.ndarray, np.ndarray])
+    assert signature_list == [np.ndarray, np.ndarray]
+
+
+def test_as_list_native_tuple():
+    signature_list = _as_list((np.ndarray, np.ndarray))
+    assert signature_list == [np.ndarray, np.ndarray]


### PR DESCRIPTION
Fixes #1036 

I'm unsure how/where to add a test for this as I didn't manage to run the test suite. Locally, I've experimented with the following snippet.

```python
from typing import Tuple
import numpy as np
from mlserver.codecs.decorator import SignatureCodec

def predict_fn_typing_tuple() -> Tuple[np.ndarray, np.ndarray]:
    return (np.array([4]), np.array([2]))


def predict_fn_native_tuple() -> tuple[np.ndarray, np.ndarray]:
    return (np.array([4]), np.array([2]))


def predict_fn_tuple_object() -> (np.ndarray, np.ndarray):
    return (np.array([4]), np.array([2]))


def test_typing_tuple():
    signature_codec = SignatureCodec(predict_fn_typing_tuple)
    assert signature_codec._output_hints == [np.ndarray, np.ndarray]


def test_native_tuple():
    signature_codec = SignatureCodec(predict_fn_native_tuple)
    assert signature_codec._output_hints == [np.ndarray, np.ndarray]


def test_tuple_object():
    signature_codec = SignatureCodec(predict_fn_tuple_object)
    assert signature_codec._output_hints == [np.ndarray, np.ndarray]
```

Please note: The notation for the `predict_fn_native_tuple` test requires Python 3.9. The PR code, however, does not depend on Python 3.9.