### PR TITLE
Add support for online drift detectors

### DIFF
--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -144,7 +144,7 @@ class AlibiDetectRuntime(MLModel):
             )
 
         # Add headers
-        y["meta"]["headers"] = {  # TODO - if we want to viz the sliding windows, where should we store window size?
+        y["meta"]["headers"] = {
             "x-seldon-alibi-type": self.alibi_type,
             "x-seldon-alibi-method": self.alibi_method,
         }

--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 from pydantic.error_wrappers import ValidationError
-from typing import Optional, List, Union
+from typing import Optional, List
 from pydantic import BaseSettings, Field
 from functools import cached_property
 
@@ -75,11 +75,11 @@ class AlibiDetectRuntime(MLModel):
             else:
                 self._ad_settings.state_save_freq = None
         except (
-                ValueError,
-                FileNotFoundError,
-                EOFError,
-                NotImplementedError,
-                ValidationError,
+            ValueError,
+            FileNotFoundError,
+            EOFError,
+            NotImplementedError,
+            ValidationError,
         ) as e:
             raise MLServerError(
                 f"Invalid configuration for model {self._settings.name}: {e}"
@@ -160,7 +160,15 @@ class AlibiDetectRuntime(MLModel):
         )
 
     @staticmethod
-    def _postproc_pred(pred: Union[dict, List[dict]]) -> dict:
+    def _postproc_pred(pred: List[dict]) -> dict:
+        """
+        Postprocess the detector's prediction(s) to return a single results dictionary.
+
+        - If a single instance (or batch of instances) was run, the predictions will be a length 1 list containing one
+        dictionary, which is returned as is.
+        - If N instances were run in an online fashion, the predictions will be a length N list of results dictionaries,
+        which are merged into a single dictionary containing data lists of length N.
+        """
         data = {key: [] for key in pred[0]['data'].keys()}
         for i, pred_i in enumerate(pred):
             for key in data:

--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from pydantic.error_wrappers import ValidationError
 from typing import Optional, List, Union
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field
 from functools import cached_property
 
 from alibi_detect.saving import load_detector
@@ -42,7 +42,7 @@ class AlibiDetectSettings(BaseSettings):
     inference runs for all of them).
     """
 
-    state_save_freq: Optional[int] = 100  # TODO - need to check != 0
+    state_save_freq: Optional[int] = Field(100, gt=0)
     """
     Save the detector state after every `state_save_freq` predictions.
     Only applicable to detectors with a `save_state` method.

--- a/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
+++ b/runtimes/alibi-detect/mlserver_alibi_detect/runtime.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 from pydantic.error_wrappers import ValidationError
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pydantic import BaseSettings, Field
 from functools import cached_property
 
@@ -118,7 +118,7 @@ class AlibiDetectRuntime(MLModel):
         # If batch is configured or X has length 1, wrap X in a list to avoid unpacking
         X = np.array(input_data)
         if not self._online or len(input_data) == 1:
-            X = [X]
+            X = [X]  # type: ignore[assignment]
 
         # Run detector inference
         pred = []
