### PR TITLE
Bumped preflight version to 1.9.7

### DIFF
--- a/.github/workflows/release-sc.yml
+++ b/.github/workflows/release-sc.yml
@@ -94,7 +94,7 @@ jobs:
           sudo mv preflight-linux-amd64 /usr/local/bin/preflight
           preflight --version
         env:
-          PREFLIGHT_VERSION: 1.4.2
+          PREFLIGHT_VERSION: 1.9.7
       - name: Submit preflight results
         run: |
           preflight check container \
@@ -164,7 +164,7 @@ jobs:
           sudo mv preflight-linux-amd64 /usr/local/bin/preflight
           preflight --version
         env:
-          PREFLIGHT_VERSION: 1.4.2
+          PREFLIGHT_VERSION: 1.9.7
       - name: Submit preflight results
         run: |
           preflight check container \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           sudo mv preflight-linux-amd64 /usr/local/bin/preflight
           preflight --version
         env:
-          PREFLIGHT_VERSION: 1.4.2
+          PREFLIGHT_VERSION: 1.9.7
       - name: Submit preflight results
         run: |
           preflight check container \
@@ -164,7 +164,7 @@ jobs:
           sudo mv preflight-linux-amd64 /usr/local/bin/preflight
           preflight --version
         env:
-          PREFLIGHT_VERSION: 1.4.2
+          PREFLIGHT_VERSION: 1.9.7
       - name: Submit preflight results
         run: |
           preflight check container \
@@ -287,7 +287,7 @@ jobs:
           sudo mv preflight-linux-amd64 /usr/local/bin/preflight
           preflight --version
         env:
-          PREFLIGHT_VERSION: 1.4.2
+          PREFLIGHT_VERSION: 1.9.7
       - name: Submit preflight results
         run: |
           preflight check container \


### PR DESCRIPTION
Bumps `preflight` to 1.9.7 because the release action fails.

```
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.4.2' is not supported. Supported versions are: ['1.9.2', '1.9.4', '1.9.5', '1.9.6', '1.9.7']", "status": 400, "trace_id": "0x8c282d1af616bcde76062a3af1c337c8"}
2024/06/07 12:02:17 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.4.2' is not supported. Supported versions are: ['1.9.2', '1.9.4', '1.9.5', '1.9.6', '1.9.7']", "status": 400, "trace_id": "0x8c282d1af616bcde76062a3af1c337c8"}
```