### PR TITLE
fix(ci): Have separate smaller tasks for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           draft: true
           tag_name: ${{ github.event.inputs.version }}
 
-  mlserver:
+  mlserver-image-build:
     needs: draft-release
     runs-on: ubuntu-latest
     steps:
@@ -51,10 +51,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Build Docker Image
         run: |
           DOCKER_BUILDKIT=1 docker build . \
@@ -110,7 +106,7 @@ jobs:
           PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
           PROJECT_ID: 63566bb9822ce8cef9ba27fc
 
-  mlserver-slim:
+  mlserver-slim-image-build:
     needs: draft-release
     runs-on: ubuntu-latest
     steps:
@@ -127,10 +123,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.version }}
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Build Docker Image
         run: |
           DOCKER_BUILDKIT=1 docker build . \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           generate_release_notes: true
           draft: true
           tag_name: ${{ github.event.inputs.version }}
+
   mlserver:
     needs: draft-release
     runs-on: ubuntu-latest
@@ -54,22 +55,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: false
-      - name: Build Python wheel
-        run: |
-          poetry build
-          poetry publish --skip-existing
-        env:
-          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       - name: Build Docker Image
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
-            --build-arg RUNTIMES="" \
-            -t $MLSERVER_IMAGE-slim
           DOCKER_BUILDKIT=1 docker build . \
             --build-arg RUNTIMES=all \
             -t $MLSERVER_IMAGE
@@ -84,7 +71,72 @@ jobs:
             --severity-threshold=high
             --file=Dockerfile
             --policy-path=.snyk
-      - name: Scan Docker Slim Image
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push to DockerHub
+        run: |
+          docker push $MLSERVER_IMAGE
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Push to Quay.io
+        run: |
+          docker tag $MLSERVER_IMAGE $QUAY_MLSERVER_IMAGE
+          docker push $QUAY_MLSERVER_IMAGE
+      - name: Install preflight
+        run: |
+          wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/$PREFLIGHT_VERSION/preflight-linux-amd64
+          chmod u+x preflight-linux-amd64
+          sudo mv preflight-linux-amd64 /usr/local/bin/preflight
+          preflight --version
+        env:
+          PREFLIGHT_VERSION: 1.4.2
+      - name: Submit preflight results
+        run: |
+          preflight check container \
+            $QUAY_MLSERVER_IMAGE \
+            --docker-config=${HOME}/.docker/config.json \
+            --certification-project-id=$PROJECT_ID \
+            --pyxis-api-token=$PYXIS_API_TOKEN \
+            --artifacts ./artifacts/mlserver-slim \
+            --submit
+        env:
+          PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
+          PROJECT_ID: 63566bb9822ce8cef9ba27fc
+
+  mlserver-slim:
+    needs: draft-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          root-reserve-mb: 30720
+          swap-size-mb: 1024
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build Docker Image
+        run: |
+          DOCKER_BUILDKIT=1 docker build . \
+            --build-arg RUNTIMES="" \
+            -t $MLSERVER_IMAGE-slim
+      - name: Scan Docker Image
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -103,7 +155,6 @@ jobs:
       - name: Push to DockerHub
         run: |
           docker push $MLSERVER_IMAGE-slim
-          docker push $MLSERVER_IMAGE
       - name: Login to Quay.io
         uses: docker/login-action@v3
         with:
@@ -114,8 +165,6 @@ jobs:
         run: |
           docker tag $MLSERVER_IMAGE-slim $QUAY_MLSERVER_IMAGE-slim
           docker push $QUAY_MLSERVER_IMAGE-slim
-          docker tag $MLSERVER_IMAGE $QUAY_MLSERVER_IMAGE
-          docker push $QUAY_MLSERVER_IMAGE
       - name: Install preflight
         run: |
           wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/$PREFLIGHT_VERSION/preflight-linux-amd64
@@ -133,17 +182,33 @@ jobs:
             --pyxis-api-token=$PYXIS_API_TOKEN \
             --artifacts ./artifacts/mlserver \
             --submit
-          preflight check container \
-            $QUAY_MLSERVER_IMAGE \
-            --docker-config=${HOME}/.docker/config.json \
-            --certification-project-id=$PROJECT_ID \
-            --pyxis-api-token=$PYXIS_API_TOKEN \
-            --artifacts ./artifacts/mlserver-slim \
-            --submit
         env:
           PYXIS_API_TOKEN: ${{ secrets.PYXIS_API_TOKEN }}
           PROJECT_ID: 63566bb9822ce8cef9ba27fc
-
+          
+  pypy-publish:
+    needs: draft-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.version }}
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+      - name: Build Python wheel
+        run: |
+          poetry build
+          poetry publish --skip-existing
+        env:
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      
   runtimes:
     needs: draft-release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently we have a task `mlserver` that:
- build python wheels and push to pypy
- build and scan mlserver big image
- build and scan mlserver slim image

This change breaks them up into individual steps as we started running out of disk space.