@@ -166,7 +166,7 @@ class AlibiDetectRuntime(MLModel):
         length N list of results dictionaries, which are merged into a single
         dictionary containing data lists of length N.
         """
-        data = {key: [] for key in pred[0]["data"].keys()}
+        data: Dict[str, list] = {key: [] for key in pred[0]["data"].keys()}
         for i, pred_i in enumerate(pred):
             for key in data:
                 data[key].append(pred_i["data"][key])

--- a/runtimes/alibi-detect/tests/conftest.py
+++ b/runtimes/alibi-detect/tests/conftest.py
@@ -137,7 +137,10 @@ def online_drift_detector_settings(
         parameters=ModelParameters(
             uri=online_drift_detector_uri,
             version="v1.2.3",  # TODO - should this match version.py?
-            extra={"batch_size": 50, "state_save_freq": 10},  # spec batch_size to check that it is ignored
+            extra={
+                "batch_size": 50,
+                "state_save_freq": 10,
+            },  # spec batch_size to check that it is ignored
         ),
     )
 
@@ -175,7 +178,9 @@ async def drift_detector(drift_detector_settings: ModelSettings) -> AlibiDetectR
 
 
 @pytest.fixture
-async def online_drift_detector(online_drift_detector_settings: ModelSettings) -> AlibiDetectRuntime:
+async def online_drift_detector(
+    online_drift_detector_settings: ModelSettings,
+) -> AlibiDetectRuntime:
     model = AlibiDetectRuntime(online_drift_detector_settings)
     model.ready = await model.load()
 

--- a/runtimes/alibi-detect/tests/conftest.py
+++ b/runtimes/alibi-detect/tests/conftest.py
@@ -5,7 +5,7 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow.keras.layers import Dense, InputLayer
-from alibi_detect.cd import TabularDrift
+from alibi_detect.cd import TabularDrift, CVMDriftOnline
 from alibi_detect.od import OutlierVAE
 from alibi_detect.saving import save_detector
 
@@ -18,6 +18,8 @@ from mlserver_alibi_detect import AlibiDetectRuntime
 tf.keras.backend.clear_session()
 
 P_VAL_THRESHOLD = 0.05
+ERT = 50
+WINDOW_SIZES = [10]
 
 TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
@@ -126,6 +128,21 @@ def drift_detector_settings(
 
 
 @pytest.fixture
+def online_drift_detector_settings(
+    online_drift_detector_uri: str,
+) -> ModelSettings:
+    return ModelSettings(
+        name="alibi-detect-model",
+        implementation=AlibiDetectRuntime,
+        parameters=ModelParameters(
+            uri=online_drift_detector_uri,
+            version="v1.2.3",  # TODO - should this match version.py?
+            extra={"batch_size": 50, "state_save_freq": 10},  # spec batch_size to check that it is ignored
+        ),
+    )
+
+
+@pytest.fixture
 def drift_detector_uri(tmp_path: str) -> str:
     X_ref = np.array([[1, 2, 3]])
 
@@ -138,8 +155,28 @@ def drift_detector_uri(tmp_path: str) -> str:
 
 
 @pytest.fixture
+def online_drift_detector_uri(tmp_path: str) -> str:
+    X_ref = np.ones((10, 3))
+
+    cd = CVMDriftOnline(X_ref, ert=ERT, window_sizes=WINDOW_SIZES)
+
+    detector_uri = os.path.join(tmp_path, "alibi-detector-artifacts")
+    save_detector(cd, detector_uri)
+
+    return detector_uri
+
+
+@pytest.fixture
 async def drift_detector(drift_detector_settings: ModelSettings) -> AlibiDetectRuntime:
     model = AlibiDetectRuntime(drift_detector_settings)
+    model.ready = await model.load()
+
+    return model
+
+
+@pytest.fixture
+async def online_drift_detector(online_drift_detector_settings: ModelSettings) -> AlibiDetectRuntime:
+    model = AlibiDetectRuntime(online_drift_detector_settings)
     model.ready = await model.load()
 
     return model

--- a/runtimes/alibi-detect/tests/conftest.py
+++ b/runtimes/alibi-detect/tests/conftest.py
@@ -136,7 +136,7 @@ def online_drift_detector_settings(
         implementation=AlibiDetectRuntime,
         parameters=ModelParameters(
             uri=online_drift_detector_uri,
-            version="v1.2.3",  # TODO - should this match version.py?
+            version="v1.2.3",
             extra={
                 "batch_size": 50,
                 "state_save_freq": 10,

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -1,13 +1,18 @@
 import numpy as np
 
-from alibi_detect.cd import TabularDrift
+from alibi_detect.cd import TabularDrift, CVMDriftOnline
 
-from mlserver.types import InferenceRequest
-from mlserver.codecs import NumpyRequestCodec
+from mlserver.types import (
+    InferenceRequest,
+    Parameters,
+    RequestInput
+)
+
+from mlserver.codecs import NumpyCodec, NumpyRequestCodec
 
 from mlserver_alibi_detect import AlibiDetectRuntime
 
-from .conftest import P_VAL_THRESHOLD
+from .conftest import P_VAL_THRESHOLD, ERT, WINDOW_SIZES
 
 
 async def test_load_folder(
@@ -15,6 +20,13 @@ async def test_load_folder(
 ):
     assert drift_detector.ready
     assert type(drift_detector._model) == TabularDrift
+
+
+async def test_load_folder_online(
+    online_drift_detector: AlibiDetectRuntime,
+):
+    assert online_drift_detector.ready
+    assert type(online_drift_detector._model) == CVMDriftOnline
 
 
 async def test_predict(
@@ -79,3 +91,59 @@ async def test_predict_batch_cleared(
     # Batch should now be cleared (and started from scratch)
     response = await drift_detector.predict(inference_request)
     assert len(response.outputs) == 0
+
+
+async def test_predict_online(
+    online_drift_detector: AlibiDetectRuntime,
+    inference_request: InferenceRequest,
+):
+    # Test a request of length 1
+    response = await online_drift_detector.predict(inference_request)
+    assert len(response.outputs) == 7
+    assert response.outputs[0].name == "is_drift"
+    assert response.outputs[0].shape == [1, 1]
+    assert response.outputs[1].name == "distance"
+    assert response.outputs[2].name == "p_val"
+    assert response.outputs[3].name == "threshold"
+    assert response.outputs[4].name == "time"
+    assert response.outputs[4].data[0] == 1
+    assert response.outputs[5].name == "ert"
+    assert response.outputs[5].data[0] == ERT
+    assert response.outputs[6].name == "test_stat"
+    assert response.outputs[6].shape == [1, 1, 3]
+
+
+async def test_predict_batch_online(
+    online_drift_detector: AlibiDetectRuntime
+):
+    # Send a batch request, the drift detector should run on one instance at a time
+    batch_size = 50
+    data = np.random.normal(size=(batch_size, 3))
+    inference_request = InferenceRequest(
+        parameters=Parameters(content_type=NumpyRequestCodec.ContentType),
+        inputs=[
+            RequestInput(
+                name="predict",
+                shape=data.shape,
+                data=data.tolist(),
+                datatype="FP32",
+            )
+        ],
+    )
+    response = await online_drift_detector.predict(inference_request)
+    assert len(response.outputs) == 7
+    assert response.outputs[0].name == "is_drift"
+    assert response.outputs[0].shape == [50, 1]
+    assert response.outputs[1].name == "distance"
+    assert response.outputs[2].name == "p_val"
+    assert response.outputs[3].name == "threshold"
+    assert response.outputs[4].name == "time"
+    assert response.outputs[4].data[-1] == 50
+    assert response.outputs[5].name == "ert"
+    assert response.outputs[5].data[0] == ERT
+    assert response.outputs[6].name == "test_stat"
+    assert response.outputs[6].shape == [50, 1, 3]
+    # Test stat should be NaN until the test window is filled
+    test_stats = NumpyCodec.decode_output(response.outputs[6])
+    assert np.isnan(test_stats[0]).all()
+    assert not np.isnan(test_stats[WINDOW_SIZES[0]]).all()

--- a/runtimes/alibi-detect/tests/test_drift_detector.py
+++ b/runtimes/alibi-detect/tests/test_drift_detector.py
@@ -2,11 +2,7 @@ import numpy as np
 
 from alibi_detect.cd import TabularDrift, CVMDriftOnline
 
-from mlserver.types import (
-    InferenceRequest,
-    Parameters,
-    RequestInput
-)
+from mlserver.types import InferenceRequest, Parameters, RequestInput
 
 from mlserver.codecs import NumpyCodec, NumpyRequestCodec
 
@@ -113,9 +109,7 @@ async def test_predict_online(
     assert response.outputs[6].shape == [1, 1, 3]
 
 
-async def test_predict_batch_online(
-    online_drift_detector: AlibiDetectRuntime
-):
+async def test_predict_batch_online(online_drift_detector: AlibiDetectRuntime):
     # Send a batch request, the drift detector should run on one instance at a time
     batch_size = 50
     data = np.random.normal(size=(batch_size, 3))

--- a/runtimes/alibi-detect/tests/test_runtime.py
+++ b/runtimes/alibi-detect/tests/test_runtime.py
@@ -24,7 +24,7 @@ async def test_saving_state(
     inference_request: InferenceRequest,
 ):
     save_freq = online_drift_detector._ad_settings.state_save_freq
-    state_uri = os.path.join(online_drift_detector._model_uri, 'state')
+    state_uri = os.path.join(online_drift_detector._model_uri, "state")
 
     # Check nothing written after (save_freq -1) requests
     for _ in range(save_freq - 1):  # type: ignore

--- a/runtimes/alibi-detect/tests/test_runtime.py
+++ b/runtimes/alibi-detect/tests/test_runtime.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from mlserver.codecs import CodecError
@@ -16,3 +17,25 @@ async def test_multiple_inputs_error(
 
     with pytest.raises(CodecError):
         await outlier_detector.predict(inference_request)
+
+
+async def test_saving_state(
+    online_drift_detector: AlibiDetectRuntime,
+    inference_request: InferenceRequest,
+):
+    save_freq = online_drift_detector._ad_settings.state_save_freq
+    state_uri = os.path.join(online_drift_detector._model_uri, 'state')
+
+    # Check nothing written after (save_freq -1) requests
+    for _ in range(save_freq - 1):  # type: ignore
+        await online_drift_detector.predict(inference_request)
+    assert not os.path.isdir(state_uri)
+
+    # Check state written after (save_freq) requests
+    await online_drift_detector.predict(inference_request)
+    assert os.path.isdir(state_uri)
+
+    # Check state properly loaded in new runtime
+    new_online_drift_detector = AlibiDetectRuntime(online_drift_detector.settings)
+    await new_online_drift_detector.load()
+    assert new_online_drift_detector._model.t == save_freq


### PR DESCRIPTION
This PR adds support for [online drift detectors](https://docs.seldon.io/projects/alibi-detect/en/stable/cd/methods.html#online) to Alibi Detect runtime. 

## Overview

This involves two primary changes:
1. Online drift detectors are run on one instance at a time, with the time-step `self.t` updated each time. If a request contains a batch of instances, the payload must be unpacked and passed to the detector one instance at a time.
2. Online drift detectors have state, which must be periodically saved for checkpointing. State is saved every `state_save_freq` time-steps, where `state_save_freq` is a new configurable parameter added to `AlibiDetectSettings`.

## Limitations

Parallel inference is NOT currently supported for online detectors (i.e. `parallel_workers=0` is required). This would require careful thought wrt to how state is managed/shared across parallel workers, in addition to considering the implications of distributing non-iid samples between workers. 

## TODO's

- [x] Documentation? - _should be auto-completed pending https://github.com/SeldonIO/MLServer/pull/1109_
- [x] Linting