### PR TITLE
Undo changes to pipelines

### DIFF
--- a/.github/workflows/release-sc.yml
+++ b/.github/workflows/release-sc.yml
@@ -40,6 +40,13 @@ jobs:
             -t $MLSERVER_IMAGE
         env:
           MLSERVER_IMAGE: seldonio/mlserver-sc:${{ github.event.inputs.version }}
+      - name: Scan Docker Image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: seldonio/mlserver-sc:${{ github.event.inputs.version }}
+          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -99,6 +106,13 @@ jobs:
             -t $MLSERVER_IMAGE
         env:
           MLSERVER_IMAGE: seldonio/mlserver-sc-slim:${{ github.event.inputs.version }}
+      - name: Scan Docker Image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: seldonio/mlserver-sc-slim:${{ github.event.inputs.version }}
+          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -143,27 +157,3 @@ jobs:
           PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
           PROJECT_ID: 63567143624969b495b69370
           QUAY_MLSERVER_IMAGE: quay.io/redhat-isv-containers/63567143624969b495b69370:${{ github.event.inputs.version }}
-
-  mlserver-sc-scan:
-    # NOTE: Scanning the full image after building it makes the worker run out
-    # of space, so we'll scan them after building and pushing to Docker Hub in
-    # a separate job.
-    needs:
-      - mlserver-sc
-      - mlserver-sc-slim
-    runs-on: ubuntu-latest
-    steps:
-      - name: Scan Docker Image
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: seldonio/mlserver-sc:${{ github.event.inputs.version }}
-          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
-      - name: Scan Docker Image
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: seldonio/mlserver-sc-slim:${{ github.event.inputs.version }}
-          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,6 @@ jobs:
     needs: draft-release
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          remove-dotnet: "true"
-          remove-haskell: "true"
-          remove-android: "true"
-          root-reserve-mb: "40960"
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
@@ -67,6 +60,20 @@ jobs:
             -t $MLSERVER_IMAGE
         env:
           MLSERVER_IMAGE: seldonio/mlserver:${{ github.event.inputs.version }}
+      - name: Scan Docker Image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: seldonio/mlserver:${{ github.event.inputs.version }}
+          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
+      - name: Scan Docker Slim Image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: seldonio/mlserver:${{ github.event.inputs.version }}-slim
+          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -121,31 +128,6 @@ jobs:
           PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
           PROJECT_ID: 63566bb9822ce8cef9ba27fc
           QUAY_MLSERVER_IMAGE: quay.io/redhat-isv-containers/63566bb9822ce8cef9ba27fc:${{ github.event.inputs.version }}
-
-  mlserver-scan:
-    # NOTE: Scanning the full image after building it makes the worker run out
-    # of space, so we'll scan them after building and pushing to Docker Hub in
-    # a separate job.
-    needs: mlserver
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
-      - name: Scan Docker Image
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: seldonio/mlserver:${{ github.event.inputs.version }}
-          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
-      - name: Scan Docker Slim Image
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: seldonio/mlserver:${{ github.event.inputs.version }}-slim
-          args: --fail-on=upgradable --app-vulns --severity-threshold=high --file=Dockerfile
 
   runtimes:
     needs: draft-release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,13 +37,13 @@ jobs:
         run: snyk test \
           --fail-on=upgradable \
           --severity-threshold=high \
-          --sarif-file-output=snyk.sarif
+          --sarif-file-output=snyk-code.sarif
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: snyk.sarif
+          sarif_file: snyk-code.sarif
 
   scan-image:
     runs-on: ubuntu-latest
@@ -65,10 +65,10 @@ jobs:
             --app-vulns
             --severity-threshold=high
             --file=Dockerfile
-            --sarif-file-output=snyk.sarif
+            --sarif-file-output=snyk-image.sarif
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: snyk.sarif
+          sarif_file: snyk-image.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan:
+  scan-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snyk/actions/setup@master
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          make install-dev
+      - name: Create requirements.txt
+        run: |
+          # Snyk has issues working with complex setup.py files (e.g.
+          # https://github.com/snyk/cli/issues/1367).
+          # To account for this, we set up the environment and then dump it
+          # into a `requirements.txt` - this env includes both production and
+          # development dependencies.
+          # TODO: Once we move into Poetry, this can be replaced for the lock
+          # file.
+          pip freeze > requirements.txt
+      - name: Security Scan
+        continue-on-error: true
+        run: snyk test \
+          --fail-on=upgradable \
+          --severity-threshold=high \
+          --sarif-file-output=snyk.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+
+  scan-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,30 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: snyk/actions/setup@master
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
+      - name: Build Docker Image
         run: |
-          make install-dev
-      - name: Create requirements.txt
-        run: |
-          # Snyk has issues working with complex setup.py files (e.g.
-          # https://github.com/snyk/cli/issues/1367).
-          # To account for this, we set up the environment and then dump it
-          # into a `requirements.txt` - this env includes both production and
-          # development dependencies.
-          # TODO: Once we move into Poetry, this can be replaced for the lock
-          # file.
-          pip freeze > requirements.txt
-      - name: Security Scan
+          DOCKER_BUILDKIT=1 docker build . \
+            --build-arg RUNTIMES=all \
+            -t $MLSERVER_IMAGE
+        env:
+          MLSERVER_IMAGE: seldonio/mlserver:${{ github.sha }}
+      - name: Scan Docker Image
+        uses: snyk/actions/docker@master
         continue-on-error: true
-        run: snyk test \
-          --fail-on=upgradable \
-          --severity-threshold=high \
-          --sarif-file-output=snyk.sarif
+        with:
+          image: seldonio/mlserver:${{ github.sha }}
+          args: --fail-on=upgradable
+            --app-vulns
+            --severity-threshold=high
+            --file=Dockerfile
+            --sarif-file-output=snyk.sarif
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload result to GitHub Code Scanning


### PR DESCRIPTION
Now that the image size has been considerably shrinked, we can try to undo the changes to the release and security pipelines.