### PR TITLE
docs: Remove quotes around local TOC

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ if html_theme == "sphinx_material":
         "globaltoc_depth": 4,
         "globaltoc_collapse": True,
         "globaltoc_includehidden": True,
+        "localtoc_label_text": "Contents",
         "repo_type": "github",
         "nav_links": [
             {


### PR DESCRIPTION
For some reason, without this it's rendered as `"Contents"`. Doing this removes the quotes.

**Before**
![24-05-16_16-12-32](https://github.com/SeldonIO/MLServer/assets/1405676/70a4f9cd-9f79-429a-b8be-133bc6dc00f3)

**After**
![24-05-16_16-14-47](https://github.com/SeldonIO/MLServer/assets/1405676/12fea7d1-2ba1-4fed-9528-ae38ca18ca55)
