### PR TITLE
build: Add Catboost runtime to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,13 @@ updates:
     reviewers:
       - "SeldonIO/mlops"
 
+  - package-ecosystem: "pip"
+    directory: "/runtimes/catboost"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "SeldonIO/mlops"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
It wasn't listed, as the other runtimes were.
