### PR TITLE
Fix content type annotations for pandas codecs

### DIFF
--- a/mlserver/codecs/base64.py
+++ b/mlserver/codecs/base64.py
@@ -4,7 +4,7 @@ import binascii
 from typing import Any, List, Union
 from functools import partial
 
-from ..types import RequestInput, ResponseOutput
+from ..types import RequestInput, ResponseOutput, Parameters
 from .lists import is_list_of
 from .base import InputCodec, register_input_codec
 from .lists import as_list, ListElement
@@ -64,6 +64,7 @@ class Base64Codec(InputCodec):
             datatype="BYTES",
             shape=shape,
             data=list(packed),
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod
@@ -82,6 +83,7 @@ class Base64Codec(InputCodec):
             datatype=output.datatype,
             shape=output.shape,
             data=output.data,
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod

--- a/mlserver/codecs/datetime.py
+++ b/mlserver/codecs/datetime.py
@@ -2,7 +2,7 @@ from typing import Any, Union, List
 from datetime import datetime
 from functools import partial
 
-from ..types import RequestInput, ResponseOutput
+from ..types import RequestInput, ResponseOutput, Parameters
 from .lists import is_list_of, as_list, ListElement
 from .base import InputCodec, register_input_codec
 
@@ -62,6 +62,7 @@ class DatetimeCodec(InputCodec):
             datatype="BYTES",
             shape=shape,
             data=list(packed),
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod
@@ -80,6 +81,7 @@ class DatetimeCodec(InputCodec):
             datatype=output.datatype,
             shape=output.shape,
             data=output.data,
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -119,6 +119,7 @@ class NumpyCodec(InputCodec):
             datatype=datatype,
             shape=shape,
             data=_encode_data(payload, datatype),
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -56,13 +56,13 @@ def _to_response_output(series: pd.Series, use_bytes: bool = True) -> ResponseOu
 
 def _process_bytes(
     data: List[ListElement], use_bytes: bool = True
-) -> Tuple[List[ListElement], bool]:
+) -> Tuple[List[ListElement], Optional[str]]:
     # To ensure that "string" columns can be encoded in gRPC, we need to
     # encode them as bytes.
     # We'll also keep track of whether the list should be treated in the
     # future as a list of strings.
     processed = []
-    content_type = StringCodec.ContentType
+    content_type: Optional[str] = StringCodec.ContentType
     for elem in data:
         converted = elem
         if not isinstance(elem, str):

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -1,14 +1,20 @@
 import pandas as pd
 import numpy as np
 
-from typing import Optional, Any, List
+from typing import Optional, Any, List, Tuple
 
 from .base import RequestCodec, register_request_codec
 from .numpy import to_datatype, to_dtype
-from .string import encode_str
+from .string import encode_str, StringCodec
 from .utils import get_decoded_or_raw, InputOrOutput, inject_batch_dimension
 from .lists import ListElement
-from ..types import InferenceRequest, InferenceResponse, RequestInput, ResponseOutput
+from ..types import (
+    InferenceRequest,
+    InferenceResponse,
+    RequestInput,
+    ResponseOutput,
+    Parameters,
+)
 
 
 def _to_series(input_or_output: InputOrOutput) -> pd.Series:
@@ -29,28 +35,46 @@ def _to_series(input_or_output: InputOrOutput) -> pd.Series:
 def _to_response_output(series: pd.Series, use_bytes: bool = True) -> ResponseOutput:
     datatype = to_datatype(series.dtype)
     data = series.tolist()
+    content_type = None
 
-    if datatype == "BYTES" and use_bytes:
-        # To ensure that "string" columns can be encoded in gRPC, we need to
-        # encode them as bytes
-        data = list(map(_ensure_bytes, data))
+    if datatype == "BYTES":
+        data, content_type = _process_bytes(data, use_bytes)
 
     shape = inject_batch_dimension(list(series.shape))
+    parameters = None
+    if content_type:
+        parameters = Parameters(content_type=content_type)
 
     return ResponseOutput(
         name=series.name,
         shape=shape,
-        # If string, it should be encoded to bytes
         data=data,
         datatype=datatype,
+        parameters=parameters,
     )
 
 
