### PR TITLE
Fix build-wheels.sh error when copying to output path

### DIFF
--- a/hack/build-wheels.sh
+++ b/hack/build-wheels.sh
@@ -15,24 +15,29 @@ fi
 _buildWheel() {
   local _srcPath=$1
   local _outputPath=$2
-  local _currentDir=$PWD
 
   # Poetry doesn't let us send the output to a separate folder so we'll `cd`
   # into the folder and them move the wheels out
   # https://github.com/python-poetry/poetry/issues/3586
   pushd $_srcPath
   poetry build
-  cp ./dist/* $_outputPath
+  # Only copy files if destination is different from source
+  local _currentDistPath=$PWD/dist
+  if ! [[ "$_currentDistPath" = "$_outputPath" ]]; then
+    cp $_currentDistPath/* $_outputPath
+  fi
   popd
 }
 
 _main() {
   # Convert any path into an absolute path
   local _outputPath=$1
-  if ! [[ "$_outputPath" = /* ]]; then
-    _outputPath="$PWD/$_outputPath"
-  fi
   mkdir -p $_outputPath
+  if ! [[ "$_outputPath" = /* ]]; then
+    pushd $_outputPath
+    _outputPath="$PWD"
+    popd
+  fi
 
   # Build MLServer
   echo "---> Building MLServer wheel"


### PR DESCRIPTION
Fixes hack/build-wheels.sh failing when trying to copy the dist over itself (source and output path the same). This occured when doing `make build` for example, where build-wheels.sh is called with an output path of ./dist and tries to copy the mlserver wheels.