### PR TITLE
Fix mlserver_huggingface settings device type

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -83,10 +83,10 @@ class HuggingFaceSettings(BaseSettings):
     runtime.
     """
 
-    device: Optional[Union[int, str]] = -1
+    device: Optional[Union[int, str]] = None
     """
     Device in which this pipeline will be loaded (e.g., "cpu", "cuda:1", "mps",
-    or a GPU ordinal rank like 1).
+    or a GPU ordinal rank like 1). Default value of None becomes cpu.
     """
 
     inter_op_threads: Optional[int] = None

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -83,7 +83,7 @@ class HuggingFaceSettings(BaseSettings):
     runtime.
     """
 
-    device: int = -1
+    device: Optional[Union[int, str, "torch.device"]] = -1
     """
     Device in which this pipeline will be loaded (e.g., "cpu", "cuda:1", "mps",
     or a GPU ordinal rank like 1).

--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -83,7 +83,7 @@ class HuggingFaceSettings(BaseSettings):
     runtime.
     """
 
-    device: Optional[Union[int, str, "torch.device"]] = -1
+    device: Optional[Union[int, str]] = -1
     """
     Device in which this pipeline will be loaded (e.g., "cpu", "cuda:1", "mps",
     or a GPU ordinal rank like 1).

--- a/runtimes/huggingface/tests/test_common.py
+++ b/runtimes/huggingface/tests/test_common.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 from optimum.onnxruntime.modeling_ort import ORTModelForQuestionAnswering
 from transformers.models.distilbert.modeling_distilbert import (
     DistilBertForQuestionAnswering,
@@ -167,6 +167,43 @@ def test_pipeline_uses_model_kwargs(
     m = load_pipeline_from_settings(hf_settings, model_settings)
 
     assert m.model.dtype == expected
+
+
+@pytest.mark.parametrize(
+    "pretrained_model, device, expected",
+    [
+        (
+            "hf-internal-testing/tiny-bert-for-token-classification",
+            None,
+            torch.device("cpu"),
+        ),
+        (
+            "hf-internal-testing/tiny-bert-for-token-classification",
+            -1,
+            torch.device("cpu"),
+        ),
+        (
+            "hf-internal-testing/tiny-bert-for-token-classification",
+            "cpu",
+            torch.device("cpu"),
+        ),
+    ],
+)
+def test_pipeline_cpu_device_set(
+    pretrained_model: str,
+    device: Optional[Union[str, int]],
+    expected: torch.device,
+):
+    hf_settings = HuggingFaceSettings(
+        pretrained_model=pretrained_model, task="token-classification", device=device
+    )
+    model_settings = ModelSettings(
+        name="foo",
+        implementation=HuggingFaceRuntime,
+    )
+    m = load_pipeline_from_settings(hf_settings, model_settings)
+
+    assert m.model.device == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If using a `model-settings.json` of the following form:
```json
{
    "name": "my-model",
    "implementation": "mlserver_huggingface.HuggingFaceRuntime",
    "parameters": {
        "extra": {
            "task": "text-generation",
            "pretrained_model": "model/path",
            "model_kwargs": {
                "load_in_8bit": true
            }
        }
    }
}
```

an error occurs when spinning up the server:
```
The model has been loaded with `accelerate` and therefore cannot be moved to a specific device. Please discard the `device` argument when creating your pipeline object.
```
because the `load_in_8bit` model kwarg makes forces the model to be loaded with Accelerate, and `HuggingFaceSettings.device` default value of -1 is passed. I tried simply passing `"device": null` to the model settings json to prevent this default value, but this wasn't accepted because the schema is typed to `int`.

The solution is to expand the typing of `HuggingFaceSettings.device` to accept null (and string, while we're at it). Therefore I have updated the typing to `Optional[Union[int,str]]`, which is very close to the type hint used in the underlying transformers [pipeline](https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/__init__.py#L542).

I have tested the above model settings json with this change and the server starts as expected.