-def _ensure_bytes(elem: ListElement) -> bytes:
-    if isinstance(elem, str):
-        return encode_str(elem)
+def _process_bytes(
+    data: List[ListElement], use_bytes: bool = True
+) -> Tuple[List[ListElement], bool]:
+    # To ensure that "string" columns can be encoded in gRPC, we need to
+    # encode them as bytes.
+    # We'll also keep track of whether the list should be treated in the
+    # future as a list of strings.
+    processed = []
+    content_type = StringCodec.ContentType
+    for elem in data:
+        converted = elem
+        if not isinstance(elem, str):
+            # There was a non-string element, so we can't determine a content
+            # type
+            content_type = None
+        elif use_bytes:
+            converted = encode_str(elem)
 
-    return elem
+        processed.append(converted)
+
+    return processed, content_type
 
 
 @register_request_codec
@@ -79,7 +103,10 @@ class PandasCodec(RequestCodec):
         outputs = cls.encode_outputs(payload, use_bytes=use_bytes)
 
         return InferenceResponse(
-            model_name=model_name, model_version=model_version, outputs=outputs
+            model_name=model_name,
+            model_version=model_version,
+            parameters=Parameters(content_type=cls.ContentType),
+            outputs=outputs,
         )
 
     @classmethod
@@ -106,15 +133,17 @@ class PandasCodec(RequestCodec):
         outputs = cls.encode_outputs(payload, use_bytes=use_bytes)
 
         return InferenceRequest(
+            parameters=Parameters(content_type=cls.ContentType),
             inputs=[
                 RequestInput(
                     name=output.name,
                     datatype=output.datatype,
                     shape=output.shape,
                     data=output.data,
+                    parameters=output.parameters,
                 )
                 for output in outputs
-            ]
+            ],
         )
 
     @classmethod

--- a/mlserver/codecs/utils.py
+++ b/mlserver/codecs/utils.py
@@ -202,7 +202,10 @@ class SingleInputRequestCodec(RequestCodec):
             f"{DefaultOutputPrefix}1", payload, **kwargs
         )
         return InferenceResponse(
-            model_name=model_name, model_version=model_version, outputs=[output]
+            model_name=model_name,
+            model_version=model_version,
+            parameters=Parameters(content_type=cls.ContentType),
+            outputs=[output],
         )
 
     @classmethod
@@ -228,7 +231,9 @@ class SingleInputRequestCodec(RequestCodec):
             )
 
         inp = cls.InputCodec.encode_input(f"{DefaultInputPrefix}1", payload, **kwargs)
-        return InferenceRequest(inputs=[inp])
+        return InferenceRequest(
+            inputs=[inp], parameters=Parameters(content_type=cls.ContentType)
+        )
 
     @classmethod
     def decode_request(cls, request: InferenceRequest) -> Any:

--- a/runtimes/mlflow/mlserver_mlflow/codecs.py
+++ b/runtimes/mlflow/mlserver_mlflow/codecs.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from typing import Optional, Dict
 
-from mlserver.types import InferenceRequest, InferenceResponse
+from mlserver.types import InferenceRequest, InferenceResponse, Parameters
 from mlserver.codecs import (
     NumpyCodec,
     RequestCodec,
@@ -46,7 +46,10 @@ class TensorDictCodec(RequestCodec):
         ]
 
         return InferenceResponse(
-            model_name=model_name, model_version=model_version, outputs=outputs
+            model_name=model_name,
+            model_version=model_version,
+            outputs=outputs,
+            parameters=Parameters(content_type=cls.ContentType),
         )
 
     @classmethod
@@ -63,7 +66,9 @@ class TensorDictCodec(RequestCodec):
             for name, value in payload.items()
         ]
 
-        return InferenceRequest(inputs=inputs)
+        return InferenceRequest(
+            inputs=inputs, parameters=Parameters(content_type=cls.ContentType)
+        )
 
     @classmethod
     def decode_request(cls, request: InferenceRequest) -> TensorDict:

