### PR TITLE
Document and test behaviour around NaN

### DIFF
--- a/docs/user-guide/content-type.md
+++ b/docs/user-guide/content-type.md
@@ -202,6 +202,56 @@ raw_response = response.json()
 inference_response = InferenceResponse(**raw_response)
 ```
 
+#### Support for NaN values
+
+The NaN (Not a Number) value is used in Numpy and other scientific libraries to
+describe an invalid or missing value (e.g. a division by zero).
+In some scenarios, it may be desirable to let your models receive and / or
+output NaN values (e.g. these can be useful sometimes with GBTs, like XGBoost
+models).
+This is why MLServer supports encoding NaN values on your request / response
+payloads under some conditions.
+
+In order to send / receive NaN values, you must ensure that:
+
+- You are using the `REST` interface.
+- The input / output entry containing NaN values uses the `FP32` datatype.
+- You are either using the [Pandas codec](#pandas-dataframe) or the [Numpy
+  codec](#numpy-array).
+
+Assuming those conditions are satisfied, any `null` value within your tensor
+payload will be converted to NaN.
+
+For example, if you take the following Numpy array:
+
+```python
+import numpy as np
+
+foo = np.array([[1.2, 2.3], [np.NaN, 4.5]])
+```
+
+We could encode it as:
+
+```{code-block} json
+---
+emphasize-lines: 8
+---
+{
+  "inputs": [
+    {
+      "name": "foo",
+      "parameters": {
+        "content_type": "np"
+      },
+      "data": [1, 2, null, 4]
+      "datatype": "FP32",
+      "shape": [2, 2],
+    }
+  ]
+}
+```
+
+
 ### Model Metadata
 
 Content types can also be defined as part of the [model's

--- a/docs/user-guide/content-type.md
+++ b/docs/user-guide/content-type.md
@@ -215,7 +215,8 @@ payloads under some conditions.
 In order to send / receive NaN values, you must ensure that:
 
 - You are using the `REST` interface.
-- The input / output entry containing NaN values uses the `FP32` datatype.
+- The input / output entry containing NaN values uses either the `FP16`, `FP32`
+  or `FP64` datatypes.
 - You are either using the [Pandas codec](#pandas-dataframe) or the [Numpy
   codec](#numpy-array).
 
@@ -244,7 +245,7 @@ emphasize-lines: 8
         "content_type": "np"
       },
       "data": [1, 2, null, 4]
-      "datatype": "FP32",
+      "datatype": "FP64",
       "shape": [2, 2],
     }
   ]

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -97,12 +97,12 @@ def _encode_data(data: np.ndarray, datatype: str) -> list:
     # Replace NaN with null
     has_nan = np.isnan(data).any()
     if has_nan:
-        flattened_list = list(map(_convert_nan, flattened_list))
+        flattened_list = list(map(convert_nan, flattened_list))
 
     return flattened_list
 
 
-def _convert_nan(val):
+def convert_nan(val):
     if np.isnan(val):
         return None
 

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -92,7 +92,21 @@ def _encode_data(data: np.ndarray, datatype: str) -> list:
             # need to encapsulate it into a list so that it's compatible.
             return [data.tobytes()]
 
-    return data.flatten().tolist()
+    flattened_list = data.flatten().tolist()
+
+    # Replace NaN with null
+    has_nan = np.isnan(data).any()
+    if has_nan:
+        flattened_list = list(map(_convert_nan, flattened_list))
+
+    return flattened_list
+
+
+def _convert_nan(val):
+    if np.isnan(val):
+        return None
+
+    return val
 
 
 @register_input_codec

--- a/mlserver/codecs/numpy.py
+++ b/mlserver/codecs/numpy.py
@@ -95,9 +95,12 @@ def _encode_data(data: np.ndarray, datatype: str) -> list:
     flattened_list = data.flatten().tolist()
 
     # Replace NaN with null
-    has_nan = np.isnan(data).any()
-    if has_nan:
-        flattened_list = list(map(convert_nan, flattened_list))
+    if datatype != "BYTES":
+        # The `isnan` method doesn't work on Numpy arrays with non-numeric
+        # types
+        has_nan = np.isnan(data).any()
+        if has_nan:
+            flattened_list = list(map(convert_nan, flattened_list))
 
     return flattened_list
 

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Optional, Any, List, Tuple
 
 from .base import RequestCodec, register_request_codec
-from .numpy import to_datatype, to_dtype
+from .numpy import to_datatype, to_dtype, convert_nan
 from .string import encode_str, StringCodec
 from .utils import get_decoded_or_raw, InputOrOutput, inject_batch_dimension
 from .lists import ListElement
@@ -35,8 +35,13 @@ def _to_series(input_or_output: InputOrOutput) -> pd.Series:
 def _to_response_output(series: pd.Series, use_bytes: bool = True) -> ResponseOutput:
     datatype = to_datatype(series.dtype)
     data = series.tolist()
-    content_type = None
 
+    # Replace NaN with null
+    has_nan = series.isnull().any()
+    if has_nan:
+        data = list(map(convert_nan, data))
+
+    content_type = None
     if datatype == "BYTES":
         data, content_type = _process_bytes(data, use_bytes)
 

--- a/tests/codecs/test_numpy.py
+++ b/tests/codecs/test_numpy.py
@@ -121,8 +121,8 @@ def test_encode_output(payload: np.ndarray, expected: ResponseOutput):
             np.array(["foo", "bar"], dtype=str),
         ),
         (
-            RequestInput(name="foo", shape=[3], data=[1, 2, None], datatype="FP64"),
-            np.array([1, 2, np.NaN], dtype="float64"),
+            RequestInput(name="foo", shape=[3], data=[1, 2, None], datatype="FP16"),
+            np.array([1, 2, np.NaN], dtype="float16"),
         ),
     ],
 )

--- a/tests/codecs/test_numpy.py
+++ b/tests/codecs/test_numpy.py
@@ -79,6 +79,16 @@ def test_can_encode(payload: Any, expected: bool):
             ),
         ),
         (
+            np.array([None, "bar"]),
+            ResponseOutput(
+                name="foo",
+                shape=[2, 1],
+                data=[None, "bar"],
+                datatype="BYTES",
+                parameters=Parameters(content_type=NumpyCodec.ContentType),
+            ),
+        ),
+        (
             np.array([2.3, 3.4, np.NaN]),
             ResponseOutput(
                 name="foo",
@@ -127,48 +137,6 @@ def test_encode_output(payload: np.ndarray, expected: ResponseOutput):
     ],
 )
 def test_decode_input(request_input: RequestInput, expected: np.ndarray):
-    decoded = NumpyCodec.decode_input(request_input)
-    np.testing.assert_array_equal(decoded, expected)
-
-
-@pytest.mark.parametrize(
-    "request_input, expected",
-    [
-        (
-            RequestInput(name="foo", shape=[3], data=[1, 2, 3], datatype="INT32"),
-            np.array([1, 2, 3]),
-        ),
-        (
-            RequestInput(name="foo", shape=[2, 2], data=[1, 2, 3, 4], datatype="INT32"),
-            np.array([[1, 2], [3, 4]]),
-        ),
-        (
-            RequestInput(name="foo", shape=[2], data=[1, 2], datatype="FP32"),
-            np.array([1, 2], dtype=float),
-        ),
-        (
-            RequestInput(
-                name="foo", shape=[2, 1], data=[b"\x01\x02"], datatype="BYTES"
-            ),
-            np.array([[b"\x01"], [b"\x02"]]),
-        ),
-        (
-            RequestInput(name="foo", shape=[2], data=["foo", "bar"], datatype="BYTES"),
-            np.array(["foo", "bar"]),
-        ),
-        (
-            RequestInput(
-                name="foo",
-                shape=[3],
-                data=[2.3, 3.4, None],
-                datatype="FP32",
-                parameters=Parameters(content_type=NumpyCodec.ContentType),
-            ),
-            np.array([2.3, 3.4, np.NaN], dtype="float32"),
-        ),
-    ],
-)
-def test_encode_input(request_input: RequestInput, expected: np.ndarray):
     decoded = NumpyCodec.decode_input(request_input)
     np.testing.assert_array_equal(decoded, expected)
 

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -70,6 +70,16 @@ def test_can_encode(payload: Any, expected: bool):
                 name="bar", shape=[2, 1], data=[[1, 2, 3], [4, 5, 6]], datatype="BYTES"
             ),
         ),
+        (
+            pd.Series(data=[4, np.NaN, 6], name="bar"),
+            True,
+            ResponseOutput(
+                name="bar",
+                shape=[3, 1],
+                data=[4, None, 6],
+                datatype="FP64",
+            ),
+        ),
     ],
 )
 def test_to_response_output(series, use_bytes, expected):
@@ -131,6 +141,23 @@ def test_to_response_output(series, use_bytes, expected):
                         data=["A", "B", "C"],
                         parameters=Parameters(content_type=StringCodec.ContentType),
                     ),
+                ],
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "a": [1, np.NaN, 3],
+                }
+            ),
+            False,
+            InferenceResponse(
+                model_name="my-model",
+                parameters=Parameters(content_type=PandasCodec.ContentType),
+                outputs=[
+                    ResponseOutput(
+                        name="a", shape=[3, 1], datatype="FP64", data=[1, None, 3]
+                    )
                 ],
             ),
         ),


### PR DESCRIPTION
Fixes #1154

## Changelog

- Add docs around NaN behaviour
- Extend Numpy and Pandas codecs to handle NaNs (only for `FP*` datatypes)