### PR TITLE
build: Bump versions for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,14 +16,14 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
     # Set up Poetry
     # From https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry==1.4.2
+      - pip install poetry==1.8.1
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
       # Install dependencies with 'docs' dependency group

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,8 +24,9 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry==1.8.1
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+    post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install -vvv --without dev --with docs --with all-runtimes --with all-runtimes-dev
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install -vvv --without dev --with docs --with all-runtimes --with all-runtimes-dev

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 start:
-	sphinx-autobuild . ./_build/html
+	poetry run sphinx-autobuild . ./_build/html
 
 install-dev:
 	poetry install -C .. --with docs --with all-runtimes --with all-runtimes-dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 import sphinx_material
 
 project = "MLServer"
-copyright = "2023, Seldon Technologies"
+copyright = "2024, Seldon Technologies"
 html_title = "MLServer Documentation"
 author = "Seldon Technologies"
 


### PR DESCRIPTION
We don't support Python `3.8` anymore.

Poetry `1.8.1` matches what's currently in our Poetry lockfile.

Building the docs is currently failing [1], and this ideally will fix that.

[1] From readthedocs.org:
```
poetry install -vvv --without dev --with docs --with all-runtimes --with all-runtimes-dev
Loading configuration file /home/docs/.config/pypoetry/config.toml
The currently activated Python version 3.8.18 is not supported by the project (>=3.9,<3.12).
Trying to find and use a compatible version.
Trying python3
Trying python3.9
```
