### PR TITLE
Make sure we use our Response class

### DIFF
--- a/mlserver/rest/app.py
+++ b/mlserver/rest/app.py
@@ -28,12 +28,14 @@ class APIRoute(FastAPIRoute):
         *args,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,
+        response_class=Response,
         **kwargs
     ):
         super().__init__(
             *args,
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_none=response_model_exclude_none,
+            response_class=Response,
             **kwargs
         )
 


### PR DESCRIPTION
We noticed recently that our custom `Response` class (using `orjson`) wasn't being used. This PR tweaks that to ensure it does get used again.