--- a/runtimes/mlflow/tests/test_codecs.py
+++ b/runtimes/mlflow/tests/test_codecs.py
@@ -38,10 +38,18 @@ def test_encode_response():
     assert inference_response.model_name == model_name
     assert len(inference_response.outputs) == 2
     assert inference_response.outputs[0] == ResponseOutput(
-        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+        name="foo",
+        datatype="INT64",
+        shape=[3, 1],
+        data=[1, 2, 3],
+        parameters=Parameters(content_type=NumpyCodec.ContentType),
     )
     assert inference_response.outputs[1] == ResponseOutput(
-        name="bar", datatype="FP64", shape=[2, 1], data=[2.3, 4.5]
+        name="bar",
+        datatype="FP64",
+        shape=[2, 1],
+        data=[2.3, 4.5],
+        parameters=Parameters(content_type=NumpyCodec.ContentType),
     )
 
 

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from typing import Any
 
-from mlserver.codecs import NumpyCodec, PandasCodec
+from mlserver.codecs import NumpyCodec, PandasCodec, StringCodec
 from mlserver.types import (
     InferenceRequest,
     Parameters,
@@ -122,6 +122,7 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
             pd.DataFrame({"foo": np.array([1, 2, 3]), "bar": ["A", "B", "C"]}),
             InferenceResponse(
                 model_name="mlflow-model",
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
@@ -131,6 +132,7 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                         datatype="BYTES",
                         shape=[3, 1],
                         data=[b"A", b"B", b"C"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),

--- a/runtimes/mlflow/tests/test_runtime.py
+++ b/runtimes/mlflow/tests/test_runtime.py
@@ -16,6 +16,7 @@ from mlflow.pyfunc import PyFuncModel
 from mlflow.models.signature import ModelSignature
 
 from mlserver_mlflow import MLflowRuntime
+from mlserver_mlflow.codecs import TensorDictCodec
 
 
 def test_load(runtime: MLflowRuntime):
@@ -62,13 +63,14 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
             ["foo"],
             InferenceResponse(
                 model_name="mlflow-model",
+                parameters=Parameters(content_type=StringCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="output-1",
                         datatype="BYTES",
                         shape=[1, 1],
                         data=[b"foo"],
-                        parameters=Parameters(content_type="str"),
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     )
                 ],
             ),
@@ -77,12 +79,14 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
             np.array([[1, 2], [3, 4]], dtype=np.float32),
             InferenceResponse(
                 model_name="mlflow-model",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="output-1",
                         datatype="FP32",
                         shape=[2, 2],
                         data=[1, 2, 3, 4],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     )
                 ],
             ),
@@ -91,12 +95,21 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
             {"foo": np.array([1, 2, 3]), "bar": np.array([1.2])},
             InferenceResponse(
                 model_name="mlflow-model",
+                parameters=Parameters(content_type=TensorDictCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+                        name="foo",
+                        datatype="INT64",
+                        shape=[3, 1],
+                        data=[1, 2, 3],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     ),
                     ResponseOutput(
-                        name="bar", datatype="FP64", shape=[1, 1], data=[1.2]
+                        name="bar",
+                        datatype="FP64",
+                        shape=[1, 1],
+                        data=[1.2],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     ),
                 ],
             ),
@@ -105,15 +118,21 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
             {"foo": np.array([1, 2, 3]), "bar": np.array(["hello", "world"])},
             InferenceResponse(
                 model_name="mlflow-model",
+                parameters=Parameters(content_type=TensorDictCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+                        name="foo",
+                        datatype="INT64",
+                        shape=[3, 1],
+                        data=[1, 2, 3],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     ),
                     ResponseOutput(
                         name="bar",
                         datatype="BYTES",
                         shape=[2, 1],
                         data=[b"hello", b"world"],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     ),
                 ],
             ),
@@ -125,7 +144,10 @@ async def test_predict_pytorch(runtime_pytorch: MLflowRuntime):
                 parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="foo", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+                        name="foo",
