### PR TITLE
fix(ci): Missing quote in CI test for all_runtimes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Maximize build space


### PR DESCRIPTION
There is a missing quote that made the CI fail. This is impacting tests that run post-merge to `master` for py3.9.