### PR TITLE
build: Migrate away from Node v16 actions

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -32,7 +32,7 @@ jobs:
             ./licenses/license_info.no_versions.csv
       - name: Open PR with License Changes
         if: ${{ failure() }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           add-paths: ./licenses
           commit-message: Re-generate license info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           args: -d=false -l=2
           header: "# Changelog\n"
       - name: Commiting & Pushing Updated Changelog
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update CHANGELOG.md for ${{ github.event.release.tag_name }}
           tagging_message: ${{ github.event.release.tag_name }}
@@ -33,7 +33,7 @@ jobs:
           # changelog.
           push_options: "--force"
       - name: Tagging release as stable
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update CHANGELOG.md for ${{ github.event.release.tag_name }}
           tagging_message: stable
@@ -57,7 +57,7 @@ jobs:
           args: -d=false -l=2
           header: "# Changelog\n\n"
       - name: Open PR with Changelog changes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           add-paths: ./CHANGELOG.md
           commit-message: Update Changelog

--- a/.github/workflows/release-sc.yml
+++ b/.github/workflows/release-sc.yml
@@ -15,12 +15,15 @@ jobs:
         run: |
           ./hack/update-version.sh ${{ github.event.inputs.version }}
       - name: Commiting & Pushing Updated Version Tag
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Bump version to ${{ github.event.inputs.version }}
           tagging_message: ${{ github.event.inputs.version }}
       - name: Draft Release
-        uses: softprops/action-gh-release@v1
+        # TODO: Use a version value, when available [1]
+        #
+        # [1] https://github.com/softprops/action-gh-release/issues/410
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           generate_release_notes: false
           draft: true
@@ -62,7 +65,7 @@ jobs:
             --file=Dockerfile
             --policy-path=.snyk
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -72,7 +75,7 @@ jobs:
         env:
           MLSERVER_IMAGE: seldonio/mlserver-sc:${{ github.event.inputs.version }}
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.SC_QUAY_USERNAME }}
@@ -132,7 +135,7 @@ jobs:
             --file=Dockerfile
             --policy-path=.snyk
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -142,7 +145,7 @@ jobs:
         env:
           MLSERVER_IMAGE: seldonio/mlserver-sc-slim:${{ github.event.inputs.version }}
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.SC_QUAY_USERNAME_SLIM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,15 @@ jobs:
         run: |
           ./hack/update-version.sh ${{ github.event.inputs.version }}
       - name: Commiting & Pushing Updated Version Tag
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Bump version to ${{ github.event.inputs.version }}
           tagging_message: ${{ github.event.inputs.version }}
       - name: Draft Release
-        uses: softprops/action-gh-release@v1
+        # TODO: Use a version value, when available [1]
+        #
+        # [1] https://github.com/softprops/action-gh-release/issues/410
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           generate_release_notes: true
           draft: true
@@ -203,7 +206,7 @@ jobs:
             --file=Dockerfile
             --policy-path=.snyk
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -211,7 +214,7 @@ jobs:
         run: |
           docker push $MLSERVER_IMAGE-${{ matrix.runtime }}
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -240,4 +243,3 @@ jobs:
         env:
           PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
           PROJECT_ID: 63566bb9822ce8cef9ba27fc
-


### PR DESCRIPTION
A few workflows needed a little updating. One of them doesn't have a specific integer version, and I've linked to the issue explaining why.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: stefanzweifel/git-auto-commit-action@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

FIXES INFRA-835
