### PR TITLE
Bump Python to 3.10 as default

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Dependencies
         run: |
           make install-dev

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,10 +14,10 @@ jobs:
         scenario: ["inference-rest.js", "inference-grpc.js"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install Dependencies
         run: |
           make install-dev

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Dependencies
         run: |
           pip install -r requirements/dev.txt

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -12,10 +12,10 @@ jobs:
     if: github.repository == 'SeldonIO/MLServer' # Do not run this on forks.
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install Dependencies
         run: |
           pip install -r requirements/dev.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install -r ./requirements/dev.txt
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install -r ./requirements/dev.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install -r ./requirements/dev.txt
@@ -148,10 +148,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install -r ./requirements/dev.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           make install-dev

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: snyk/actions/setup@master
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           make install-dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           make install-dev
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup docker (missing on MacOS)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.10
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
@@ -90,7 +90,7 @@ jobs:
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.11
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.10
       - name: Install dependencies
         run: |
           make install-dev
@@ -29,7 +29,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        # NOTE: There's no pre-built `grpcio` wheel for Python 3.11 yet
+        # https://github.com/grpc/grpc/issues/32454
+        python-version: ["3.8", "3.9", "3.10"]
         tox-environment:
           - mlserver
           - sklearn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           make install-dev
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         tox-environment:
           - mlserver
           - sklearn
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup docker (missing on MacOS)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim AS wheel-builder
+FROM python:3.10-slim AS wheel-builder
 SHELL ["/bin/bash", "-l", "-c"]
 
 COPY ./hack/build-wheels.sh ./hack/build-wheels.sh
@@ -18,8 +18,8 @@ RUN ./hack/build-wheels.sh /opt/mlserver/dist
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 SHELL ["/bin/bash", "-c"]
 
-ARG PYTHON_VERSION=3.8.16
-ARG CONDA_VERSION=22.11.1
+ARG PYTHON_VERSION=3.10.11
+ARG CONDA_VERSION=23.3.1
 ARG MINIFORGE_VERSION=${CONDA_VERSION}-4
 ARG RUNTIMES="all"
 
@@ -32,7 +32,7 @@ ENV MLSERVER_MODELS_DIR=/mnt/models \
     MLSERVER_PATH=/opt/mlserver \
     CONDA_PATH=/opt/conda \
     PATH=/opt/mlserver/.local/bin:/opt/conda/bin:$PATH \
-    LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/opt/conda/lib/python3.8/site-packages/nvidia/cuda_runtime/lib:$LD_LIBRARY_PATH \
+    LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/opt/conda/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$LD_LIBRARY_PATH \
     TRANSFORMERS_CACHE=/opt/mlserver/.cache \
     NUMBA_CACHE_DIR=/opt/mlserver/.cache
 
@@ -46,7 +46,7 @@ RUN microdnf update -y && \
         glib2-devel \
         shadow-utils
 
-# Install Conda, Python 3.8 and FFmpeg
+# Install Conda, Python 3.10 and FFmpeg
 RUN microdnf install -y wget && \
     wget "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" \
         -O miniforge3.sh && \
@@ -101,7 +101,7 @@ RUN . $CONDA_PATH/etc/profile.d/conda.sh && \
     fi && \
     pip install $(ls "./dist/mlserver-"*.whl) && \
     pip install -r ./requirements/docker.txt && \
-    rm -f /opt/conda/lib/python3.8/site-packages/spacy/tests/package/requirements.txt && \
+    rm -f /opt/conda/lib/python3.10/site-packages/spacy/tests/package/requirements.txt && \
     rm -rf /root/.cache/pip
 
 COPY ./licenses/license.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal
 SHELL ["/bin/bash", "-c"]
 
 ARG PYTHON_VERSION=3.10.11
-ARG CONDA_VERSION=23.3.1
-ARG MINIFORGE_VERSION=${CONDA_VERSION}-4
+ARG CONDA_VERSION=23.1.0
+ARG MINIFORGE_VERSION=${CONDA_VERSION}-1
 ARG RUNTIMES="all"
 
 # Set a few default environment variables, including `LD_LIBRARY_PATH`


### PR DESCRIPTION
Fixes #1072 

## Changelog

- Use `3.10` as default in MLServer images
- Use `3.10` as default in CI Actions

## Notes

We haven't added support for `3.11` in this PR because there's no `grpcio` pre-built wheel available yet:

https://github.com/grpc/grpc/issues/32454