### PR TITLE
Update opentelemetry dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,10 @@ uvloop = {version = "*", markers = "sys_platform != 'win32' and (sys_platform !=
 ## functionality added in Python 3.10
 ## https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
 importlib-resources = "^5.12.0"
-opentelemetry-instrumentation-fastapi = "^0.39b0"
+opentelemetry-instrumentation-fastapi = ">=0.39b0"
 opentelemetry-sdk = "^1.18.0"
 opentelemetry-exporter-otlp-proto-grpc = "^1.18.0"
-opentelemetry-instrumentation-grpc = "^0.39b0"
+opentelemetry-instrumentation-grpc = ">=0.39b0"
 
 [tool.poetry.group.dev.dependencies]
 datamodel-code-generator = "0.21.0"


### PR DESCRIPTION
The poetry caret requirements operate differently for version 0.x than for 1.x and above. For ^0.2.0, for example, it would update to 0.2.1 but not 0.3.0. Whereas ^1.2.0 would update to 1.3.0 if it existed.

This has the effect of pinning these opentelemetry deps to a specific version, which I'm not sure was intended, and creates problems for projects that depend on mlserver and also use opentelemetry. Updating to `>=` instead of `^` should still work and offer more flexibility