### PR TITLE
Remove fastapi dependency upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ addopts = "--import-mode=importlib"
 [tool.poetry.dependencies]
 python = "^3.8.1,<3.12"
 click = "*"
-fastapi = ">=0.88.0,!=0.89.0,<=0.97.0"
+fastapi = ">=0.88.0,!=0.89.0"
 python-dotenv = "*"
 grpcio = "*"
 numpy = "*"


### PR DESCRIPTION
This is messing up my ability to install mlserver alongside other packages, and I can't see the reason why the fastapi version should have an upper limit. Almost all the other dependencies are either "*" or "^..."