### PR TITLE
fix: Update stale reviewer in licenses.yml workflow

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -47,4 +47,4 @@ jobs:
             subdependency.
             This automated PR will re-generate the licenses to keep them up to
             date."
-          reviewers: adriangonz
+          reviewers: "SeldonIO/mlops"


### PR DESCRIPTION
Adjusting reviewers to "SeldonIO/mlops"