### PR TITLE
Build(deps): Update to poetry version 1.8.3 in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim AS wheel-builder
 SHELL ["/bin/bash", "-l", "-c"]
 
-ARG POETRY_VERSION="1.8.1"
+ARG POETRY_VERSION="1.8.3"
 
 COPY ./hack/build-wheels.sh ./hack/build-wheels.sh
 COPY ./mlserver ./mlserver


### PR DESCRIPTION
This is to use the newest release of poetry 1.8.3. Actual lockfiles should be upgraded when they are changed in future PRs.