### PR TITLE
test: Detect generate failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,24 +9,47 @@ on:
     branches: [master]
 
 jobs:
-  lint:
+  generate:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: false
       - name: Install dependencies
-        run: |
-          make install-dev
+        run: poetry install --sync --only dev
+      - name: Generate
+        run: make generate
+      - name: Check for changes
+        run: git --no-pager diff --exit-code .
+
+  lint:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+      - name: Install dependencies
+        run: poetry install --sync --only dev
       - name: Lint
-        run: |
-          make lint
+        run: make lint
 
   mlserver:
     strategy:
@@ -72,11 +95,9 @@ jobs:
         with:
           virtualenvs-create: false
       - name: Install Dependencies
-        run: |
-          poetry install --sync --only dev
+        run: poetry install --sync --only dev
       - name: Test
-        run: |
-          tox -e mlserver
+        run: tox -e mlserver
 
   runtimes:
     strategy:
@@ -116,11 +137,9 @@ jobs:
         with:
           virtualenvs-create: false
       - name: Install Dependencies
-        run: |
-          poetry install --sync --only dev
+        run: poetry install --sync --only dev
       - name: Test
-        run: |
-          tox -c ./runtimes/${{ matrix.tox-environment }}
+        run: tox -c ./runtimes/${{ matrix.tox-environment }}
 
   # Ensure that having all the runtimes installed together works
   all-runtimes:
@@ -180,8 +199,6 @@ jobs:
         with:
           virtualenvs-create: false
       - name: Install Dependencies
-        run: |
-          poetry install --sync --only dev
+        run: poetry install --sync --only dev
       - name: Test
-        run: |
-          tox -e all-runtimes
+        run: tox -e all-runtimes

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test:
 		tox -c $$_runtime; \
 	done
 
-lint: generate
+lint:
 	black --check .
 	flake8 .
 	mypy ./mlserver
@@ -77,7 +77,9 @@ lint: generate
 	done
 	mypy ./benchmarking
 	mypy ./docs/examples
-	# Check if something has changed after generation
+
+# Check if something has changed after generation
+lint-generate: generate
 	git \
 		--no-pager diff \
 		--exit-code \

--- a/hack/generate-types.sh
+++ b/hack/generate-types.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
 ROOT_FOLDER="$(dirname "${0}")/.."
 
 _generatePB() {


### PR DESCRIPTION
Currently, since we don't exit on a command failure, it's been missed that generation is currently broken for the dataplane.

You can see an example in these logs from a previous workflow (https://github.com/SeldonIO/MLServer/actions/runs/8880776962/job/24381621013).

```
Writing mypy to dataplane_pb2.pyi
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/datamodel_code_generator/__main__.py", line 428, in main
    generate(
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/datamodel_code_generator/__init__.py", line 462, in generate
    results = parser.parse()
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/datamodel_code_generator/parser/base.py", line 1153, in parse
    self.parse_raw()
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/datamodel_code_generator/parser/openapi.py", line 571, in parse_raw
    specification: Dict[str, Any] = load_yaml(source.text)
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/datamodel_code_generator/__init__.py", line 51, in load_yaml
    return yaml.load(stream, Loader=SafeLoader)
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "yaml/_yaml.pyx", line 673, in yaml._yaml.CParser.get_single_node
  File "yaml/_yaml.pyx", line 687, in yaml._yaml.CParser._compose_document
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 845, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 845, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 845, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 845, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 847, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 860, in yaml._yaml.CParser._parse_next_event
yaml.scanner.ScannerError: mapping values are not allowed in this context
  in "<unicode string>", line 324, column 23

/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/grpc_tools/protoc.py:21: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
Writing mypy to model_repository_pb2.pyi
poetry run black .
Skipping virtualenv creation, as specified in config file.
Skipping .ipynb files as Jupyter dependencies are not installed.
You can fix this by running ``pip install "black[jupyter]"``
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/dataplane_pb2_grpc.py
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/model_repository_pb2.py
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/model_repository_pb2.pyi
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/dataplane_pb2.py
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/model_repository_pb2_grpc.py
reformatted /home/runner/work/MLServer/MLServer/mlserver/grpc/dataplane_pb2.pyi
reformatted /home/runner/work/MLServer/MLServer/mlserver/types/model_repository.py
```

This will now be detected/surfaced.

This allows linting to go on and makes the generation check separate.

The intent is to surface this failure but still let PRs go in, as they currently have, as we don't currently have (some) required status checks.

I've also reduced what's installed for the lint job which dramatically speeds it up. Along with this, I've cleaned up run commands that didn't need multi-line syntax.
