### PR TITLE
build: Bump versions for Read the Docs (#1761)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,16 +16,17 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
     # Set up Poetry
     # From https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry==1.4.2
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      - pip install poetry==1.8.1
+    post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install -vvv --without dev --with docs --with all-runtimes --with all-runtimes-dev
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install -vvv --without dev --with docs --with all-runtimes --with all-runtimes-dev

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 start:
-	sphinx-autobuild . ./_build/html
+	poetry run sphinx-autobuild . ./_build/html
 
 install-dev:
 	poetry install -C .. --with docs --with all-runtimes --with all-runtimes-dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 import sphinx_material
 
 project = "MLServer"
-copyright = "2023, Seldon Technologies"
+copyright = "2024, Seldon Technologies"
 html_title = "MLServer Documentation"
 author = "Seldon Technologies"
 


### PR DESCRIPTION
Cherry-pick https://github.com/SeldonIO/MLServer/pull/1761 into the release branch so that the docs can be built and displayed publicly.