### PR TITLE
fix(ci): optimise disk space for GH workers

### DIFF
--- a/.github/workflows/release-sc.yml
+++ b/.github/workflows/release-sc.yml
@@ -41,7 +41,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - uses: actions/checkout@v4
         with:
@@ -118,7 +118,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - uses: actions/checkout@v4
         with:
@@ -225,7 +225,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - uses: actions/checkout@v4
       - name: Build Docker Image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
           remove-android: 'true'
           remove-codeql: 'true'
           remove-docker-images: 'true'
-          root-reserve-mb: 30720
+          overprovision-lvm: 'true'
           swap-size-mb: 1024
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
This change introduces the use of `overprovision-lvm` (instead of setting `root-reserve-mb`) to optimise disk space for the docker build actions, which is the recommendation described here 
![image](https://github.com/SeldonIO/llm-runtimes/assets/5911512/49a624ae-2401-4feb-bce6-253e26d5cea3)

from the action [docs](https://github.com/easimon/maximize-build-space/tree/master/).