### PR TITLE
Fix Pandas codec decoding from numpy arrays

### DIFF
--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -26,8 +26,7 @@ def _to_series(input_or_output: InputOrOutput) -> pd.Series:
         return pd.Series(payload)
 
     if isinstance(payload, np.ndarray):
-        # Necessary so that it's compatible with pd.Series
-        payload = list(payload)
+        payload = payload.reshape(-1, 1).squeeze(axis=1)
 
     dtype = to_dtype(input_or_output)
     return pd.Series(payload, dtype=dtype)

--- a/mlserver/codecs/pandas.py
+++ b/mlserver/codecs/pandas.py
@@ -26,7 +26,7 @@ def _to_series(input_or_output: InputOrOutput) -> pd.Series:
         return pd.Series(payload)
 
     if isinstance(payload, np.ndarray):
-        payload = payload.reshape(-1, 1).squeeze(axis=1)
+        payload = payload.reshape(input_or_output.shape[0], 1).squeeze(axis=1)
 
     dtype = to_dtype(input_or_output)
     return pd.Series(payload, dtype=dtype)

--- a/runtimes/mlflow/mlserver_mlflow/metadata.py
+++ b/runtimes/mlflow/mlserver_mlflow/metadata.py
@@ -46,7 +46,7 @@ def _get_shape(input_spec: InputSpec) -> List[int]:
     if isinstance(input_spec, TensorSpec):
         return list(input_spec.shape)
 
-    return [-1]
+    return [-1, 1]
 
 
 def to_metadata_tensors(

--- a/runtimes/mlflow/tests/test_metadata.py
+++ b/runtimes/mlflow/tests/test_metadata.py
@@ -62,7 +62,7 @@ def test_get_content_type(input_spec: InputSpec, expected: Tuple[MDatatype, str]
         ),
         (
             ColSpec(name="foo", type=DataType.string),
-            [-1],
+            [-1, 1],
         ),
     ],
 )
@@ -131,13 +131,13 @@ def test_get_shape(input_spec: InputSpec, expected: List[int]):
                 MetadataTensor(
                     name="input-0",
                     datatype="BYTES",
-                    shape=[-1],
+                    shape=[-1, 1],
                     parameters=Parameters(content_type=StringCodec.ContentType),
                 ),
                 MetadataTensor(
                     name="input-1",
                     datatype="INT32",
-                    shape=[-1],
+                    shape=[-1, 1],
                     parameters=Parameters(content_type=NumpyCodec.ContentType),
                 ),
             ],
@@ -169,8 +169,8 @@ def test_to_metadata_tensors(schema: Schema, expected: List[MetadataTensor]):
                 name="foo",
                 datatype="BYTES",
                 parameters=Parameters(content_type=StringCodec.ContentType),
-                shape=[2, 11],
-                data=b"hello worldhello world",
+                shape=[2],
+                data=[b"hello", b"world"],
             ),
         ),
         (
@@ -179,8 +179,8 @@ def test_to_metadata_tensors(schema: Schema, expected: List[MetadataTensor]):
                 name="foo",
                 datatype="BYTES",
                 parameters=Parameters(content_type=Base64Codec.ContentType),
-                shape=[1, 20],
-                data=b"UHl0aG9uIGlzIGZ1bg==",
+                shape=[1],
+                data=[b"UHl0aG9uIGlzIGZ1bg=="],
             ),
         ),
         (
@@ -189,8 +189,8 @@ def test_to_metadata_tensors(schema: Schema, expected: List[MetadataTensor]):
                 name="foo",
                 datatype="BYTES",
                 parameters=Parameters(content_type=DatetimeCodec.ContentType),
-                shape=[1, 19],
-                data=b"2021-08-24T15:01:19",
+                shape=[1],
+                data=[b"2021-08-24T15:01:19"],
             ),
         ),
     ],

