### PR TITLE
feat(huggingface): Merge model settings

### DIFF
--- a/runtimes/huggingface/tests/test_settings.py
+++ b/runtimes/huggingface/tests/test_settings.py
@@ -1,0 +1,168 @@
+import pytest
+
+from typing import Dict
+
+from mlserver.settings import ModelSettings, ModelParameters
+
+from mlserver_huggingface.runtime import HuggingFaceRuntime
+from mlserver_huggingface.settings import (
+    HuggingFaceSettings,
+    PARAMETERS_ENV_NAME,
+    get_huggingface_settings,
+    merge_huggingface_settings_extra,
+)
+from mlserver_huggingface.errors import MissingHuggingFaceSettings
+
+
+@pytest.fixture()
+def model_settings_extra_task():
+    return ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(
+            extra={"task": "text-generation", "pretrained_model": "distilgpt2"}
+        ),
+    )
+
+
+@pytest.fixture()
+def model_settings_extra_none():
+    return ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(extra=None),
+    )
+
+
+@pytest.fixture()
+def model_settings_extra_empty():
+    return ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+        parameters=ModelParameters(extra={}),
+    )
+
+
+@pytest.mark.parametrize(
+    "model_settings,env_params,expected",
+    [
+        (
+            "model_settings_extra_task",
+            {"task": "question-answering"},
+            {"task": "question-answering", "pretrained_model": "distilgpt2"},
+        ),
+        (
+            "model_settings_extra_task",
+            {},
+            {"task": "text-generation", "pretrained_model": "distilgpt2"},
+        ),
+        (
+            "model_settings_extra_none",
+            {"task": "question-answering"},
+            {"task": "question-answering"},
+        ),
+        (
+            "model_settings_extra_empty",
+            {"task": "question-answering"},
+            {"task": "question-answering"},
+        ),
+    ],
+)
+def test_merge_huggingface_settings_extra(
+    model_settings: str,
+    env_params: Dict,
+    expected: Dict,
+    request: pytest.FixtureRequest,
+):
+    assert expected == merge_huggingface_settings_extra(
+        request.getfixturevalue(model_settings), env_params
+    )
+
+
+def test_merge_huggingface_settings_extra_raises(model_settings_extra_none):
+    with pytest.raises(MissingHuggingFaceSettings):
+        merge_huggingface_settings_extra(model_settings_extra_none, {})
+
+
+@pytest.mark.parametrize(
+    "model_settings,env_params,expected",
+    [
+        (
+            "model_settings_extra_task",
+            '[{"name": "task", "value": "question-answering", "type": "STRING"}]',
+            HuggingFaceSettings(
+                task="question-answering",
+                task_suffix="",
+                pretrained_model="distilgpt2",
+                pretrained_tokenizer=None,
+                framework=None,
+                optimum_model=False,
+                device=-1,
+                inter_op_threads=None,
+                intra_op_threads=None,
+            ),
+        ),
+        (
+            "model_settings_extra_task",
+            "[]",
+            HuggingFaceSettings(
+                task="text-generation",
+                task_suffix="",
+                pretrained_model="distilgpt2",
+                pretrained_tokenizer=None,
+                framework=None,
+                optimum_model=False,
+                device=-1,
+                inter_op_threads=None,
+                intra_op_threads=None,
+            ),
+        ),
+        (
+            "model_settings_extra_none",
+            '[{"name": "task", "value": "question-answering", "type": "STRING"}]',
+            HuggingFaceSettings(
+                task="question-answering",
+                task_suffix="",
+                pretrained_model=None,
+                pretrained_tokenizer=None,
+                framework=None,
+                optimum_model=False,
+                device=-1,
+                inter_op_threads=None,
+                intra_op_threads=None,
+            ),
+        ),
+        (
+            "model_settings_extra_empty",
+            '[{"name": "task", "value": "question-answering", "type": "STRING"}]',
+            HuggingFaceSettings(
+                task="question-answering",
+                task_suffix="",
+                pretrained_model=None,
+                pretrained_tokenizer=None,
+                framework=None,
+                optimum_model=False,
+                device=-1,
+                inter_op_threads=None,
+                intra_op_threads=None,
+            ),
+        ),
+    ],
+)
+def test_get_huggingface_settings(
+    model_settings: str,
+    env_params: str,
+    expected: HuggingFaceSettings,
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(PARAMETERS_ENV_NAME, env_params)
+
+    assert expected == get_huggingface_settings(request.getfixturevalue(model_settings))
+
+    monkeypatch.delenv(PARAMETERS_ENV_NAME)
+
+
+def test_get_huggingface_settings_raises(model_settings_extra_none):
+    with pytest.raises(MissingHuggingFaceSettings):
+        get_huggingface_settings(model_settings_extra_none)

--- a/runtimes/huggingface/tests/test_settings.py
+++ b/runtimes/huggingface/tests/test_settings.py
@@ -7,6 +7,7 @@ from mlserver.settings import ModelSettings, ModelParameters
 from mlserver_huggingface.runtime import HuggingFaceRuntime
 from mlserver_huggingface.settings import (
     HuggingFaceSettings,
+    ExtraDict,
     PARAMETERS_ENV_NAME,
     get_huggingface_settings,
     merge_huggingface_settings_extra,
@@ -70,7 +71,7 @@ def model_settings_extra_empty():
 )
 def test_merge_huggingface_settings_extra(
     model_settings: str,
-    env_params: Dict,
+    env_params: ExtraDict,
     expected: Dict,
     request: pytest.FixtureRequest,
 ):


### PR DESCRIPTION
If settings for the model are provided in both the `model-settings.json` *and* environment variables, merge them.

Precedence is given to environment variables.

FIXES #1329 