### PR TITLE
fix(pandas): Use Pydantic v2 compatible type

### DIFF
--- a/mlserver/types/dataplane.py
+++ b/mlserver/types/dataplane.py
@@ -33,8 +33,8 @@ class Parameters(BaseModel):
     headers: Optional[Dict[str, Any]] = None
 
 
-class TensorData(RootModel[Union[List, str]]):
-    root: Union[List, str] = Field(..., title="TensorData")
+class TensorData(RootModel[Union[List, Any]]):
+    root: Union[List, Any] = Field(..., title="TensorData")
 
     def __iter__(self):
         return iter(self.root)

--- a/openapi/dataplane.yaml
+++ b/openapi/dataplane.yaml
@@ -431,7 +431,7 @@ components:
       title: TensorData
       oneOf:
         - type: array
-        - type: string
+        - type: bytes
     RequestOutput:
       title: RequestOutput
       type: object


### PR DESCRIPTION
This is a follow-up to #1752 and supersedes #1759.

It's understood that `string` type is no longer being treated as a list by Pydantic. `bytes` should be.

The code generator seems aware of the `bytes` type [1][2].

[1] https://github.com/koxudaxi/datamodel-code-generator/blob/fcab9a4d555d4b96d64bb277f974bb7507982fb2/datamodel_code_generator/types.py#L536-L569
[2] https://github.com/koxudaxi/datamodel-code-generator/blob/fcab9a4d555d4b96d64bb277f974bb7507982fb2/datamodel_code_generator/types.py#L624-L640
