### PR TITLE
Move OpenAPI schemas into Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include openapi/*.json
+include mlserver/rest/openapi/*.json

--- a/mlserver/rest/openapi/__init__.py
+++ b/mlserver/rest/openapi/__init__.py
@@ -1,0 +1,3 @@
+from .schema import get_openapi_schema, get_model_schema, get_model_schema_uri
+
+__all__ = ["get_openapi_schema", "get_model_schema", "get_model_schema_uri"]

--- a/mlserver/rest/openapi/dataplane.json
+++ b/mlserver/rest/openapi/dataplane.json
@@ -1,1 +1,1 @@
-/home/agm/Seldon/mlserver/openapi/dataplane.json
+../../../openapi/dataplane.json

--- a/mlserver/rest/openapi/dataplane.json
+++ b/mlserver/rest/openapi/dataplane.json
@@ -1,0 +1,1 @@
+/home/agm/Seldon/mlserver/openapi/dataplane.json

--- a/mlserver/rest/openapi/model_repository.json
+++ b/mlserver/rest/openapi/model_repository.json
@@ -1,1 +1,1 @@
-/home/agm/Seldon/mlserver/openapi/model_repository.json
+../../../openapi/model_repository.json

--- a/mlserver/rest/openapi/model_repository.json
+++ b/mlserver/rest/openapi/model_repository.json
@@ -1,0 +1,1 @@
+/home/agm/Seldon/mlserver/openapi/model_repository.json

--- a/mlserver/rest/openapi/schema.py
+++ b/mlserver/rest/openapi/schema.py
@@ -4,15 +4,13 @@ from functools import lru_cache
 from typing import Optional, Tuple
 from importlib_resources import files
 
-OPENAPI_SCHEMA_RELATIVE_PATH = "../openapi/dataplane.json"
 MODEL_NAME_PARAMETER = "model_name"
 MODEL_VERSION_PARAMETER = "model_version"
 
 
 @lru_cache
 def get_openapi_schema() -> dict:
-    mlserver_package = __package__.split(".")[0]
-    openapi_schema_path = files(mlserver_package).joinpath(OPENAPI_SCHEMA_RELATIVE_PATH)
+    openapi_schema_path = files(__package__).joinpath("dataplane.json")
     return orjson.loads(openapi_schema_path.read_bytes())
 
 

--- a/tests/rest/openapi/test_schema.py
+++ b/tests/rest/openapi/test_schema.py
@@ -2,7 +2,7 @@ import pytest
 
 from typing import Optional
 
-from mlserver.rest.openapi import (
+from mlserver.rest.openapi.schema import (
     get_openapi_schema,
     get_model_schema,
     MODEL_VERSION_PARAMETER,


### PR DESCRIPTION
Fixes #1093 

## Changelog
- Add OpenAPI schema under `mlserver.rest.openapi` package as symbolic links (i.e. files in root repo remain source-of-truth) 