### PR TITLE
Add unload method to MLModel interface

### DIFF
--- a/docs/reference/api/model.md
+++ b/docs/reference/api/model.md
@@ -5,8 +5,9 @@ runtimes](../../user-guide/custom).
 It exposes the main interface that MLServer will use to interact with ML
 models.
 
-The bulk of its public interface are the {func}`load() <mlserver.MLModel.load>`
-and {func}`predict() <mlserver.MLModel.predict>` methods.
+The bulk of its public interface are the {func}`load()
+<mlserver.MLModel.load>`, {func}`unload() <mlserver.MLModel.unload>` and
+{func}`predict() <mlserver.MLModel.predict>` methods.
 However, it also contains helpers with encoding / decoding of requests and
 responses, as well as properties to access the most common bits of the model's
 metadata.

--- a/docs/user-guide/custom.md
+++ b/docs/user-guide/custom.md
@@ -20,7 +20,7 @@ abstract class, whose main methods are:
 - {func}`load() <mlserver.MLModel.load>`:
   Responsible for loading any artifacts related to a model (e.g. model
   weights, pickle files, etc.).
-- {func}`load() <mlserver.MLModel.unload>`:
+- {func}`unload() <mlserver.MLModel.unload>`:
   Responsible for unloading the model, freeing any resources (e.g. GPU memory,
   etc.).
 - {func}`predict() <mlserver.MLModel.predict>`:

--- a/docs/user-guide/custom.md
+++ b/docs/user-guide/custom.md
@@ -20,6 +20,9 @@ abstract class, whose main methods are:
 - {func}`load() <mlserver.MLModel.load>`:
   Responsible for loading any artifacts related to a model (e.g. model
   weights, pickle files, etc.).
+- {func}`load() <mlserver.MLModel.unload>`:
+  Responsible for unloading the model, freeing any resources (e.g. GPU memory,
+  etc.).
 - {func}`predict() <mlserver.MLModel.predict>`:
   Responsible for using a model to perform inference on an incoming data point.
 

--- a/mlserver/model.py
+++ b/mlserver/model.py
@@ -79,7 +79,7 @@ class MLModel:
         """
         raise NotImplementedError("predict() method not implemented")
 
-    async def unload(self) -> None:
+    async def unload(self) -> bool:
         """
         Method responsible for unloading the model, freeing any resources (e.g.
         CPU memory, GPU memory, etc.).
@@ -91,7 +91,7 @@ class MLModel:
         **This method should be overriden to implement your custom unload
         logic.**
         """
-        pass
+        return True
 
     @property
     def name(self) -> str:

--- a/mlserver/model.py
+++ b/mlserver/model.py
@@ -79,6 +79,20 @@ class MLModel:
         """
         raise NotImplementedError("predict() method not implemented")
 
+    async def unload(self) -> None:
+        """
+        Method responsible for unloading the model, freeing any resources (e.g.
+        CPU memory, GPU memory, etc.).
+        This method will be called on each of the parallel workers (when
+        :doc:`parallel inference </user-guide/parallel-inference>`) is
+        enabled).
+        A return value of ``True`` will mean the model is now unloaded.
+
+        **This method should be overriden to implement your custom unload
+        logic.**
+        """
+        pass
+
     @property
     def name(self) -> str:
         """

--- a/mlserver/registry.py
+++ b/mlserver/registry.py
@@ -186,6 +186,7 @@ class SingleModelRegistry:
         if old_model == self.default:
             self._clear_default()
 
+        old_model.ready = not await old_model.unload()
         logger.info(f"Reloaded model '{new_model.name}' succesfully.")
 
     async def unload(self):
@@ -220,6 +221,8 @@ class SingleModelRegistry:
 
         if model == self.default:
             self._clear_default()
+
+        model.ready = not await model.unload()
 
     def _find_model(self, version: Optional[str] = None) -> Optional[MLModel]:
         if version:

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -52,6 +52,7 @@ class HuggingFaceRuntime(MLModel):
         )
 
     async def unload(self) -> bool:
+        # TODO: Free up Tensorflow's GPU memory
         is_torch = self._model.framework == "pt"
         if not is_torch:
             return True

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import torch
 
 from mlserver.model import MLModel
 from mlserver.settings import ModelSettings
@@ -49,6 +50,20 @@ class HuggingFaceRuntime(MLModel):
         return self.encode_response(
             payload=prediction, default_codec=HuggingfaceRequestCodec
         )
+
+    async def unload(self) -> bool:
+        is_torch = self._model.framework == "pt"
+        if not is_torch:
+            return True
+
+        uses_gpu = torch.cuda.is_available() and self._model.device != -1
+        if not uses_gpu:
+            # Nothing to free
+            return True
+
+        # Free up Torch's GPU memory
+        torch.cuda.empty_cache()
+        return True
 
     def _merge_metadata(self) -> None:
         meta = METADATA.get(self.hf_settings.task)

--- a/runtimes/huggingface/tests/test_runtime.py
+++ b/runtimes/huggingface/tests/test_runtime.py
@@ -27,6 +27,14 @@ async def test_load(future_runtime: Awaitable[HuggingFaceRuntime]):
     assert isinstance(runtime._model, QuestionAnsweringPipeline)
 
 
+async def test_unload(future_runtime: Awaitable[HuggingFaceRuntime]):
+    runtime = await future_runtime
+    assert runtime.ready
+
+    unloaded = await runtime.unload()
+    assert unloaded
+
+
 async def test_infer(
     future_runtime: Awaitable[HuggingFaceRuntime], inference_request: InferenceRequest
 ):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -97,6 +97,7 @@ async def test_reload_model(
     assert new_model != existing_model
     assert new_model == reloaded_model
     assert reloaded_model.ready
+    assert not existing_model.ready
 
     for callback in model_registry._on_model_load:
         callback.assert_not_called()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -139,6 +139,14 @@ async def test_load_multi_version(
         callback.assert_not_called_with(existing_model)
 
 
+async def test_unload(model_registry: MultiModelRegistry, sum_model: MLModel, mocker):
+    spy = mocker.spy(sum_model, "unload")
+    await model_registry.unload(sum_model.name)
+
+    assert not sum_model.ready
+    spy.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "versions_to_unload",
     [


### PR DESCRIPTION
Fixes #1145 

## Changelog

- Add `unload()` method in `MLModel` interface (called by registry when unloading models)

## TODO

- [x] In HF runtime, unload model from GPU (as discussed in https://github.com/SeldonIO/MLServer/issues/986#issuecomment-1587422911)