+                        datatype="INT64",
+                        shape=[3, 1],
+                        data=[1, 2, 3],
                     ),
                     ResponseOutput(
                         name="bar",

--- a/tests/codecs/test_base64.py
+++ b/tests/codecs/test_base64.py
@@ -3,7 +3,7 @@ import pytest
 from typing import Any
 
 from mlserver.codecs import Base64Codec
-from mlserver.types import RequestInput, ResponseOutput
+from mlserver.types import RequestInput, ResponseOutput, Parameters
 
 
 @pytest.mark.parametrize(
@@ -31,6 +31,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -42,6 +43,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -53,6 +55,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -64,6 +67,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=["UHl0aG9uIGlzIGZ1bg==", "UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
     ],
@@ -139,6 +143,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -150,6 +155,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -161,6 +167,7 @@ def test_decode_output(encoded, expected):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=[b"UHl0aG9uIGlzIGZ1bg==", b"UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
         (
@@ -172,6 +179,7 @@ def test_decode_output(encoded, expected):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=["UHl0aG9uIGlzIGZ1bg==", "UHl0aG9uIGlzIGZ1bg=="],
+                parameters=Parameters(content_type=Base64Codec.ContentType),
             ),
         ),
     ],

--- a/tests/codecs/test_datetime.py
+++ b/tests/codecs/test_datetime.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from mlserver.codecs import DatetimeCodec
-from mlserver.types import RequestInput, ResponseOutput
+from mlserver.types import RequestInput, ResponseOutput, Parameters
 
 TestDatetimeIso = "2021-08-24T15:01:19"
 TestDatetimeIsoB = b"2021-08-24T15:01:19"
@@ -39,6 +39,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -50,6 +51,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -61,6 +63,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -72,6 +75,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -83,6 +87,7 @@ def test_can_encode(payload: Any, expected: bool):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
     ],
@@ -168,6 +173,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -179,6 +185,7 @@ def test_decode_output(encoded, expected):
                 shape=[2, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB, TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -190,6 +197,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -201,6 +209,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIsoB],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
         (
@@ -212,6 +221,7 @@ def test_decode_output(encoded, expected):
                 shape=[1, 1],
                 datatype="BYTES",
                 data=[TestTzDatetimeIso],
+                parameters=Parameters(content_type=DatetimeCodec.ContentType),
             ),
         ),
     ],

--- a/tests/codecs/test_decorator.py
+++ b/tests/codecs/test_decorator.py
@@ -152,6 +152,7 @@ def test_decode_request_not_found(
                     datatype="INT64",
                     shape=[1, 1],
                     data=[2],
+                    parameters=Parameters(content_type=NumpyCodec.ContentType),
                 )
             ],
         ),
@@ -177,6 +178,7 @@ def test_decode_request_not_found(
                     datatype="INT64",
                     shape=[1, 1],
                     data=[2],
+                    parameters=Parameters(content_type=NumpyCodec.ContentType),
                 ),
                 ResponseOutput(
                     name="output-1",
@@ -203,6 +205,7 @@ def test_decode_request_not_found(
                     datatype="INT64",
                     shape=[1, 1],
                     data=[2],
+                    parameters=Parameters(content_type=NumpyCodec.ContentType),
                 ),
             ],
         ),
