### PR TITLE
added model_kwargs to huggingface model

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -25,7 +25,6 @@ def load_pipeline_from_settings(
     hf_settings: HuggingFaceSettings, settings: ModelSettings
 ) -> Pipeline:
     pipeline = _get_pipeline_class(hf_settings)
-
     batch_size = 1
     if settings.max_batch_size:
         batch_size = settings.max_batch_size

--- a/runtimes/huggingface/mlserver_huggingface/common.py
+++ b/runtimes/huggingface/mlserver_huggingface/common.py
@@ -54,6 +54,7 @@ def load_pipeline_from_settings(
     hf_pipeline = pipeline(
         hf_settings.task_name,
         model=model,
+        model_kwargs=hf_settings.model_kwargs,
         tokenizer=tokenizer,
         device=hf_settings.device,
         batch_size=batch_size,

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -61,7 +61,10 @@ class HuggingFaceSettings(BaseSettings):
     """
     Name of the model that should be loaded in the pipeline.
     """
-
+    model_kwargs: Optional[dict] = None
+    """
+    model kwargs that should be loaded in the pipeline.
+    """
     pretrained_tokenizer: Optional[str] = None
     """
     Name of the tokenizer that should be loaded in the pipeline.

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -12,7 +12,7 @@ from mlserver.settings import ModelSettings, ModelParameters
 
 from mlserver_huggingface.runtime import HuggingFaceRuntime
 from mlserver_huggingface.settings import HuggingFaceSettings
-from mlserver_huggingface.common import load_pipeline_from_settings, _get_pipeline_class
+from mlserver_huggingface.common import load_pipeline_from_settings
 
 
 @pytest.mark.parametrize(

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -123,12 +123,10 @@ def test_pipeline_is_initialised_with_correct_model_kwargs(
     mock_pipeline_factory.return_value = MagicMock()
 
     hf_settings = HuggingFaceSettings(model_kwargs=model_kwargs)
-
+    model_params = ModelParameters(uri="dummy_uri")
     model_settings = ModelSettings(
-        name="foo",
-        implementation=HuggingFaceRuntime,
+        name="foo", implementation=HuggingFaceRuntime, parameters=model_params
     )
-
     _ = load_pipeline_from_settings(hf_settings, model_settings)
 
     mock_pipeline_factory.return_value.assert_called_once()

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -155,7 +155,7 @@ def test_pipeline_is_initialised_with_correct_model_kwargs(
 def test_pipeline_uses_model_kwargs(
     pretrained_model: str,
     model_kwargs: Optional[dict],
-    expected: bool,
+    expected: torch.dtype,
 ):
     hf_settings = HuggingFaceSettings(
         pretrained_model=pretrained_model,

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -138,7 +138,7 @@ def test_pipeline_is_initialised_with_correct_model_kwargs(
 
 
 @pytest.mark.parametrize(
-    "pretrained_model, model_kwargs, expected_model_kwargs",
+    "pretrained_model, model_kwargs, expected",
     [
         (
             "hf-internal-testing/tiny-bert-for-token-classification",
@@ -155,7 +155,7 @@ def test_pipeline_is_initialised_with_correct_model_kwargs(
 def test_pipeline_uses_model_kwargs(
     pretrained_model: str,
     model_kwargs: Optional[dict],
-    expected_model_kwargs: Optional[str],
+    expected: bool,
 ):
     hf_settings = HuggingFaceSettings(
         pretrained_model=pretrained_model,
@@ -169,7 +169,7 @@ def test_pipeline_uses_model_kwargs(
 
     m = load_pipeline_from_settings(hf_settings, model_settings)
 
-    assert m.model.is_loaded_in_8bit == expected_model_kwargs
+    assert m.model.is_loaded_in_8bit == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is for issue [1344](https://github.com/SeldonIO/MLServer/issues/1344)
This allow `model-settings.json` to take `model_kwargs`:
example below:
```json
{
    "name": "llama",
    "implementation": "mlserver_huggingface.HuggingFaceRuntime",
    "parameters": {
        "extra": {
            "task": "text-generation",
            "pretrained_model": "daryl149/llama-2-7b-hf",
            "model_kwargs": {
                "device_map": "auto",
                "load_in_8bit": true
            }
        }
    }
}

``` 
