### PR TITLE
 docs: List supported Python versions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ Out of the box, MLServer provides support for:
 | Alibi-Explain | ✅        | [MLServer Alibi Explain](./runtimes/alibi-explain)               |
 | HuggingFace   | ✅        | [MLServer HuggingFace](./runtimes/huggingface)                   |
 
+## Supported Python Versions
+
+🔴 Unsupported
+
+🟠 Deprecated: To be removed in a future version
+
+🟢 Supported
+
+🔵 Untested
+
+| Python Version | Status |
+| -------------- | ------ |
+| 3.7            | 🔴     |
+| 3.8            | 🔴     |
+| 3.9            | 🟢     |
+| 3.10           | 🟢     |
+| 3.11           | 🔵     |
+| 3.12           | 🔵     |
+
 ## Examples
 
 To see MLServer in action, check out [our full list of

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Out of the box, MLServer provides support for:
 | XGBoost       | ✅        | [MLServer XGBoost](./runtimes/xgboost)                           |
 | Spark MLlib   | ✅        | [MLServer MLlib](./runtimes/mllib)                               |
 | LightGBM      | ✅        | [MLServer LightGBM](./runtimes/lightgbm)                         |
-| CatBoost     | ✅        | [MLServer CatBoost](./runtimes/catboost)                         |
+| CatBoost      | ✅        | [MLServer CatBoost](./runtimes/catboost)                         |
 | Tempo         | ✅        | [`github.com/SeldonIO/tempo`](https://github.com/SeldonIO/tempo) |
 | MLflow        | ✅        | [MLServer MLflow](./runtimes/mlflow)                             |
 | Alibi-Detect  | ✅        | [MLServer Alibi Detect](./runtimes/alibi-detect)                 |


### PR DESCRIPTION
> Python 3.8 is due to reach its scheduled upstream end-of-life in October 2024.

In preparation for this, we're marking support for this version as deprecated. It's still available, but will be removed in a future version.