@@ -250,6 +253,7 @@ def test_decode_request_not_found(
                     datatype="INT64",
                     shape=[1, 1],
                     data=[3],
+                    parameters=Parameters(content_type=NumpyCodec.ContentType),
                 ),
                 ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
                 ResponseOutput(

--- a/tests/codecs/test_decorator.py
+++ b/tests/codecs/test_decorator.py
@@ -211,7 +211,13 @@ def test_decode_request_not_found(
             [PandasCodec],
             [
                 ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
+                ResponseOutput(
+                    name="b",
+                    datatype="BYTES",
+                    shape=[1, 1],
+                    data=[b"foo"],
+                    parameters=Parameters(content_type=StringCodec.ContentType),
+                ),
             ],
         ),
         (
@@ -219,7 +225,13 @@ def test_decode_request_not_found(
             [PandasCodec, StringCodec],
             [
                 ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
+                ResponseOutput(
+                    name="b",
+                    datatype="BYTES",
+                    shape=[1, 1],
+                    data=[b"foo"],
+                    parameters=Parameters(content_type=StringCodec.ContentType),
+                ),
                 ResponseOutput(
                     name="output-1",
                     datatype="BYTES",
@@ -240,7 +252,13 @@ def test_decode_request_not_found(
                     data=[3],
                 ),
                 ResponseOutput(name="a", datatype="INT64", shape=[1, 1], data=[2]),
-                ResponseOutput(name="b", datatype="BYTES", shape=[1, 1], data=[b"foo"]),
+                ResponseOutput(
+                    name="b",
+                    datatype="BYTES",
+                    shape=[1, 1],
+                    data=[b"foo"],
+                    parameters=Parameters(content_type=StringCodec.ContentType),
+                ),
             ],
         ),
     ],

--- a/tests/codecs/test_numpy.py
+++ b/tests/codecs/test_numpy.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Any
 
 from mlserver.codecs.numpy import NumpyCodec, to_datatype
-from mlserver.types import RequestInput, ResponseOutput
+from mlserver.types import RequestInput, ResponseOutput, Parameters
 
 
 @pytest.mark.parametrize(
@@ -20,34 +20,62 @@ def test_can_encode(payload: Any, expected: bool):
     [
         (
             np.array([1, 2, 3]),
-            ResponseOutput(name="foo", shape=[3, 1], data=[1, 2, 3], datatype="INT64"),
+            ResponseOutput(
+                name="foo",
+                shape=[3, 1],
+                data=[1, 2, 3],
+                datatype="INT64",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
+            ),
         ),
         (
             np.array([[1, 2], [3, 4]]),
             ResponseOutput(
-                name="foo", shape=[2, 2], data=[1, 2, 3, 4], datatype="INT64"
+                name="foo",
+                shape=[2, 2],
+                data=[1, 2, 3, 4],
+                datatype="INT64",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
             ),
         ),
         (
             np.array([[1, 2], [3, 4]], dtype=np.int32),
             ResponseOutput(
-                name="foo", shape=[2, 2], data=[1, 2, 3, 4], datatype="INT32"
+                name="foo",
+                shape=[2, 2],
+                data=[1, 2, 3, 4],
+                datatype="INT32",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
             ),
         ),
         (
             np.array([1.0, 2.0]),
-            ResponseOutput(name="foo", shape=[2, 1], data=[1, 2], datatype="FP64"),
+            ResponseOutput(
+                name="foo",
+                shape=[2, 1],
+                data=[1, 2],
+                datatype="FP64",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
+            ),
         ),
         (
             np.array([[b"\x01"], [b"\x02"]], dtype=bytes),
             ResponseOutput(
-                name="foo", shape=[2, 1], data=[b"\x01\x02"], datatype="BYTES"
+                name="foo",
+                shape=[2, 1],
+                data=[b"\x01\x02"],
+                datatype="BYTES",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
             ),
         ),
         (
             np.array(["foo", "bar"], dtype=str),
             ResponseOutput(
-                name="foo", shape=[2, 1], data=[b"foo", b"bar"], datatype="BYTES"
+                name="foo",
+                shape=[2, 1],
+                data=[b"foo", b"bar"],
+                datatype="BYTES",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
             ),
         ),
     ],

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -5,6 +5,7 @@ import numpy as np
 from typing import Any
 
 from mlserver.codecs.pandas import PandasCodec, _to_response_output
+from mlserver.codecs.string import StringCodec
 from mlserver.types import (
     InferenceRequest,
     InferenceResponse,
@@ -32,14 +33,22 @@ def test_can_encode(payload: Any, expected: bool):
             pd.Series(data=["hey", "abc"], name="foo"),
             True,
             ResponseOutput(
-                name="foo", shape=[2, 1], data=[b"hey", b"abc"], datatype="BYTES"
+                name="foo",
+                shape=[2, 1],
+                data=[b"hey", b"abc"],
+                datatype="BYTES",
+                parameters=Parameters(content_type=StringCodec.ContentType),
             ),
         ),
         (
             pd.Series(data=["hey", "abc"], name="foo"),
             False,
             ResponseOutput(
-                name="foo", shape=[2, 1], data=["hey", "abc"], datatype="BYTES"
+                name="foo",
+                shape=[2, 1],
+                data=["hey", "abc"],
+                datatype="BYTES",
+                parameters=Parameters(content_type=StringCodec.ContentType),
             ),
         ),
         (
@@ -82,15 +91,20 @@ def test_to_response_output(series, use_bytes, expected):
             True,
             InferenceResponse(
                 model_name="my-model",
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
+                        name="a",
+                        shape=[3, 1],
+                        datatype="INT64",
+                        data=[1, 2, 3],
                     ),
                     ResponseOutput(
                         name="b",
                         shape=[3, 1],
                         datatype="BYTES",
                         data=[b"A", b"B", b"C"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),
@@ -105,12 +119,17 @@ def test_to_response_output(series, use_bytes, expected):
             False,
             InferenceResponse(
                 model_name="my-model",
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     ResponseOutput(
-                        name="b", shape=[3, 1], datatype="BYTES", data=["A", "B", "C"]
+                        name="b",
+                        shape=[3, 1],
+                        datatype="BYTES",
+                        data=["A", "B", "C"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),
@@ -219,6 +238,7 @@ def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
             ),
             True,
             InferenceRequest(
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 inputs=[
                     RequestInput(
                         name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
@@ -228,6 +248,7 @@ def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
                         shape=[3, 1],
                         datatype="BYTES",
                         data=[b"A", b"B", b"C"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),
@@ -241,12 +262,17 @@ def test_decode_response(response: InferenceResponse, expected: pd.DataFrame):
             ),
             False,
             InferenceRequest(
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 inputs=[
                     RequestInput(
                         name="a", shape=[3, 1], datatype="INT64", data=[1, 2, 3]
                     ),
                     RequestInput(
-                        name="b", shape=[3, 1], datatype="BYTES", data=["A", "B", "C"]
+                        name="b",
+                        shape=[3, 1],
+                        datatype="BYTES",
+                        data=["A", "B", "C"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -23,7 +23,7 @@ from mlserver.codecs.utils import (
     DecodedParameterName,
 )
 from mlserver.codecs.pandas import PandasCodec
-from mlserver.codecs.numpy import NumpyRequestCodec
+from mlserver.codecs.numpy import NumpyCodec, NumpyRequestCodec
 from mlserver.codecs.string import StringCodec
 
 
@@ -34,7 +34,11 @@ from mlserver.codecs.string import StringCodec
             np.array([1, 2, 3, 4]),
             RequestOutput(name="foo"),
             ResponseOutput(
-                name="foo", datatype="INT64", shape=[4, 1], data=[1, 2, 3, 4]
+                name="foo",
+                datatype="INT64",
+                shape=[4, 1],
+                data=[1, 2, 3, 4],
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
             ),
         ),
         (
@@ -56,6 +60,7 @@ from mlserver.codecs.string import StringCodec
                 datatype="BYTES",
                 shape=[1, 1],
                 data=[b"2021-02-25T12:00:00Z"],
+                parameters=Parameters(content_type="datetime"),
             ),
         ),
         ({1, 2, 3, 4}, RequestOutput(name="bar"), None),
@@ -87,7 +92,10 @@ def test_encode_response_output(
                 parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="a", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+                        name="a",
+                        datatype="INT64",
+                        shape=[3, 1],
+                        data=[1, 2, 3],
                     ),
                     ResponseOutput(
                         name="b",
@@ -104,9 +112,14 @@ def test_encode_response_output(
             InferenceResponse(
                 model_name="sum-model",
                 model_version="v1.2.3",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
                 outputs=[
                     ResponseOutput(
-                        name="output-1", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
+                        name="output-1",
+                        datatype="INT64",
+                        shape=[3, 1],
+                        data=[1, 2, 3],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
                     ),
                 ],
             ),
@@ -116,6 +129,7 @@ def test_encode_response_output(
             InferenceResponse(
                 model_name="sum-model",
                 model_version="v1.2.3",
+                parameters=Parameters(content_type=StringCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="output-1",
@@ -145,7 +159,13 @@ def test_encode_inference_response(
             InferenceRequest(
                 parameters=Parameters(content_type=PandasCodec.ContentType),
                 inputs=[
-                    RequestInput(name="a", datatype="INT64", shape=[3], data=[1, 2, 3]),
+                    RequestInput(
+                        name="a",
+                        datatype="INT64",
+                        shape=[3],
+                        data=[1, 2, 3],
+                        parameters=Parameters(content_type=NumpyCodec.ContentType),
+                    ),
                     RequestInput(
                         name="b",
                         datatype="BYTES",

--- a/tests/codecs/test_utils.py
+++ b/tests/codecs/test_utils.py
@@ -84,6 +84,7 @@ def test_encode_response_output(
             InferenceResponse(
                 model_name="sum-model",
                 model_version="v1.2.3",
+                parameters=Parameters(content_type=PandasCodec.ContentType),
                 outputs=[
                     ResponseOutput(
                         name="a", datatype="INT64", shape=[3, 1], data=[1, 2, 3]
@@ -93,6 +94,7 @@ def test_encode_response_output(
                         datatype="BYTES",
                         shape=[3, 1],
                         data=[b"a", b"b", b"c"],
+                        parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
                 ],
             ),

--- a/tests/grpc/test_codecs.py
+++ b/tests/grpc/test_codecs.py
@@ -35,6 +35,11 @@ from mlserver.grpc.converters import (
             PandasCodec,
             pb.ModelInferResponse(
                 model_name="my-model",
+                parameters={
+                    "content_type": pb.InferParameter(
+                        string_param=PandasCodec.ContentType
+                    )
+                },
                 outputs=[
                     pb.ModelInferResponse.InferOutputTensor(
                         name="a",
@@ -49,6 +54,11 @@ from mlserver.grpc.converters import (
                         contents=pb.InferTensorContents(
                             bytes_contents=[b"A", b"B", b"C"]
                         ),
+                        parameters={
+                            "content_type": pb.InferParameter(
+                                string_param=StringCodec.ContentType
+                            )
+                        },
                     ),
                 ],
             ),
@@ -115,6 +125,11 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
                 datatype="FP64",
                 shape=[1, 1],
                 contents=pb.InferTensorContents(fp64_contents=[21.0]),
+                parameters={
+                    "content_type": pb.InferParameter(
+                        string_param=NumpyCodec.ContentType
+                    )
+                },
             ),
         ),
         (
@@ -125,6 +140,11 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
                 datatype="BYTES",
                 shape=[2, 1],
                 contents=pb.InferTensorContents(bytes_contents=[b"\x01\x02"]),
+                parameters={
+                    "content_type": pb.InferParameter(
+                        string_param=NumpyCodec.ContentType
+                    )
+                },
             ),
         ),
         (
@@ -154,6 +174,11 @@ def test_decode_infer_request(encoded: pb.ModelInferRequest, expected: Any):
                 contents=pb.InferTensorContents(
                     bytes_contents=[b"UHl0aG9uIGlzIGZ1bg=="]
                 ),
+                parameters={
+                    "content_type": pb.InferParameter(
+                        string_param=Base64Codec.ContentType
+                    )
+                },
             ),
         ),
     ],

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -4,7 +4,6 @@ import json
 
 from typing import Any
 
-from mlserver.types import Parameters
 from mlserver.codecs import NumpyCodec, StringCodec, InputCodec, Base64Codec
 from mlserver.rest.responses import Response
 
@@ -41,7 +40,6 @@ from mlserver.rest.responses import Response
                 "name": "output-0",
                 "datatype": "BYTES",
                 "shape": [3, 1],
-                "parameters": Parameters(content_type=StringCodec.ContentType),
                 "data": ["hey", "what's", "up"],
                 "parameters": {"content_type": StringCodec.ContentType},
             },

--- a/tests/rest/test_codecs.py
+++ b/tests/rest/test_codecs.py
@@ -20,6 +20,7 @@ from mlserver.rest.responses import Response
                 "datatype": "FP64",
                 "shape": [1, 1],
                 "data": [21.0],
+                "parameters": {"content_type": NumpyCodec.ContentType},
             },
         ),
         (
@@ -30,6 +31,7 @@ from mlserver.rest.responses import Response
                 "datatype": "BYTES",
                 "shape": [2, 1],
                 "data": ["\x01\x02"],
+                "parameters": {"content_type": NumpyCodec.ContentType},
             },
         ),
         (
@@ -41,6 +43,7 @@ from mlserver.rest.responses import Response
                 "shape": [3, 1],
                 "parameters": Parameters(content_type=StringCodec.ContentType),
                 "data": ["hey", "what's", "up"],
+                "parameters": {"content_type": StringCodec.ContentType},
             },
         ),
         (
@@ -51,6 +54,7 @@ from mlserver.rest.responses import Response
                 "datatype": "BYTES",
                 "shape": [1, 1],
                 "data": ["UHl0aG9uIGlzIGZ1bg=="],
+                "parameters": {"content_type": Base64Codec.ContentType},
             },
         ),
     ],


### PR DESCRIPTION
Fixes #737

# Changelog

- Ensure encode methods in `PandasCodec` always add the `content_type: pd` and `content_type: str` as needed.