### PR TITLE
Update Apache-2.0 notation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver"
 version = "1.4.0.dev2"
 description = "MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 classifiers = [
     "Operating System :: POSIX",

--- a/runtimes/alibi-detect/pyproject.toml
+++ b/runtimes/alibi-detect/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-alibi-detect"
 version = "1.4.0.dev2"
 description = "Alibi-Detect runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_alibi_detect"}]
 

--- a/runtimes/alibi-explain/pyproject.toml
+++ b/runtimes/alibi-explain/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-alibi-explain"
 version = "1.4.0.dev2"
 description = "Alibi-Explain runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_alibi_explain"}]
 

--- a/runtimes/huggingface/pyproject.toml
+++ b/runtimes/huggingface/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-huggingface"
 version = "1.4.0.dev2"
 description = "HuggingFace runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_huggingface"}]
 

--- a/runtimes/lightgbm/pyproject.toml
+++ b/runtimes/lightgbm/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-lightgbm"
 version = "1.4.0.dev2"
 description = "LightGBM runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_lightgbm"}]
 

--- a/runtimes/mlflow/pyproject.toml
+++ b/runtimes/mlflow/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-mlflow"
 version = "1.4.0.dev2"
 description = "MLflow runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_mlflow"}]
 

--- a/runtimes/mllib/pyproject.toml
+++ b/runtimes/mllib/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-mllib"
 version = "1.4.0.dev2"
 description = "Spark MLlib runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_mllib"}]
 

--- a/runtimes/sklearn/pyproject.toml
+++ b/runtimes/sklearn/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-sklearn"
 version = "1.4.0.dev2"
 description = "Scikit-Learn runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_sklearn"}]
 

--- a/runtimes/xgboost/pyproject.toml
+++ b/runtimes/xgboost/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlserver-xgboost"
 version = "1.4.0.dev2"
 description = "XGBoost runtime for MLServer"
 authors = ["Seldon Technologies Ltd. <hello@seldon.io>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "mlserver_xgboost"}]
 


### PR DESCRIPTION
It seems the standard way to annotate the license is `Apache-2.0` instead of `Apache 2.0`:

https://python-poetry.org/docs/pyproject/#license