### PR TITLE
Rename HF codec to `hf`

### DIFF
--- a/runtimes/huggingface/README.md
+++ b/runtimes/huggingface/README.md
@@ -13,6 +13,16 @@ pip install mlserver mlserver-huggingface
 For further information on how to use MLServer with HuggingFace, you can check
 out this [worked out example](../../docs/examples/huggingface/README.md).
 
+## Content Types
+
+The HuggingFace runtime will always decode the input request using its own
+built-in codec.
+Therefore, [content type annotations](../../docs/user-guide/content-type) at
+the request level will **be ignored**.
+Not that this **doesn't include [input-level content
+type](../../docs/user-guide/content-type#Codecs) annotations**, which will be
+respected as usual.
+
 ## Settings
 
 The HuggingFace runtime exposes a couple extra parameters which can be used to

--- a/runtimes/huggingface/mlserver_huggingface/codecs/base.py
+++ b/runtimes/huggingface/mlserver_huggingface/codecs/base.py
@@ -44,7 +44,7 @@ class MultiInputRequestCodec(RequestCodec):
 
     DefaultCodec: Type["InputCodecTy"] = StringCodec
     InputCodecsWithPriority: List[Type[InputCodecTy]] = []
-    ContentType = StringCodec.ContentType
+    ContentType = ""
 
     @classmethod
     def _find_encode_codecs(
@@ -194,5 +194,5 @@ class HuggingfaceRequestCodec(MultiInputRequestCodec):
         NumpyListCodec,
         RawCodec,
     ]
-    ContentType = StringCodec.ContentType
+    ContentType = "hf"
     DefaultCodec = StringCodec

--- a/runtimes/huggingface/mlserver_huggingface/runtime.py
+++ b/runtimes/huggingface/mlserver_huggingface/runtime.py
@@ -39,7 +39,7 @@ class HuggingFaceRuntime(MLModel):
 
     async def predict(self, payload: InferenceRequest) -> InferenceResponse:
         # TODO: convert and validate?
-        kwargs = self.decode_request(payload, default_codec=HuggingfaceRequestCodec)
+        kwargs = HuggingfaceRequestCodec.decode_request(payload)
         args = kwargs.pop("args", [])
 
         array_inputs = kwargs.pop("array_inputs", [])

--- a/runtimes/huggingface/tests/test_codecs/test_base.py
+++ b/runtimes/huggingface/tests/test_codecs/test_base.py
@@ -26,7 +26,7 @@ from ..utils import (
             {"foo": ["bar1", "bar2"], "foo2": ["var1"]},
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="foo",
@@ -49,7 +49,7 @@ from ..utils import (
             {"foo": ["bar1", "bar2"], "foo2": ["var1"]},
             True,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="foo",
@@ -77,7 +77,7 @@ from ..utils import (
             },
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="images",
@@ -98,7 +98,7 @@ from ..utils import (
             },
             True,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="images",
@@ -128,7 +128,7 @@ from ..utils import (
             },
             True,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="conversations",
@@ -158,7 +158,7 @@ from ..utils import (
             },
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="conversations",
@@ -182,7 +182,7 @@ from ..utils import (
             },
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="singlejson",
@@ -207,7 +207,7 @@ from ..utils import (
             },
             True,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="singlejson",
@@ -241,7 +241,7 @@ from ..utils import (
             },
             True,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="jsonlist",
@@ -277,7 +277,7 @@ from ..utils import (
             },
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="jsonlist",
@@ -299,7 +299,7 @@ from ..utils import (
             {"nplist": [np.int8([[2, 2], [2, 2]]), np.float64([[2, 2], [2, 2]])]},
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="nplist",
@@ -319,7 +319,7 @@ from ..utils import (
             },
             False,
             InferenceRequest(
-                parameters=Parameters(content_type="str"),
+                parameters=Parameters(content_type="hf"),
                 inputs=[
                     RequestInput(
                         name="raw_int",


### PR DESCRIPTION
## Changelog

- Rename multi-input HF codec's content type to `hf` (the previous `str` caused conflicts with MLServer's base one)
- Always use `HuggingfaceRequestCodec` in HF runtime (i.e. ignore top-level request `content_type` annotation)