### PR TITLE
Improve typing on `Environment` class

### DIFF
--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -114,7 +114,7 @@ class Environment:
 
         return ""
 
-    def __enter__(self):
+    def __enter__(self) -> "Environment":
         self._prev_sys_path = sys.path
         self._prev_bin_path = os.environ["PATH"]
 


### PR DESCRIPTION
Per title; added return type of `Environment` to `__enter__()` as it was missing