### PR TITLE
Fix JSON input shapes

### DIFF
--- a/docs/user-guide/content-type.md
+++ b/docs/user-guide/content-type.md
@@ -461,19 +461,19 @@ emphasize-lines: 3, 7-8, 13-14, 19-20
       "name": "A",
       "data": ["a1", "a2", "a3", "a4"]
       "datatype": "BYTES",
-      "shape": [3],
+      "shape": [4],
     },
     {
       "name": "B",
       "data": ["b1", "b2", "b3", "b4"]
       "datatype": "BYTES",
-      "shape": [3],
+      "shape": [4],
     },
     {
       "name": "C",
       "data": ["c1", "c2", "c3", "c4"]
       "datatype": "BYTES",
-      "shape": [3],
+      "shape": [4],
     },
   ]
 }


### PR DESCRIPTION
Closes #1678 

Fixes JSON Payload input shapes in Pandas DataFrame content type section of User Guide.

For example DataFrame:

| A   | B   | C   |
| --- | --- | --- |
| a1  | b1  | c1  |
| a2  | b2  | c2  |
| a3  | b3  | c3  |
| a4  | b4  | c4  |

All inputs in JSON payload had `"shape": [3]` (the number of _columns_ in the DataFrame) instead of `"shape": [4]` (the number of _rows_ in the DataFrame). 

This PR assumes that #1625 is in fact a bug, and that the shape values should not have an extra dimension added to them. If that assumption is incorrect, I would recommend also adding a disclaimer to this section like the one seen in the [Numpy Array section](https://mlserver.readthedocs.io/en/latest/user-guide/content-type.html#numpy-array) before it:

> ### Note
>By default, MLServer will always assume that an array with a single-dimensional shape, e.g. [N], is equivalent to [N, 1]. That is, each entry will be treated like a single one-dimensional data point (i.e. instead of a [1, D] array, where the full array is a single D-dimensional data point). To avoid any ambiguity, where possible, the Numpy codec will always explicitly encode [N] arrays as [N, 1].