--- a/tests/codecs/test_pandas.py
+++ b/tests/codecs/test_pandas.py
@@ -321,10 +321,10 @@ def test_encode_request(
                 inputs=[
                     RequestInput(
                         name="a",
-                        data=[1, 2, 3],
-                        datatype="FP32",
-                        shape=[1, 3],
-                        parameters=Parameters(_decoded_payload=np.array([[1, 2, 3]])),
+                        data=[[1, 2, 3]],
+                        datatype="BYTES",
+                        shape=[1, 1],
+                        parameters=Parameters(_decoded_payload=[[1, 2, 3]]),
                     ),
                     RequestInput(
                         name="b",
@@ -335,7 +335,7 @@ def test_encode_request(
                     ),
                 ]
             ),
-            pd.DataFrame({"a": [np.array([1, 2, 3])], "b": ["hello world"]}),
+            pd.DataFrame({"a": [[1, 2, 3]], "b": ["hello world"]}),
         ),
         (
             InferenceRequest(
@@ -343,7 +343,7 @@ def test_encode_request(
                     RequestInput(
                         name="a",
                         data=[1, 2, 3],
-                        datatype="FP32",
+                        datatype="INT64",
                         shape=[3, 1],
                         parameters=Parameters(
                             _decoded_payload=np.array([[1], [2], [3]])
@@ -359,7 +359,7 @@ def test_encode_request(
             ),
             pd.DataFrame(
                 {
-                    "a": [[1], [2], [3]],
+                    "a": [1, 2, 3],
                     "b": [a for a in b"ABC"],
                 }
             ),


### PR DESCRIPTION
Pandas codec currently breaks mlflow runtime's schema enforcement (#1625). This is because numeric mlflow datatypes are assigned `NumpyCodec` content type [by default](https://github.com/SeldonIO/MLServer/blob/410cf6f838782443267c88bd410cabf95c760c54/runtimes/mlflow/mlserver_mlflow/metadata.py#L24-L28), which decodes `PandasCodec`'s explicit batch size into a column vector:
```
input = RequestInput(
	name="foo",
	shape=[3, 1],
	data=[1,2,3],
	datatype="INT64",
)
NumpyCodec.decode_input(input)  # np.array([[1], [2], [3]])
```

However, `pd.Series` expects one-dimensional data, and when the `_decoded_payload` is converted to a `pd.Series` [here](https://github.com/SeldonIO/MLServer/blob/410cf6f838782443267c88bd410cabf95c760c54/mlserver/codecs/pandas.py#L28-L33) returns unexpected results:
```
# Expect pd.Series([1,2,3]), got pd.Series([(1,), (2,), (3,)])
payload = np.array([[1], [2], [3]])
payload = list(payload)
pd.Series(payload, dtype="int64")
```

This seems like a bug from pandas side, `dtype="int64"` should have thrown an error (and in fact it does for higher dimension, but for some reason is okay with `[np.array([1]), np.array([2]), np.array([3])]` and weirdly casts them into tuples), but either way mlserver should have dropped the trailing axis as `pd.Series` already implies column vector. 

From this [test](https://github.com/SeldonIO/MLServer/blob/410cf6f838782443267c88bd410cabf95c760c54/tests/codecs/test_pandas.py#L319-L339), it seems like the conversion to `list` in the codec was to accommodate the use case of `pd.Series` of tensors:
```
# Expect decoded pd.Series([np.array([1,2,3])]) in test
RequestInput(
	name="a",
	data=[1, 2, 3],
	datatype="FP32",
	shape=[1, 3],
	parameters=Parameters(_decoded_payload=np.array([[1, 2, 3]])),
)
```

I'd argue in the context of Pandas codec this should be made explicit with shape `[1, 1]` and datatype `BYTES` for array elements. In fact, a [test](https://github.com/SeldonIO/MLServer/blob/410cf6f838782443267c88bd410cabf95c760c54/tests/codecs/test_pandas.py#L66-L72) above does so, specifying the intended shape is a `[2,1]` column vector with datatype `BYTES` for `list` elements.
```
# Expect encoded ResponseOutput(name="bar", shape=[2, 1], data=[[1, 2, 3], [4, 5, 6]], datatype="BYTES") in test
pd.Series(data=[[1, 2, 3], [4, 5, 6]], name="bar")
```

This PR explicitly reshapes `np.array` payload to expected shapes before conversion to `pd.Series`.