### PR TITLE
Improvements for HuggingFace runtime

### DIFF
--- a/docs/examples/huggingface/README.ipynb
+++ b/docs/examples/huggingface/README.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "id": "b5b2588c",
    "metadata": {},
    "outputs": [],
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "id": "6df62443",
    "metadata": {},
    "outputs": [
@@ -59,7 +59,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"parameters\": {\n",
     "        \"extra\": {\n",
     "            \"task\": \"text-generation\",\n",
@@ -93,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "id": "759ad7df",
    "metadata": {},
    "outputs": [
@@ -101,17 +100,16 @@
      "data": {
       "text/plain": [
        "{'model_name': 'transformer',\n",
-       " 'model_version': None,\n",
-       " 'id': '9b24304e-730f-4a98-bfde-8949851388a9',\n",
-       " 'parameters': None,\n",
+       " 'id': 'eb160c6b-8223-4342-ad92-6ac301a9fa5d',\n",
+       " 'parameters': {},\n",
        " 'outputs': [{'name': 'output',\n",
-       "   'shape': [1],\n",
+       "   'shape': [1, 1],\n",
        "   'datatype': 'BYTES',\n",
-       "   'parameters': None,\n",
-       "   'data': ['[{\"generated_text\": \"this is a test-case where you\\'re checking if someone\\'s going to have an encrypted file that they like to open, or whether their file has a hidden contents if their file is not opened. If it\\'s the same file, when all the\"}]']}]}"
+       "   'parameters': {'content_type': 'hg_jsonlist'},\n",
+       "   'data': ['{\"generated_text\": \"this is a testnet with 1-3,000-bit nodes as nodes.\"}']}]}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "6d185281",
    "metadata": {},
    "outputs": [
@@ -162,7 +160,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"parameters\": {\n",
     "        \"extra\": {\n",
     "            \"task\": \"text-generation\",\n",
@@ -197,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 12,
    "id": "39d8b438",
    "metadata": {},
    "outputs": [
@@ -205,17 +202,16 @@
      "data": {
       "text/plain": [
        "{'model_name': 'transformer',\n",
-       " 'model_version': None,\n",
-       " 'id': '296ea44e-7696-4584-af5a-148a7083b2e7',\n",
-       " 'parameters': None,\n",
+       " 'id': '9c482c8d-b21e-44b1-8a42-7650a9dc01ef',\n",
+       " 'parameters': {},\n",
        " 'outputs': [{'name': 'output',\n",
-       "   'shape': [1],\n",
+       "   'shape': [1, 1],\n",
        "   'datatype': 'BYTES',\n",
-       "   'parameters': None,\n",
-       "   'data': ['[{\"generated_text\": \"this is a test that allows us to define the value type, and a function is defined directly with these variables.\\\\n\\\\n\\\\nThe function is defined for a parameter with type\\\\nIn this example,\\\\nif you pass a message function like\\\\ntype\"}]']}]}"
+       "   'parameters': {'content_type': 'hg_jsonlist'},\n",
+       "   'data': ['{\"generated_text\": \"this is a test of the \\\\\"safe-code-safe-code-safe-code\\\\\" approach. The method only accepts two parameters as parameters: the code. The parameter \\'unsafe-code-safe-code-safe-code\\' should\"}']}]}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "id": "4492dc01",
    "metadata": {},
    "outputs": [
@@ -273,7 +269,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"parameters\": {\n",
     "        \"extra\": {\n",
     "            \"task\": \"question-answering\"\n",
@@ -296,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "d7aaf365",
    "metadata": {
     "scrolled": true
@@ -305,18 +300,17 @@
     {
      "data": {
       "text/plain": [
-       "{'model_name': 'gpt2-model',\n",
-       " 'model_version': None,\n",
-       " 'id': '204ad4e7-79ea-40b4-8efb-aed16dedf7ed',\n",
-       " 'parameters': None,\n",
+       "{'model_name': 'transformer',\n",
+       " 'id': '4efac938-86d8-41a1-b78f-7690b2dcf197',\n",
+       " 'parameters': {},\n",
        " 'outputs': [{'name': 'output',\n",
-       "   'shape': [1],\n",
+       "   'shape': [1, 1],\n",
        "   'datatype': 'BYTES',\n",
-       "   'parameters': None,\n",
-       "   'data': ['{\"score\": 0.9869922995567322, \"start\": 12, \"end\": 18, \"answer\": \"Seldon\"}']}]}"
+       "   'parameters': {'content_type': 'hg_jsonlist'},\n",
+       "   'data': ['{\"score\": 0.9869915843009949, \"start\": 12, \"end\": 18, \"answer\": \"Seldon\"}']}]}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8e70c7d7",
    "metadata": {},
    "outputs": [
@@ -369,7 +363,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"parameters\": {\n",
     "        \"extra\": {\n",
     "            \"task\": \"text-classification\"\n",
@@ -392,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "id": "2f704413",
    "metadata": {
     "scrolled": true
@@ -402,17 +395,16 @@
      "data": {
       "text/plain": [
        "{'model_name': 'transformer',\n",
-       " 'model_version': None,\n",
-       " 'id': '463ceddb-f426-4815-9c46-9fa9fc5272b1',\n",
-       " 'parameters': None,\n",
+       " 'id': '835eabbd-daeb-4423-a64f-a7c4d7c60a9b',\n",
+       " 'parameters': {},\n",
        " 'outputs': [{'name': 'output',\n",
-       "   'shape': [1],\n",
+       "   'shape': [1, 1],\n",
        "   'datatype': 'BYTES',\n",
-       "   'parameters': None,\n",
-       "   'data': ['[{\"label\": \"NEGATIVE\", \"score\": 0.9996137022972107}]']}]}"
+       "   'parameters': {'content_type': 'hg_jsonlist'},\n",
+       "   'data': ['{\"label\": \"NEGATIVE\", \"score\": 0.9996137022972107}']}]}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "id": "827472eb",
    "metadata": {},
    "outputs": [
@@ -465,7 +457,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"max_batch_size\": 128,\n",
     "    \"max_batch_time\": 1,\n",
     "    \"parameters\": {\n",
@@ -491,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 19,
    "id": "888501c1",
    "metadata": {},
    "outputs": [
@@ -499,7 +490,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 81.57849169999827\n"
+      "Elapsed time: 66.42268538899953\n"
      ]
     }
    ],
@@ -546,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "032b8f4e",
    "metadata": {},
    "outputs": [
@@ -563,7 +554,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"parameters\": {\n",
     "        \"extra\": {\n",
     "            \"task\": \"text-generation\",\n",
@@ -632,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "id": "810a4abe",
    "metadata": {},
    "outputs": [
@@ -649,7 +639,6 @@
     "{\n",
     "    \"name\": \"transformer\",\n",
     "    \"implementation\": \"mlserver_huggingface.HuggingFaceRuntime\",\n",
-    "    \"parallel_workers\": 0,\n",
     "    \"max_batch_size\": 128,\n",
     "    \"max_batch_time\": 1,\n",
     "    \"parameters\": {\n",
@@ -718,7 +707,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -732,7 +721,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.8"
   }
  },
  "nbformat": 4,

--- a/docs/examples/huggingface/README.md
+++ b/docs/examples/huggingface/README.md
@@ -27,7 +27,6 @@ We will show how to add share a task
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "parameters": {
         "extra": {
             "task": "text-generation",
@@ -76,7 +75,6 @@ We can download pretrained optimized models from the hub if available by enablin
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "parameters": {
         "extra": {
             "task": "text-generation",
@@ -127,7 +125,6 @@ We can support multiple other transformers other than just text generation, belo
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "parameters": {
         "extra": {
             "task": "question-answering"
@@ -172,7 +169,6 @@ requests.post("http://localhost:8080/v2/models/transformer/infer", json=inferenc
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "parameters": {
         "extra": {
             "task": "text-classification"
@@ -217,7 +213,6 @@ We first test the time taken with the device=-1 which configures CPU by default
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "max_batch_size": 128,
     "max_batch_time": 1,
     "parameters": {
@@ -271,7 +266,6 @@ Now we'll run the benchmark with GPU configured, which we can do by setting `dev
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "parameters": {
         "extra": {
             "task": "text-generation",
@@ -319,7 +313,6 @@ We will also configure `max_batch_time` which specifies` the maximum amount of t
 {
     "name": "transformer",
     "implementation": "mlserver_huggingface.HuggingFaceRuntime",
-    "parallel_workers": 0,
     "max_batch_size": 128,
     "max_batch_time": 1,
     "parameters": {

--- a/runtimes/huggingface/README.md
+++ b/runtimes/huggingface/README.md
@@ -12,3 +12,45 @@ pip install mlserver mlserver-huggingface
 
 For further information on how to use MLServer with HuggingFace, you can check
 out this [worked out example](../../docs/examples/huggingface/README.md).
+
+## Settings
+
+The HuggingFace runtime exposes a couple extra parameters which can be used to
+customise how the runtime behaves.
+These settings can be added under the `parameters.extra` section of your
+`model-settings.json` file, e.g.
+
+```{code-block} json
+---
+emphasize-lines: 5-8
+---
+{
+  "name": "qa",
+  "implementation": "mlserver_huggingface.HuggingFaceRuntime",
+  "parameters": {
+    "extra": {
+      "task": "question-answering",
+      "optimum_model": true
+    }
+  }
+}
+```
+
+````{note}
+These settings can also be injected through environment variables prefixed with `MLSERVER_MODEL_HUGGINGFACE_`, e.g.
+
+```bash
+MLSERVER_MODEL_HUGGINGFACE_TASK="question-answering"
+MLSERVER_MODEL_HUGGINGFACE_OPTIMUM_MODEL=true
+```
+````
+
+### Reference
+
+You can find the full reference of the accepted extra settings for the
+HuggingFace runtime below:
+
+```{eval-rst}
+
+.. autopydantic_settings:: mlserver_huggingface.settings.HuggingFaceSettings
+```

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -53,7 +53,9 @@ def load_pipeline_from_settings(
 
     # If max_batch_size > 0 we need to ensure tokens are padded
     if settings.max_batch_size:
-        hf_pipeline.tokenizer.pad_token_id = [str(pp.model.config.eos_token_id)]  # type: ignore
+        model = hf_pipeline.model
+        eos_token_id = model.config.eos_token_id
+        hf_pipeline.tokenizer.pad_token_id = [str(eos_token_id)]  # type: ignore
 
     return hf_pipeline
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -9,20 +9,6 @@ from optimum.pipelines import pipeline as opt_pipeline
 from transformers.pipelines import pipeline as trf_pipeline
 from transformers.pipelines.base import Pipeline
 
-try:
-    # Optimum 1.7 changed the import name from `SUPPORTED_TASKS` to
-    # `ORT_SUPPORTED_TASKS`.
-    # We'll try to import the more recent one, falling back to the previous
-    # import name if not present.
-    # https://github.com/huggingface/optimum/blob/987b02e4f6e2a1c9325b364ff764da2e57e89902/optimum/pipelines/__init__.py#L18
-    from optimum.pipelines import (  # noqa: F401
-        ORT_SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS,
-    )
-except ImportError:
-    from optimum.pipelines import (  # noqa: F401
-        SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS,
-    )
-
 from .settings import HuggingFaceSettings
 
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -15,9 +15,13 @@ try:
     # We'll try to import the more recent one, falling back to the previous
     # import name if not present.
     # https://github.com/huggingface/optimum/blob/987b02e4f6e2a1c9325b364ff764da2e57e89902/optimum/pipelines/__init__.py#L18
-    from optimum.pipelines import ORT_SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
+    from optimum.pipelines import (  # noqa: F401
+        ORT_SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS,
+    )
 except ImportError:
-    from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
+    from optimum.pipelines import (  # noqa: F401
+        SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS,
+    )
 
 from .settings import HuggingFaceSettings
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -1,12 +1,8 @@
-import os
 import json
-from typing import Callable, Optional, Dict
-from distutils.util import strtobool
-
 import numpy as np
-from pydantic import BaseSettings
+
+from typing import Callable
 from functools import partial
-from mlserver.errors import MLServerError
 from mlserver.settings import ModelSettings
 
 from optimum.pipelines import pipeline as opt_pipeline
@@ -23,92 +19,12 @@ try:
 except ImportError:
     from optimum.pipelines import SUPPORTED_TASKS as SUPPORTED_OPTIMUM_TASKS
 
+from .settings import HuggingFaceSettings
+
 
 OPTIMUM_ACCELERATOR = "ort"
-ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
-PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
 
 _PipelineConstructor = Callable[..., Pipeline]
-
-
-class InvalidTranformerInitialisation(MLServerError):
-    def __init__(self, code: int, reason: str):
-        super().__init__(
-            f"Huggingface server failed with {code}, {reason}",
-            status_code=code,
-        )
-
-
-class HuggingFaceSettings(BaseSettings):
-    """
-    Parameters that apply only to HuggingFace models
-    """
-
-    class Config:
-        env_prefix = ENV_PREFIX_HUGGINGFACE_SETTINGS
-
-    task: str = ""
-    # Why need this filed?
-    # for translation task, required a suffix to specify source and target
-    # related issue: https://github.com/SeldonIO/MLServer/issues/947
-    task_suffix: str = ""
-    pretrained_model: Optional[str] = None
-    pretrained_tokenizer: Optional[str] = None
-    framework: Optional[str] = None
-    optimum_model: bool = False
-    device: int = -1
-
-    @property
-    def task_name(self):
-        if self.task == "translation":
-            return f"{self.task}{self.task_suffix}"
-        return self.task
-
-
-def parse_parameters_from_env() -> Dict:
-    """
-    This method parses the environment variables injected via SCv1.
-    """
-    # TODO: Once support for SCv1 is deprecated, we should remove this method and rely
-    # purely on settings coming via the `model-settings.json` file.
-    parameters = json.loads(os.environ.get(PARAMETERS_ENV_NAME, "[]"))
-
-    type_dict = {
-        "INT": int,
-        "FLOAT": float,
-        "DOUBLE": float,
-        "STRING": str,
-        "BOOL": bool,
-    }
-
-    parsed_parameters = {}
-    for param in parameters:
-        name = param.get("name")
-        value = param.get("value")
-        type_ = param.get("type")
-        if type_ == "BOOL":
-            parsed_parameters[name] = bool(strtobool(value))
-        else:
-            try:
-                parsed_parameters[name] = type_dict[type_](value)
-            except ValueError:
-                raise InvalidTranformerInitialisation(
-                    "Bad model parameter: "
-                    + name
-                    + " with value "
-                    + value
-                    + " can't be parsed as a "
-                    + type_,
-                    reason="MICROSERVICE_BAD_PARAMETER",
-                )
-            except KeyError:
-                raise InvalidTranformerInitialisation(
-                    "Bad model parameter type: "
-                    + type_
-                    + " valid are INT, FLOAT, DOUBLE, STRING, BOOL",
-                    reason="MICROSERVICE_BAD_PARAMETER",
-                )
-    return parsed_parameters
 
 
 def load_pipeline_from_settings(
@@ -117,11 +33,19 @@ def load_pipeline_from_settings(
     # TODO: Support URI for locally downloaded artifacts
     # uri = model_parameters.uri
     pipeline = _get_pipeline_class(hf_settings)
-    batch_size = 1 if settings.max_batch_size == 0 else settings.max_batch_size
+
+    batch_size = 1
+    if settings.max_batch_size:
+        batch_size = settings.max_batch_size
+
+    tokenizer = hf_settings.pretrained_tokenizer
+    if not tokenizer:
+        tokenizer = hf_settings.pretrained_model
+
     hf_pipeline = pipeline(
         hf_settings.task_name,
         model=hf_settings.pretrained_model,
-        tokenizer=hf_settings.tokenizer or hf_settings.pretrained_model,
+        tokenizer=tokenizer,
         device=hf_settings.device,
         batch_size=batch_size,
         framework=hf_settings.framework,
@@ -134,7 +58,7 @@ def load_pipeline_from_settings(
     return hf_pipeline
 
 
-def _get_pipeline_class(hf_settings: HuggingfaceSettings) -> _PipelineConstructor:
+def _get_pipeline_class(hf_settings: HuggingFaceSettings) -> _PipelineConstructor:
     if hf_settings.optimum_model:
         return partial(opt_pipeline, accelerator=OPTIMUM_ACCELERATOR)
 

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -66,8 +66,10 @@ class HuggingFaceSettings(BaseSettings):
 
 def parse_parameters_from_env() -> Dict:
     """
-    TODO
+    This method parses the environment variables injected via SCv1.
     """
+    # TODO: Once support for SCv1 is deprecated, we should remove this method and rely
+    # purely on settings coming via the `model-settings.json` file.
     parameters = json.loads(os.environ.get(PARAMETERS_ENV_NAME, "[]"))
 
     type_dict = {
@@ -130,9 +132,6 @@ def load_pipeline_from_settings(
             from_transformers=True,
         )
         tokenizer = AutoTokenizer.from_pretrained(tokenizer)
-        # Device needs to be set to -1 due to known issue
-        # https://github.com/huggingface/optimum/issues/191
-        device = -1
 
     batch_size = 1 if settings.max_batch_size == 0 else settings.max_batch_size
     pp = pipeline(

--- a/runtimes/huggingface/mlserver_huggingface/errors.py
+++ b/runtimes/huggingface/mlserver_huggingface/errors.py
@@ -1,0 +1,27 @@
+from mlserver.errors import MLServerError
+from transformers.pipelines import SUPPORTED_TASKS
+
+from .common import SUPPORTED_OPTIMUM_TASKS
+
+
+class MissingHuggingFaceSettings(MLServerError):
+    def __init__(self):
+        super().__init__("Missing HuggingFace Runtime settings.")
+
+
+class InvalidHuggingFaceTask(MLServerError):
+    def __init__(self, task: str):
+        msg = (
+            f"Invalid transformer task: {task}."
+            f" Available tasks: {SUPPORTED_TASKS.keys()}"
+        )
+        super().__init__(msg)
+
+
+class InvalidOptimumTask(MLServerError):
+    def __init__(self, task: str):
+        msg = (
+            "Invalid transformer task for Optimum model: {task}. "
+            f"Supported Optimum tasks: {SUPPORTED_OPTIMUM_TASKS.keys()}"
+        )
+        super().__init__(msg)

--- a/runtimes/huggingface/mlserver_huggingface/errors.py
+++ b/runtimes/huggingface/mlserver_huggingface/errors.py
@@ -25,3 +25,22 @@ class InvalidOptimumTask(MLServerError):
             f"Supported Optimum tasks: {SUPPORTED_OPTIMUM_TASKS.keys()}"
         )
         super().__init__(msg)
+
+
+class InvalidModelParameter(MLServerError):
+    def __init__(self, name: str, value: str, param_type: str):
+        msg = (
+            f"Bad model parameter: {name}"
+            f" with value {value}"
+            f" can't be parsed as a {param_type}"
+        )
+        super().__init__(msg)
+
+
+class InvalidModelParameterType(MLServerError):
+    def __init__(self, param_type: str):
+        msg = (
+            f"Bad model parameter type: {param_type}."
+            f" Only valid types are INT, FLOAT, DOUBLE, STRING, BOOL."
+        )
+        super().__init__(msg)

--- a/runtimes/huggingface/mlserver_huggingface/errors.py
+++ b/runtimes/huggingface/mlserver_huggingface/errors.py
@@ -1,7 +1,6 @@
-from mlserver.errors import MLServerError
-from transformers.pipelines import SUPPORTED_TASKS
+from typing import List
 
-from .common import SUPPORTED_OPTIMUM_TASKS
+from mlserver.errors import MLServerError
 
 
 class MissingHuggingFaceSettings(MLServerError):
@@ -9,20 +8,17 @@ class MissingHuggingFaceSettings(MLServerError):
         super().__init__("Missing HuggingFace Runtime settings.")
 
 
-class InvalidHuggingFaceTask(MLServerError):
-    def __init__(self, task: str):
-        msg = (
-            f"Invalid transformer task: {task}."
-            f" Available tasks: {SUPPORTED_TASKS.keys()}"
-        )
+class InvalidTransformersTask(MLServerError):
+    def __init__(self, task: str, available_tasks: List[str]):
+        msg = f"Invalid transformer task: {task}. Available tasks: {available_tasks}."
         super().__init__(msg)
 
 
 class InvalidOptimumTask(MLServerError):
-    def __init__(self, task: str):
+    def __init__(self, task: str, available_tasks: List[str]):
         msg = (
             "Invalid transformer task for Optimum model: {task}. "
-            f"Supported Optimum tasks: {SUPPORTED_OPTIMUM_TASKS.keys()}"
+            f"Available Optimum tasks: {available_tasks}."
         )
         super().__init__(msg)
 

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -47,7 +47,7 @@ class HuggingFaceRuntime(MLModel):
 
     async def load(self) -> bool:
         # Loading & caching pipeline in asyncio loop to avoid blocking
-        logger.info("Loading model for task '{self.hf_settings.task_name}'...")
+        logger.info(f"Loading model for task '{self.hf_settings.task_name}'...")
         await asyncio.get_running_loop().run_in_executor(
             None,
             load_pipeline_from_settings,

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -9,14 +9,13 @@ from transformers.pipelines import SUPPORTED_TASKS
 
 from mlserver.logging import logger
 
+from .settings import HuggingFaceSettings, parse_parameters_from_env
 from .errors import (
     MissingHuggingFaceSettings,
-    InvalidHugginFaceTask,
+    InvalidHuggingFaceTask,
     InvalidOptimumTask,
 )
 from .common import (
-    HuggingFaceSettings,
-    parse_parameters_from_env,
     load_pipeline_from_settings,
     SUPPORTED_OPTIMUM_TASKS,
 )
@@ -38,7 +37,7 @@ class HuggingFaceRuntime(MLModel):
         self.hf_settings = HuggingFaceSettings(**extra)  # type: ignore
 
         if self.hf_settings.task not in SUPPORTED_TASKS:
-            raise InvalidHugginFaceTask(self.hf_settings.task)
+            raise InvalidHuggingFaceTask(self.hf_settings.task)
 
         if self.hf_settings.optimum_model:
             if self.hf_settings.task not in SUPPORTED_OPTIMUM_TASKS:

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -5,6 +5,8 @@ from typing import Optional, Dict
 from pydantic import BaseSettings
 from distutils.util import strtobool
 
+from .errors import InvalidModelParameter, InvalidModelParameterType
+
 ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
 PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
 
@@ -26,7 +28,7 @@ class HuggingFaceSettings(BaseSettings):
 
     - `Optimum Tasks <https://huggingface.co/docs/optimum/onnxruntime/usage_guides/pipelines#inference-pipelines-with-the-onnx-runtime-accelerator>`_
     - `Transformer Tasks <https://huggingface.co/docs/transformers/task_summary>`_
-    """
+    """  # noqa: E501
 
     task_suffix: str = ""
     """
@@ -98,20 +100,7 @@ def parse_parameters_from_env() -> Dict:
             try:
                 parsed_parameters[name] = type_dict[type_](value)
             except ValueError:
-                raise InvalidTranformerInitialisation(
-                    "Bad model parameter: "
-                    + name
-                    + " with value "
-                    + value
-                    + " can't be parsed as a "
-                    + type_,
-                    reason="MICROSERVICE_BAD_PARAMETER",
-                )
+                raise InvalidModelParameter(name, value, type_)
             except KeyError:
-                raise InvalidTranformerInitialisation(
-                    "Bad model parameter type: "
-                    + type_
-                    + " valid are INT, FLOAT, DOUBLE, STRING, BOOL",
-                    reason="MICROSERVICE_BAD_PARAMETER",
-                )
+                raise InvalidModelParameterType(type_)
     return parsed_parameters

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -19,15 +19,50 @@ class HuggingFaceSettings(BaseSettings):
 
     # TODO: Document fields
     task: str = ""
-    # Why need this filed?
-    # for translation task, required a suffix to specify source and target
-    # related issue: https://github.com/SeldonIO/MLServer/issues/947
+    """
+    Pipeline task to load.
+    You can see the available Optimum and Transformers tasks available in the
+    links below:
+
+    - `Optimum Tasks <https://huggingface.co/docs/optimum/onnxruntime/usage_guides/pipelines#inference-pipelines-with-the-onnx-runtime-accelerator>`_
+    - `Transformer Tasks <https://huggingface.co/docs/transformers/task_summary>`_
+    """
+
     task_suffix: str = ""
+    """
+    Suffix to append to the base task name.
+    Useful for, e.g. translation tasks which require a suffix on the task name
+    to specify source and target.
+    """
+
     pretrained_model: Optional[str] = None
+    """
+    Name of the model that should be loaded in the pipeline.
+    """
+
     pretrained_tokenizer: Optional[str] = None
+    """
+    Name of the tokenizer that should be loaded in the pipeline.
+    """
+
     framework: Optional[str] = None
+    """
+    The framework to use, either "pt" for PyTorch or "tf" for TensorFlow.
+    """
+
     optimum_model: bool = False
+    """
+    Flag to decide whether the pipeline should use a Optimum-optimised model or
+    the standard Transformers model.
+    Under the hood, this will enable the model to use the optimised ONNX
+    runtime.
+    """
+
     device: int = -1
+    """
+    Device in which this pipeline will be loaded (e.g., "cpu", "cuda:1", "mps",
+    or a GPU ordinal rank like 1).
+    """
 
     @property
     def task_name(self):

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -1,0 +1,82 @@
+import os
+import orjson
+
+from typing import Optional, Dict
+from pydantic import BaseSettings
+from distutils.util import strtobool
+
+ENV_PREFIX_HUGGINGFACE_SETTINGS = "MLSERVER_MODEL_HUGGINGFACE_"
+PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
+
+
+class HuggingFaceSettings(BaseSettings):
+    """
+    Parameters that apply only to HuggingFace models
+    """
+
+    class Config:
+        env_prefix = ENV_PREFIX_HUGGINGFACE_SETTINGS
+
+    # TODO: Document fields
+    task: str = ""
+    # Why need this filed?
+    # for translation task, required a suffix to specify source and target
+    # related issue: https://github.com/SeldonIO/MLServer/issues/947
+    task_suffix: str = ""
+    pretrained_model: Optional[str] = None
+    pretrained_tokenizer: Optional[str] = None
+    framework: Optional[str] = None
+    optimum_model: bool = False
+    device: int = -1
+
+    @property
+    def task_name(self):
+        if self.task == "translation":
+            return f"{self.task}{self.task_suffix}"
+        return self.task
+
+
+def parse_parameters_from_env() -> Dict:
+    """
+    This method parses the environment variables injected via SCv1.
+    """
+    # TODO: Once support for SCv1 is deprecated, we should remove this method and rely
+    # purely on settings coming via the `model-settings.json` file.
+    parameters = orjson.loads(os.environ.get(PARAMETERS_ENV_NAME, "[]"))
+
+    type_dict = {
+        "INT": int,
+        "FLOAT": float,
+        "DOUBLE": float,
+        "STRING": str,
+        "BOOL": bool,
+    }
+
+    parsed_parameters = {}
+    for param in parameters:
+        name = param.get("name")
+        value = param.get("value")
+        type_ = param.get("type")
+        if type_ == "BOOL":
+            parsed_parameters[name] = bool(strtobool(value))
+        else:
+            try:
+                parsed_parameters[name] = type_dict[type_](value)
+            except ValueError:
+                raise InvalidTranformerInitialisation(
+                    "Bad model parameter: "
+                    + name
+                    + " with value "
+                    + value
+                    + " can't be parsed as a "
+                    + type_,
+                    reason="MICROSERVICE_BAD_PARAMETER",
+                )
+            except KeyError:
+                raise InvalidTranformerInitialisation(
+                    "Bad model parameter type: "
+                    + type_
+                    + " valid are INT, FLOAT, DOUBLE, STRING, BOOL",
+                    reason="MICROSERVICE_BAD_PARAMETER",
+                )
+    return parsed_parameters

--- a/runtimes/huggingface/setup.py
+++ b/runtimes/huggingface/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         "mlserver",
         "optimum[onnxruntime]>=1.4.0, <1.8.0",
-        "transformers",
         "Pillow",
     ],
     long_description=_load_description(),

--- a/runtimes/huggingface/tests/conftest.py
+++ b/runtimes/huggingface/tests/conftest.py
@@ -3,9 +3,6 @@ import asyncio
 
 from mlserver.utils import install_uvloop_event_loop
 from mlserver.types import InferenceRequest, RequestInput
-from mlserver.settings import ModelSettings, ModelParameters
-
-from mlserver_huggingface import HuggingFaceRuntime
 
 
 # test a prediction spend long time, so add this command argument to enable test tasks
@@ -14,7 +11,7 @@ def pytest_addoption(parser):
     parser.addoption("--test-hg-tasks", action="store_true", default=False)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def event_loop():
     # NOTE: We need to override the `event_loop` fixture to change its scope to
     # `module`, so that it can be used downstream on other `module`-scoped
@@ -23,26 +20,6 @@ def event_loop():
     loop = asyncio.get_event_loop()
     yield loop
     loop.close()
-
-
-@pytest.fixture(scope="module")
-def model_settings() -> ModelSettings:
-    return ModelSettings(
-        name="foo",
-        implementation=HuggingFaceRuntime,
-        parameters=ModelParameters(
-            extra={
-                "task": "question-answering",
-            }
-        ),
-    )
-
-
-@pytest.fixture(scope="module")
-async def runtime(model_settings: ModelSettings) -> HuggingFaceRuntime:
-    runtime = HuggingFaceRuntime(model_settings)
-    runtime.ready = await runtime.load()
-    return runtime
 
 
 @pytest.fixture

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -1,6 +1,8 @@
 import pytest
+
 from typing import Dict
-from mlserver_huggingface.common import HuggingFaceSettings
+
+from mlserver_huggingface.settings import HuggingFaceSettings
 
 
 @pytest.mark.parametrize(

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -1,8 +1,16 @@
 import pytest
 
 from typing import Dict
+from optimum.onnxruntime.modeling_ort import ORTModelForQuestionAnswering
+from transformers.models.distilbert.modeling_distilbert import (
+    DistilBertForQuestionAnswering,
+)
 
+from mlserver.settings import ModelSettings, ModelParameters
+
+from mlserver_huggingface.runtime import HuggingFaceRuntime
 from mlserver_huggingface.settings import HuggingFaceSettings
+from mlserver_huggingface.common import load_pipeline_from_settings
 
 
 @pytest.mark.parametrize(
@@ -18,3 +26,22 @@ from mlserver_huggingface.settings import HuggingFaceSettings
 def test_settings_task_name(envs: Dict[str, str], expected: str):
     setting = HuggingFaceSettings(**envs)
     assert setting.task_name == expected
+
+
+@pytest.mark.parametrize(
+    "optimum_model, expected",
+    [(True, ORTModelForQuestionAnswering), (False, DistilBertForQuestionAnswering)],
+)
+def test_load_pipeline(optimum_model: bool, expected):
+    hf_settings = HuggingFaceSettings(
+        task="question-answering", optimum_model=optimum_model
+    )
+    model_settings = ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(extra=hf_settings.dict()),
+    )
+
+    pipeline = load_pipeline_from_settings(hf_settings, model_settings)
+
+    assert isinstance(pipeline.model, expected)

--- a/runtimes/huggingface/tests/test_runtime_cases.py
+++ b/runtimes/huggingface/tests/test_runtime_cases.py
@@ -1,0 +1,24 @@
+from mlserver.settings import ModelSettings, ModelParameters
+from mlserver_huggingface import HuggingFaceRuntime
+
+
+def case_optimum_settings() -> ModelSettings:
+    return ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(
+            extra={"task": "question-answering", "optimum_model": True}
+        ),
+    )
+
+
+def case_transformers_settings() -> ModelSettings:
+    return ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(
+            extra={
+                "task": "question-answering",
+            }
+        ),
+    )


### PR DESCRIPTION
Fixes #870
Fixes #852
Fixes #786

## Changelog
- Use `accelerator='ort'` to load Optimum models (as opposed to previous `from_transformers=True` kwarg)
- Document available HuggingFace extra settings
- Enable GPU usage for Optimum models