### PR TITLE
Use default initialiser if not using a custom env

### DIFF
--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -130,6 +130,12 @@ class InferencePoolRegistry:
             # as normal.
             return model_initialiser(model_settings)
 
+        parameters = model_settings.parameters
+        if not parameters or not parameters.environment_tarball:
+            # If model is not using a custom environment, instantiate the model
+            # as normal.
+            return model_initialiser(model_settings)
+
         # Otherwise, return a dummy model for now and wait for the load_model
         # hook to create the actual thing.
         # This avoids instantiating the model's actual class within the

--- a/runtimes/alibi-explain/tests/conftest.py
+++ b/runtimes/alibi-explain/tests/conftest.py
@@ -115,6 +115,7 @@ async def model_registry(
         on_model_load=[inference_pool_registry.load_model],
         on_model_reload=[inference_pool_registry.reload_model],
         on_model_unload=[inference_pool_registry.unload_model],
+        model_initialiser=inference_pool_registry.model_initialiser,
     )
 
     await model_registry.load(custom_runtime_tf_settings)

--- a/runtimes/mlflow/tests/rest/conftest.py
+++ b/runtimes/mlflow/tests/rest/conftest.py
@@ -71,6 +71,7 @@ async def model_registry(
         on_model_load=[inference_pool_registry.load_model],
         on_model_reload=[inference_pool_registry.reload_model],
         on_model_unload=[inference_pool_registry.unload_model],
+        model_initialiser=inference_pool_registry.model_initialiser,
     )
 
     await model_registry.load(model_settings)

--- a/tests/grpc/conftest.py
+++ b/tests/grpc/conftest.py
@@ -37,6 +37,7 @@ async def model_registry(
         on_model_load=[inference_pool_registry.load_model, load_batching],
         on_model_reload=[inference_pool_registry.reload_model],
         on_model_unload=[inference_pool_registry.unload_model],
+        model_initialiser=inference_pool_registry.model_initialiser,
     )
 
     model_name = sum_model_settings.name

--- a/tests/rest/conftest.py
+++ b/tests/rest/conftest.py
@@ -22,6 +22,7 @@ async def model_registry(
         on_model_load=[inference_pool_registry.load_model, load_batching],
         on_model_reload=[inference_pool_registry.reload_model],
         on_model_unload=[inference_pool_registry.unload_model],
+        model_initialiser=inference_pool_registry.model_initialiser,
     )
 
     model_name = sum_model_settings.name


### PR DESCRIPTION
Fixes #1101 

## Changelog

- When loading a model, use the default initialiser if the model doesn't use any custom environments