### PR TITLE
build: Update maintainers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,4 +69,4 @@ jobs:
             # Updated CHANGELOG\n
             This automated PR re-generates the changelog to keep it up to
             date."
-          reviewers: adriangonz
+          reviewers: "SeldonIO/mlops"

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,4 @@
 approvers:
-- cliveseldon
-- adriangonz
-- RafalSkolasinski
+- SeldonIO/mlops
 reviewers:
-- cliveseldon
-- adriangonz
-- RafalSkolasinski
+- SeldonIO/mlops

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,8 +1,4 @@
 approvers:
-- cliveseldon
-- adriangonz
-- RafalSkolasinski
+- SeldonIO/mlops
 reviewers:
-- cliveseldon
-- adriangonz
-- RafalSkolasinski
+- SeldonIO/mlops


### PR DESCRIPTION
Doing some cleanup. This matches the reviewers in the Dependabot config [1].

[1] https://github.com/jesse-c/MLServer/blob/eefbb430870b994f223251f4d8b988482ea18163/.github/dependabot.yml#L72
