### PR TITLE
Bump Miniforge3 to 23.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal
 SHELL ["/bin/bash", "-c"]
 
 ARG PYTHON_VERSION=3.10.11
-ARG CONDA_VERSION=23.1.0
-ARG MINIFORGE_VERSION=${CONDA_VERSION}-1
+ARG CONDA_VERSION=23.3.1
+ARG MINIFORGE_VERSION=${CONDA_VERSION}-0
 ARG RUNTIMES="all"
 
 # Set a few default environment variables, including `LD_LIBRARY_PATH`


### PR DESCRIPTION
## Changelog
- Update Conda to bump the included `requests` lib to `2.31.0+` to sort out CVE-2023-32681