### PR TITLE
Spawn worker in custom environment

### DIFF
--- a/docs/user-guide/custom.md
+++ b/docs/user-guide/custom.md
@@ -224,10 +224,12 @@ To load a custom environment, [parallel inference](./parallel-inference)
 ```
 
 ```{warning}
-When loading custom environments, MLServer will always use the same Python
-interpreter that is used to run the main process.
-In other words, all custom environments will use the same version of Python
-than the main MLServer process.
+The main MLServer process communicates with workers in custom environments via
+[`multiprocessing.Queue`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue)
+using pickled objects. Custom environments therefore **must** use the same
+version of MLServer and a compatible version of Python with the same [default
+pickle protocol](https://docs.python.org/3/library/pickle.html#pickle.DEFAULT_PROTOCOL)
+as the main process.
 ```
 
 If we take the [previous example](#loading-a-custom-mlserver-runtime) above as

--- a/docs/user-guide/custom.md
+++ b/docs/user-guide/custom.md
@@ -229,8 +229,20 @@ The main MLServer process communicates with workers in custom environments via
 using pickled objects. Custom environments therefore **must** use the same
 version of MLServer and a compatible version of Python with the same [default
 pickle protocol](https://docs.python.org/3/library/pickle.html#pickle.DEFAULT_PROTOCOL)
-as the main process.
+as the main process. Consult the tables below for environment compatibility.
 ```
+
+| Status | Description  |
+| ------ | ------------ |
+| 🔴     | Unsupported  |
+| 🟢     | Supported    |
+| 🔵     | Untested     |
+
+| Worker Python \ Server Python | 3.9 | 3.10 | 3.11 |
+| ----------------------------- | --- | ---- | ---- |
+| 3.9                           | 🟢  | 🟢   | 🔵   |
+| 3.10                          | 🟢  | 🟢   | 🔵   |
+| 3.11                          | 🔵  | 🔵   | 🔵   |
 
 If we take the [previous example](#loading-a-custom-mlserver-runtime) above as
 a reference, we could extend it to include our custom environment as:

--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -101,7 +101,7 @@ class Environment:
         return os.path.join(self._env_path, "bin")
 
     @cached_property
-    def _python_path(self) -> str:
+    def _exec_path(self) -> str:
         """
         Path to python executable in our custom environment.
         """
@@ -126,7 +126,7 @@ class Environment:
         self._prev_sys_path = sys.path
         self._prev_bin_path = os.environ["PATH"]
 
-        multiprocessing.set_executable(self._python_path)
+        multiprocessing.set_executable(self._exec_path)
         sys.path = [*self._sys_path, *self._prev_sys_path]
         os.environ["PATH"] = os.pathsep.join([self._bin_path, self._prev_bin_path])
 

--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -1,4 +1,5 @@
 import asyncio
+import multiprocessing
 import os
 import sys
 import tarfile
@@ -100,6 +101,13 @@ class Environment:
         return os.path.join(self._env_path, "bin")
 
     @cached_property
+    def _python_path(self) -> str:
+        """
+        Path to python executable in our custom environment.
+        """
+        return os.path.join(self._bin_path, "python")
+
+    @cached_property
     def _lib_path(self) -> str:
         """
         Base environment path (i.e. user data directory - as defined by
@@ -118,11 +126,13 @@ class Environment:
         self._prev_sys_path = sys.path
         self._prev_bin_path = os.environ["PATH"]
 
+        multiprocessing.set_executable(self._python_path)
         sys.path = [*self._sys_path, *self._prev_sys_path]
         os.environ["PATH"] = os.pathsep.join([self._bin_path, self._prev_bin_path])
 
         return self
 
     def __exit__(self, *exc_details) -> None:
+        multiprocessing.set_executable(sys.executable)
         sys.path = self._prev_sys_path
         os.environ["PATH"] = self._prev_bin_path

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -25,7 +25,11 @@ PredictMethod = Callable[[InferenceRequest], Awaitable[InferenceResponse]]
 InferencePoolHook = Callable[[Worker], Awaitable[None]]
 
 
-def _spawn_worker(settings: Settings, responses: Queue, env: Optional[Environment]):
+def _spawn_worker(
+    settings: Settings,
+    responses: Queue,
+    env: Optional[Environment],
+) -> Worker:
     with env or nullcontext():
         worker = Worker(settings, responses, env)
         worker.start()

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -25,7 +25,7 @@ PredictMethod = Callable[[InferenceRequest], Awaitable[InferenceResponse]]
 InferencePoolHook = Callable[[Worker], Awaitable[None]]
 
 
-def _spawn_worker(settings: Settings, responses: Queue[ModelResponseMessage], env: Optional[Environment]):
+def _spawn_worker(settings: Settings, responses: Queue, env: Optional[Environment]):
     with env or nullcontext():
         worker = Worker(settings, responses, env)
         worker.start()
@@ -87,7 +87,7 @@ class InferencePool:
         self._worker_registry = WorkerRegistry()
         self._settings = settings
         self._responses: Queue[ModelResponseMessage] = Queue()
-        for idx in range(self._settings.parallel_workers):
+        for _ in range(self._settings.parallel_workers):
             worker = _spawn_worker(self._settings, self._responses, self._env)
             self._workers[worker.pid] = worker  # type: ignore
 

--- a/mlserver/parallel/pool.py
+++ b/mlserver/parallel/pool.py
@@ -25,7 +25,7 @@ PredictMethod = Callable[[InferenceRequest], Awaitable[InferenceResponse]]
 InferencePoolHook = Callable[[Worker], Awaitable[None]]
 
 
-def spawn_worker(settings: Settings, responses: Queue, env: Optional[Environment]):
+def _spawn_worker(settings: Settings, responses: Queue, env: Optional[Environment]):
     with env or nullcontext():
         worker = Worker(settings, responses, env)
         worker.start()
@@ -88,7 +88,7 @@ class InferencePool:
         self._settings = settings
         self._responses: Queue[ModelResponseMessage] = Queue()
         for _ in range(self._settings.parallel_workers):
-            worker = spawn_worker(self._settings, self._responses, self._env)
+            worker = _spawn_worker(self._settings, self._responses, self._env)
             self._workers[worker.pid] = worker  # type: ignore
 
         self._dispatcher = Dispatcher(self._workers, self._responses)
@@ -131,7 +131,7 @@ class InferencePool:
         await self._start_worker()
 
     async def _start_worker(self) -> Worker:
-        worker = spawn_worker(self._settings, self._responses, self._env)
+        worker = _spawn_worker(self._settings, self._responses, self._env)
         logger.info(f"Starting new worker with PID {worker.pid} on {self.name}...")
 
         # Add to dispatcher so that it can receive load requests and reload all

--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -72,7 +72,7 @@ class InferencePoolRegistry:
 
         await self._default_pool.on_worker_stop(pid, exit_code)
         await asyncio.gather(
-            *[pool.on_worker_stop(pid) for pool in self._pools.values()]
+            *[pool.on_worker_stop(pid, exit_code) for pool in self._pools.values()]
         )
 
     async def _get_or_create(self, model: MLModel) -> InferencePool:

--- a/tests/cli/test_build_cases.py
+++ b/tests/cli/test_build_cases.py
@@ -5,6 +5,7 @@ import json
 from typing import List
 
 from ..conftest import TESTS_PATH, TESTDATA_PATH
+from ..utils import _render_env_yml
 
 
 def _copy_test_files(
@@ -38,7 +39,11 @@ def case_environment_yml(tmp_path: str) -> str:
     """
     Custom model with environment provided through an environment.yml file.
     """
-    to_copy = ["env_models.py", "environment.yml"]
+    to_copy = ["env_models.py"]
+    _render_env_yml(
+        os.path.join(TESTDATA_PATH, "environment.yml"),
+        os.path.join(tmp_path, "environment.yml"),
+    )
     model_settings = {
         "name": "environment-yml",
         "implementation": "env_models.DummySKLearnModel",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import shutil
 import asyncio
 import glob
 import json
-import sys
 
 from filelock import FileLock
 from typing import Dict, Any, Tuple
@@ -30,9 +29,13 @@ from .metrics.utils import unregister_metrics
 from .fixtures import SumModel, ErrorModel, SimpleModel
 from .utils import RESTClient, get_available_ports, _pack, _get_tarball_name
 
-PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor)
 MIN_PYTHON_VERSION = (3, 9)
 MAX_PYTHON_VERSION = (3, 10)
+PYTHON_VERSIONS = [
+    (major, minor)
+    for major in range(MIN_PYTHON_VERSION[0], MAX_PYTHON_VERSION[0] + 1)
+    for minor in range(MIN_PYTHON_VERSION[1], MAX_PYTHON_VERSION[1] + 1)
+]
 TESTS_PATH = os.path.dirname(__file__)
 TESTDATA_PATH = os.path.join(TESTS_PATH, "testdata")
 TESTDATA_CACHE_PATH = os.path.join(TESTDATA_PATH, ".cache")
@@ -64,23 +67,8 @@ def testdata_cache_path() -> str:
 
 
 @pytest.fixture(
-    params=[
-        PYTHON_VERSION,
-        pytest.param(
-            MIN_PYTHON_VERSION,
-            marks=pytest.mark.skipif(
-                MIN_PYTHON_VERSION >= PYTHON_VERSION,
-                reason="requires lower Python version",
-            ),
-        ),
-        pytest.param(
-            MAX_PYTHON_VERSION,
-            marks=pytest.mark.skipif(
-                MAX_PYTHON_VERSION <= PYTHON_VERSION,
-                reason="requires higher Python version",
-            ),
-        ),
-    ],
+    params=PYTHON_VERSIONS,
+    ids=[f"py{major}{minor}" for (major, minor) in PYTHON_VERSIONS],
 )
 def env_python_version(request: pytest.FixtureRequest) -> Tuple[int, int]:
     return request.param

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -10,7 +10,7 @@ from mlserver.model import MLModel
 from mlserver.env import Environment
 from mlserver.parallel.dispatcher import Dispatcher
 from mlserver.parallel.model import ModelMethods
-from mlserver.parallel.pool import InferencePool, spawn_worker
+from mlserver.parallel.pool import InferencePool, _spawn_worker
 from mlserver.parallel.worker import Worker
 from mlserver.parallel.utils import configure_inference_pool, cancel_task
 from mlserver.parallel.messages import (
@@ -170,7 +170,7 @@ async def worker_with_env(
 ):
     # NOTE: This fixture will start an actual worker running on a separate
     # process.
-    worker = spawn_worker(settings, responses, env)
+    worker = _spawn_worker(settings, responses, env)
 
     load_message = ModelUpdateMessage(
         update_type=ModelUpdateType.Load, model_settings=env_model_settings

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -10,7 +10,7 @@ from mlserver.model import MLModel
 from mlserver.env import Environment
 from mlserver.parallel.dispatcher import Dispatcher
 from mlserver.parallel.model import ModelMethods
-from mlserver.parallel.pool import InferencePool
+from mlserver.parallel.pool import InferencePool, spawn_worker
 from mlserver.parallel.worker import Worker
 from mlserver.parallel.utils import configure_inference_pool, cancel_task
 from mlserver.parallel.messages import (
@@ -170,9 +170,7 @@ async def worker_with_env(
 ):
     # NOTE: This fixture will start an actual worker running on a separate
     # process.
-    worker = Worker(settings, responses, env)
-
-    worker.start()
+    worker = spawn_worker(settings, responses, env)
 
     load_message = ModelUpdateMessage(
         update_type=ModelUpdateType.Load, model_settings=env_model_settings

--- a/tests/parallel/test_registry.py
+++ b/tests/parallel/test_registry.py
@@ -90,20 +90,28 @@ async def test_load_model_with_env(
     assert sklearn_version == "1.0.2"
 
 
-async def test_load_creates_or_reuses_pool(
+async def test_load_creates_pool(
     inference_pool_registry: InferencePoolRegistry,
     env_model_settings: MLModel,
 ):
-    # Create new pool
     assert len(inference_pool_registry._pools) == 0
     env_model = EnvModel(env_model_settings)
     await inference_pool_registry.load_model(env_model)
+
     assert len(inference_pool_registry._pools) == 1
 
-    # Reuse pool
+
+async def test_load_reuses_pool(
+    inference_pool_registry: InferencePoolRegistry,
+    env_model: MLModel,
+    env_model_settings: ModelSettings,
+):
     env_model_settings.name = "foo"
     new_model = EnvModel(env_model_settings)
+
+    assert len(inference_pool_registry._pools) == 1
     await inference_pool_registry.load_model(new_model)
+
     assert len(inference_pool_registry._pools) == 1
 
 

--- a/tests/parallel/test_registry.py
+++ b/tests/parallel/test_registry.py
@@ -90,28 +90,20 @@ async def test_load_model_with_env(
     assert sklearn_version == "1.0.2"
 
 
-async def test_load_creates_pool(
+async def test_load_creates_or_reuses_pool(
     inference_pool_registry: InferencePoolRegistry,
     env_model_settings: MLModel,
 ):
+    # Create new pool
     assert len(inference_pool_registry._pools) == 0
     env_model = EnvModel(env_model_settings)
     await inference_pool_registry.load_model(env_model)
-
     assert len(inference_pool_registry._pools) == 1
 
-
-async def test_load_reuses_pool(
-    inference_pool_registry: InferencePoolRegistry,
-    env_model: MLModel,
-    env_model_settings: ModelSettings,
-):
+    # Reuse pool
     env_model_settings.name = "foo"
     new_model = EnvModel(env_model_settings)
-
-    assert len(inference_pool_registry._pools) == 1
     await inference_pool_registry.load_model(new_model)
-
     assert len(inference_pool_registry._pools) == 1
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,13 +3,15 @@ import sys
 import os
 import shutil
 
+from typing import Tuple
+
 from mlserver.env import Environment, compute_hash
 
 
 @pytest.fixture
-def expected_python_folder() -> str:
-    v = sys.version_info
-    return f"python{v.major}.{v.minor}"
+def expected_python_folder(env_python_version: Tuple[int, int]) -> str:
+    major, minor = env_python_version
+    return f"python{major}.{minor}"
 
 
 async def test_compute_hash(env_tarball: str):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -68,6 +68,10 @@ def test_bin_path(env: Environment):
     assert env._bin_path == f"{env._env_path}/bin"
 
 
+def test_exec_path(env: Environment):
+    assert env._exec_path == f"{env._env_path}/bin/python"
+
+
 def test_activate_env(env: Environment):
     assert env._env_path not in ",".join(sys.path)
     assert env._env_path not in os.environ["PATH"]
@@ -81,6 +85,9 @@ def test_activate_env(env: Environment):
 
         bin_paths = os.environ["PATH"].split(os.pathsep)
         assert bin_paths[0] == env._bin_path
+
+        exec_path = os.path.join(bin_paths[0], "python")
+        assert exec_path == env._exec_path
 
     assert env._env_path not in ",".join(sys.path)
     assert env._env_path not in os.environ["PATH"]

--- a/tests/testdata/environment.yml
+++ b/tests/testdata/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - python == 3.9
   - scikit-learn == 1.0.2
   - pip:
-      - mlserver @ git+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git@${GITHUB_REF_NAME}
+      - mlserver @ git+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git@${GITHUB_REF}

--- a/tests/testdata/environment.yml
+++ b/tests/testdata/environment.yml
@@ -2,7 +2,7 @@ name: custom-runtime-environment
 channels:
   - conda-forge
 dependencies:
-  - python == 3.8
+  - python == 3.9
   - scikit-learn == 1.0.2
   - pip:
-      - mlserver == 1.3.0.dev2
+      - ../..

--- a/tests/testdata/environment.yml
+++ b/tests/testdata/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - python == 3.9
   - scikit-learn == 1.0.2
   - pip:
-      - git+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git@${GITHUB_REF}
+      - mlserver @ git+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git@${GITHUB_REF_NAME}

--- a/tests/testdata/environment.yml
+++ b/tests/testdata/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - python == 3.9
   - scikit-learn == 1.0.2
   - pip:
-      - ../..
+      - git+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git@${GITHUB_REF}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,7 @@ def _is_python(dep: str) -> bool:
     return "python" in dep
 
 
-def _inject_python_version(version: Tuple[int, int], env_yml: str) -> str:
+def _inject_python_version(version: Tuple[int, int], env_yml: str, tarball_path: str) -> str:
     """
     To test the same environment.yml fixture we've got with different Python
     versions across environments, we inject dynamically the requested version.
@@ -75,7 +75,7 @@ def _inject_python_version(version: Tuple[int, int], env_yml: str) -> str:
     with_env_python = [f"python == {major}.{minor}", *without_python]
     env["dependencies"] = with_env_python
 
-    dst_folder = os.path.dirname(env_yml)
+    dst_folder = os.path.dirname(tarball_path)
     new_env_yml = os.path.join(dst_folder, f"environment-py{major}{minor}.yml")
     _write_env(env, new_env_yml)
     return new_env_yml
@@ -83,7 +83,7 @@ def _inject_python_version(version: Tuple[int, int], env_yml: str) -> str:
 
 async def _pack(version: Tuple[int, int], env_yml: str, tarball_path: str):
     uuid = generate_uuid()
-    fixed_env_yml = _inject_python_version(version, env_yml)
+    fixed_env_yml = _inject_python_version(version, env_yml, tarball_path)
     env_name = f"mlserver-{uuid}"
     try:
         await _run(f"conda env create -n {env_name} -f {fixed_env_yml}")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,13 +3,12 @@ import aiohttp
 import socket
 import yaml
 
-import sys
 import os
 
 from itertools import filterfalse
 
 from asyncio import subprocess
-from typing import List
+from typing import List, Tuple
 
 from aiohttp.client_exceptions import (
     ClientConnectorError,
@@ -65,29 +64,26 @@ def _is_python(dep: str) -> bool:
     return "python" in dep
 
 
-def _inject_python_version(env_yml: str, tarball_path: str) -> str:
+def _inject_python_version(version: Tuple[int, int], env_yml: str) -> str:
     """
-    To ensure the same environment.yml fixture we've got works across
-    environments, we inject dynamically the current Python version.
-    That way, we ensure tests using the tarball to load a dynamic custom
-    environment are using the same Python version used to run the tests.
+    To test the same environment.yml fixture we've got with different Python
+    versions across environments, we inject dynamically the requested version.
     """
     env = _read_env(env_yml)
-
-    v = sys.version_info
+    major, minor = version
     without_python = list(filterfalse(_is_python, env["dependencies"]))
-    with_env_python = [f"python == {v.major}.{v.minor}", *without_python]
+    with_env_python = [f"python == {major}.{minor}", *without_python]
     env["dependencies"] = with_env_python
 
-    dst_folder = os.path.dirname(tarball_path)
-    new_env_yml = os.path.join(dst_folder, f"environment-py{v.major}{v.minor}.yml")
+    dst_folder = os.path.dirname(env_yml)
+    new_env_yml = os.path.join(dst_folder, f"environment-py{major}{minor}.yml")
     _write_env(env, new_env_yml)
     return new_env_yml
 
 
-async def _pack(env_yml: str, tarball_path: str):
+async def _pack(version: Tuple[int, int], env_yml: str, tarball_path: str):
     uuid = generate_uuid()
-    fixed_env_yml = _inject_python_version(env_yml, tarball_path)
+    fixed_env_yml = _inject_python_version(version, env_yml)
     env_name = f"mlserver-{uuid}"
     try:
         await _run(f"conda env create -n {env_name} -f {fixed_env_yml}")
@@ -104,9 +100,9 @@ async def _pack(env_yml: str, tarball_path: str):
         await _run(f"conda env remove -n {env_name}")
 
 
-def _get_tarball_name() -> str:
-    v = sys.version_info
-    return f"environment-py{v.major}{v.minor}.tar.gz"
+def _get_tarball_name(version: Tuple[int, int]) -> str:
+    major, minor = version
+    return f"environment-py{major}{minor}.tar.gz"
 
 
 class RESTClient:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,11 @@ def _is_python(dep: str) -> bool:
     return "python" in dep
 
 
-def _inject_python_version(version: Tuple[int, int], env_yml: str, tarball_path: str) -> str:
+def _inject_python_version(
+    version: Tuple[int, int],
+    env_yml: str,
+    tarball_path: str,
+) -> str:
     """
     To test the same environment.yml fixture we've got with different Python
     versions across environments, we inject dynamically the requested version.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ import yaml
 import os
 
 from itertools import filterfalse
-
+from string import Template
 from asyncio import subprocess
 from typing import List, Tuple
 
@@ -50,7 +50,14 @@ async def _run(cmd):
         raise Exception(f"Command '{cmd}' failed with code '{return_code}'")
 
 
-def _read_env(env_yml) -> dict:
+def _render_env_yml(src_env_yml: str, dst_env_yml: str):
+    with open(src_env_yml, "r") as src_env_file:
+        env = Template(src_env_file.read()).substitute(os.environ)
+    with open(dst_env_yml, "w") as dst_env_file:
+        dst_env_file.write(env)
+
+
+def _read_env(env_yml: str) -> dict:
     with open(env_yml, "r") as env_file:
         return yaml.safe_load(env_file.read())
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ commands_pre =
 commands =
     python -m pytest {posargs} -n auto \
         {toxinidir}/tests
+set_env =
+    GITHUB_SERVER_URL = {env:GITHUB_SERVER_URL:https\://github.com}
+    GITHUB_REPOSITORY = {env:GITHUB_REPOSITORY:SeldonIO/MLServer}
+    GITHUB_REF        = {env:GITHUB_REF:/refs/heads/master}
 
 [testenv:all-runtimes]
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 set_env =
     GITHUB_SERVER_URL = {env:GITHUB_SERVER_URL:https\://github.com}
     GITHUB_REPOSITORY = {env:GITHUB_REPOSITORY:SeldonIO/MLServer}
-    GITHUB_REF_NAME   = {env:GITHUB_REF_NAME:master}
+    GITHUB_REF        = {env:GITHUB_REF:refs/heads/master}
 
 [testenv:all-runtimes]
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 set_env =
     GITHUB_SERVER_URL = {env:GITHUB_SERVER_URL:https\://github.com}
     GITHUB_REPOSITORY = {env:GITHUB_REPOSITORY:SeldonIO/MLServer}
-    GITHUB_REF        = {env:GITHUB_REF:/refs/heads/master}
+    GITHUB_REF_NAME   = {env:GITHUB_REF_NAME:master}
 
 [testenv:all-runtimes]
 commands_pre =


### PR DESCRIPTION
As per #1461, MLServer currently spawns worker with the same Python version as the main process, so user-provided environment is forced to match the Python version of the server. However, `multiprocessing` allows setting the worker's executable path, this PR extends support for spawning workers in custom environments.