### PR TITLE
Fix small typo in Python API docs

### DIFF
--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,6 +1,6 @@
 # Python API
 
-MLServer can be installed as a Python packaged, which exposes a public
+MLServer can be installed as a Python package, which exposes a public
 framework which can be used to build [custom inference
 runtimes](../../user-guide/custom) and [codecs](../../user-guide/content-type).
 


### PR DESCRIPTION
`a python packaged` -> `a python package`