### PR TITLE
Included Prometheus interceptor support for gRPC streaming

### DIFF
--- a/docs/examples/streaming/README.ipynb
+++ b/docs/examples/streaming/README.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -138,8 +138,7 @@
     "{\n",
     "  \"debug\": false,\n",
     "  \"parallel_workers\": 0,\n",
-    "  \"gzip_enabled\": false,\n",
-    "  \"metrics_endpoint\": null\n",
+    "  \"gzip_enabled\": false\n",
     "}\n"
    ]
   },
@@ -150,8 +149,7 @@
     "Note the currently there are three main limitations of the streaming support in MLServer:\n",
     "\n",
     "- distributed workers are not supported (i.e., the `parallel_workers` setting should be set to `0`)\n",
-    "- `gzip` middleware is not supported for REST (i.e., `gzip_enabled` setting should be set to `false`)\n",
-    "- metrics endpoint is not available (i.e. `metrics_endpoint` is also disabled for streaming for gRPC)"
+    "- `gzip` middleware is not supported for REST (i.e., `gzip_enabled` setting should be set to `false`)"
    ]
   },
   {
@@ -163,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -227,14 +225,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing generate-request.json\n"
+      "Overwriting generate-request.json\n"
      ]
     }
    ],
@@ -272,9 +270,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['What']\n",
+      "[' is']\n",
+      "[' the']\n",
+      "[' capital']\n",
+      "[' of']\n",
+      "[' France?']\n"
+     ]
+    }
+   ],
    "source": [
     "import httpx\n",
     "from httpx_sse import connect_sse\n",
@@ -301,9 +312,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['What']\n",
+      "[' is']\n",
+      "[' the']\n",
+      "[' capital']\n",
+      "[' of']\n",
+      "[' France?']\n"
+     ]
+    }
+   ],
    "source": [
     "import grpc\n",
     "import mlserver.types as types\n",
@@ -315,7 +339,7 @@
     "inference_request = types.InferenceRequest.parse_file(\"./generate-request.json\")\n",
     "\n",
     "# need to convert from string to bytes for grpc\n",
-    "inference_request.inputs[0] = StringCodec.encode_input(\"prompt\", inference_request.inputs[0].data.__root__)\n",
+    "inference_request.inputs[0] = StringCodec.encode_input(\"prompt\", inference_request.inputs[0].data.root)\n",
     "inference_request_g = converters.ModelInferRequestConverter.from_types(\n",
     "    inference_request, model_name=\"text-model\", model_version=None\n",
     ")\n",
@@ -338,11 +362,6 @@
    "source": [
     "Note that for gRPC, the request is transformed into an async generator which is then passed to the `ModelStreamInfer` method. The response is also an async generator which can be iterated over to get the response."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/streaming/README.ipynb
+++ b/docs/examples/streaming/README.ipynb
@@ -380,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/examples/streaming/README.md
+++ b/docs/examples/streaming/README.md
@@ -78,8 +78,7 @@ The next step will be to create 2 configuration files:
 {
   "debug": false,
   "parallel_workers": 0,
-  "gzip_enabled": false,
-  "metrics_endpoint": null
+  "gzip_enabled": false
 }
 
 ```
@@ -88,7 +87,6 @@ Note the currently there are three main limitations of the streaming support in 
 
 - distributed workers are not supported (i.e., the `parallel_workers` setting should be set to `0`)
 - `gzip` middleware is not supported for REST (i.e., `gzip_enabled` setting should be set to `false`)
-- metrics endpoint is not available (i.e. `metrics_endpoint` is also disabled for streaming for gRPC)
 
 #### model-settings.json
 
@@ -195,7 +193,7 @@ import mlserver.grpc.dataplane_pb2_grpc as dataplane
 inference_request = types.InferenceRequest.parse_file("./generate-request.json")
 
 # need to convert from string to bytes for grpc
-inference_request.inputs[0] = StringCodec.encode_input("prompt", inference_request.inputs[0].data.__root__)
+inference_request.inputs[0] = StringCodec.encode_input("prompt", inference_request.inputs[0].data.root)
 inference_request_g = converters.ModelInferRequestConverter.from_types(
     inference_request, model_name="text-model", model_version=None
 )
@@ -213,5 +211,3 @@ async with grpc.aio.insecure_channel("localhost:8081") as grpc_channel:
 ```
 
 Note that for gRPC, the request is transformed into an async generator which is then passed to the `ModelStreamInfer` method. The response is also an async generator which can be iterated over to get the response.
-
-

--- a/docs/examples/streaming/settings.json
+++ b/docs/examples/streaming/settings.json
@@ -2,6 +2,5 @@
 {
   "debug": false,
   "parallel_workers": 0,
-  "gzip_enabled": false,
-  "metrics_endpoint": null
+  "gzip_enabled": false
 }

--- a/docs/examples/streaming/text_model.py
+++ b/docs/examples/streaming/text_model.py
@@ -1,3 +1,4 @@
+
 import asyncio
 from typing import AsyncIterator
 from mlserver import MLModel
@@ -6,19 +7,6 @@ from mlserver.codecs import StringCodec
 
 
 class TextModel(MLModel):
-
-    async def predict(self, payload: InferenceRequest) -> InferenceResponse:
-        text = StringCodec.decode_input(payload.inputs[0])[0]
-        return InferenceResponse(
-            model_name=self._settings.name,
-            outputs=[
-                StringCodec.encode_output(
-                    name="output",
-                    payload=[text],
-                    use_bytes=True,
-                ),
-            ],
-        )
 
     async def predict_stream(
         self, payloads: AsyncIterator[InferenceRequest]

--- a/docs/examples/streaming/text_model.py
+++ b/docs/examples/streaming/text_model.py
@@ -1,4 +1,3 @@
-
 import asyncio
 from typing import AsyncIterator
 from mlserver import MLModel

--- a/docs/user-guide/streaming.md
+++ b/docs/user-guide/streaming.md
@@ -32,4 +32,3 @@ There are three main limitations of the streaming support in MLServer:
 
 - the `parallel_workers` setting should be set to `0` to disable distributed workers (to be addressed in future releases)
 - for REST, the `gzip_enabled` setting should be set to `false` to disable GZIP compression, as streaming is not compatible with GZIP compression (see issue [here]( https://github.com/encode/starlette/issues/20#issuecomment-704106436))
-- `metrics_endpoint` is also disabled for streaming for gRPC (to be addressed in future releases)

--- a/mlserver/grpc/interceptors.py
+++ b/mlserver/grpc/interceptors.py
@@ -50,6 +50,157 @@ class PromServerInterceptor(ServerInterceptor):
         metrics_wrapper = partial(self._metrics_wrapper, method_call)
         return self._interceptor._wrap_rpc_behavior(handler, metrics_wrapper)
 
+    def _metrics_wrapper(
+        self,
+        method_call: Tuple[str, str, str],
+        behavior: RpcMethodHandler,
+        request_streaming: bool,
+        response_streaming: bool,
+    ):
+        """
+        Port of `py-grpc-prometheus` metrics_wrapper method to work with gRPC's
+        AsyncIO support.
+        To see the original implementation, please check:
+
+        https://github.com/lchenn/py-grpc-prometheus/blob/eb9dee1f0a4e57cef220193ee48021dc9a9f3d82/py_grpc_prometheus/prometheus_server_interceptor.py#L46-L120
+        """
+        grpc_service_name, grpc_method_name, _ = method_call
+
+        async def new_behavior(request, servicer_context):
+            response = None
+            try:
+                start = default_timer()
+                grpc_type = grpc_utils.get_method_type(
+                    request_streaming, response_streaming
+                )
+
+                try:
+                    self._interceptor._metrics["grpc_server_started_counter"].labels(
+                        grpc_type=grpc_type,
+                        grpc_service=grpc_service_name,
+                        grpc_method=grpc_method_name,
+                    ).inc()
+
+                    # Invoke the original rpc behavior.
+                    # NOTE: This is the main change required with respect to
+                    # the original implementation in `py-grpc-prometheus`.
+                    response = await behavior(request, servicer_context)
+                    self._interceptor.increase_grpc_server_handled_total_counter(
+                        grpc_type,
+                        grpc_service_name,
+                        grpc_method_name,
+                        self._compute_status_code(servicer_context).name,
+                    )
+                    return response
+
+                except RpcError as e:
+                    self._interceptor.increase_grpc_server_handled_total_counter(
+                        grpc_type,
+                        grpc_service_name,
+                        grpc_method_name,
+                        self._interceptor._compute_error_code(e).name,
+                    )
+                    raise e
+
+                finally:
+                    if self._interceptor._legacy:
+                        self._interceptor._metrics[
+                            "legacy_grpc_server_handled_latency_seconds"
+                        ].labels(
+                            grpc_type=grpc_type,
+                            grpc_service=grpc_service_name,
+                            grpc_method=grpc_method_name,
+                        ).observe(
+                            max(default_timer() - start, 0)
+                        )
+                    elif self._interceptor._enable_handling_time_histogram:
+                        self._interceptor._metrics[
+                            "grpc_server_handled_histogram"
+                        ].labels(
+                            grpc_type=grpc_type,
+                            grpc_service=grpc_service_name,
+                            grpc_method=grpc_method_name,
+                        ).observe(
+                            max(default_timer() - start, 0)
+                        )
+            except Exception as e:  # pylint: disable=broad-except
+                # Allow user to skip the exceptions in order to maintain
+                # the basic functionality in the server
+                # The logging function in exception can be toggled with log_exceptions
+                # in order to suppress the noise in logging
+                if self._interceptor._skip_exceptions:
+                    if self._interceptor._log_exceptions:
+                        logger.error(e)
+
+                    if response is None:
+                        return response
+
+                    return await behavior(request, servicer_context)
+                raise e
+
+        async def new_behavior_stream(
+            request_async_iterator, servicer_context: ServicerContext
+        ):
+            response_async_iterator = None
+            try:
+                grpc_type = grpc_utils.get_method_type(
+                    request_streaming, response_streaming
+                )
+                try:
+                    request_async_iterator = wrap_async_iterator_inc_counter(
+                        request_async_iterator,
+                        self._interceptor._metrics["grpc_server_stream_msg_received"],
+                        grpc_type,
+                        grpc_service_name,
+                        grpc_method_name,
+                    )
+
+                    # wrap the original behavior with the metrics
+                    sent_metric = self._interceptor._metrics[
+                        "grpc_server_stream_msg_sent"
+                    ]
+                    response_async_iterator = wrap_async_iterator_inc_counter(
+                        behavior(request_async_iterator, servicer_context),
+                        sent_metric,
+                        grpc_type,
+                        grpc_service_name,
+                        grpc_method_name,
+                    )
+
+                    # invoke the original rpc behavior
+                    async for item in response_async_iterator:
+                        yield item
+
+                except RpcError as e:
+                    self._interceptor.increase_grpc_server_handled_total_counter(
+                        grpc_type,
+                        grpc_service_name,
+                        grpc_method_name,
+                        self._interceptor._compute_error_code(e).name,
+                    )
+                    raise e
+
+            except Exception as e:  # pylint: disable=broad-except
+                # Allow user to skip the exceptions in order to maintain
+                # the basic functionality in the server
+                # The logging function in exception can be toggled with log_exceptions
+                # in order to suppress the noise in logging
+                if self._interceptor._skip_exceptions:
+                    if self._interceptor._log_exceptions:
+                        logger.error(e)
+
+                    if response_async_iterator is not None:
+                        async for item in behavior(
+                            request_async_iterator, servicer_context
+                        ):
+                            yield item
+                raise e
+
+        if request_streaming and response_streaming:
+            return new_behavior_stream
+
+        return new_behavior
+
     def _compute_status_code(self, servicer_context: ServicerContext) -> StatusCode:
         """
         This method is mostly copied from `py-grpc-prometheus`, with a couple
@@ -83,118 +234,16 @@ class PromServerInterceptor(ServerInterceptor):
 
         return code
 
-    def _metrics_wrapper(
-        self,
-        method_call: Tuple[str, str, str],
-        old_handler: RpcMethodHandler,
-        request_streaming: bool,
-        response_streaming: bool,
-    ):
-        """
-        Port of `py-grpc-prometheus` metrics_wrapper method to work with gRPC's
-        AsyncIO support.
-        To see the original implementation, please check:
 
-        https://github.com/lchenn/py-grpc-prometheus/blob/eb9dee1f0a4e57cef220193ee48021dc9a9f3d82/py_grpc_prometheus/prometheus_server_interceptor.py#L46-L120
-        """
-        grpc_service_name, grpc_method_name, _ = method_call
+async def wrap_async_iterator_inc_counter(
+    iterator, counter, grpc_type, grpc_service_name, grpc_method_name
+):
+    """Wraps an async iterator and collect metrics."""
 
-        async def _new_handler(request_or_iterator, servicer_context: ServicerContext):
-            response_or_iterator = None
-            try:
-                start = default_timer()
-                grpc_type = grpc_utils.get_method_type(
-                    request_streaming, response_streaming
-                )
-                try:
-                    if request_streaming:
-                        request_or_iterator = grpc_utils.wrap_iterator_inc_counter(
-                            request_or_iterator,
-                            self._interceptor._metrics[
-                                "grpc_server_stream_msg_received"
-                            ],
-                            grpc_type,
-                            grpc_service_name,
-                            grpc_method_name,
-                        )
-                    else:
-                        self._interceptor._metrics[
-                            "grpc_server_started_counter"
-                        ].labels(
-                            grpc_type=grpc_type,
-                            grpc_service=grpc_service_name,
-                            grpc_method=grpc_method_name,
-                        ).inc()
-
-                    # Invoke the original rpc behavior.
-                    # NOTE: This is the main change required with respect to
-                    # the original implementation in `py-grpc-prometheus`.
-                    response_or_iterator = await old_handler(
-                        request_or_iterator, servicer_context
-                    )
-
-                    if response_streaming:
-                        sent_metric = self._interceptor._metrics[
-                            "grpc_server_stream_msg_sent"
-                        ]
-                        response_or_iterator = grpc_utils.wrap_iterator_inc_counter(
-                            response_or_iterator,
-                            sent_metric,
-                            grpc_type,
-                            grpc_service_name,
-                            grpc_method_name,
-                        )
-
-                    else:
-                        self._interceptor.increase_grpc_server_handled_total_counter(
-                            grpc_type,
-                            grpc_service_name,
-                            grpc_method_name,
-                            self._compute_status_code(servicer_context).name,
-                        )
-                    return response_or_iterator
-                except RpcError as e:
-                    self._interceptor.increase_grpc_server_handled_total_counter(
-                        grpc_type,
-                        grpc_service_name,
-                        grpc_method_name,
-                        self._interceptor._compute_error_code(e).name,
-                    )
-                    raise e
-
-                finally:
-                    if not response_streaming:
-                        if self._interceptor._legacy:
-                            self._interceptor._metrics[
-                                "legacy_grpc_server_handled_latency_seconds"
-                            ].labels(
-                                grpc_type=grpc_type,
-                                grpc_service=grpc_service_name,
-                                grpc_method=grpc_method_name,
-                            ).observe(
-                                max(default_timer() - start, 0)
-                            )
-                        elif self._interceptor._enable_handling_time_histogram:
-                            self._interceptor._metrics[
-                                "grpc_server_handled_histogram"
-                            ].labels(
-                                grpc_type=grpc_type,
-                                grpc_service=grpc_service_name,
-                                grpc_method=grpc_method_name,
-                            ).observe(
-                                max(default_timer() - start, 0)
-                            )
-            except Exception as e:  # pylint: disable=broad-except
-                # Allow user to skip the exceptions in order to maintain
-                # the basic functionality in the server
-                # The logging function in exception can be toggled with log_exceptions
-                # in order to suppress the noise in logging
-                if self._interceptor._skip_exceptions:
-                    if self._interceptor._log_exceptions:
-                        logger.error(e)
-                    if response_or_iterator is None:
-                        return response_or_iterator
-                    return old_handler(request_or_iterator, servicer_context)
-                raise e
-
-        return _new_handler
+    async for item in iterator:
+        counter.labels(
+            grpc_type=grpc_type,
+            grpc_service=grpc_service_name,
+            grpc_method=grpc_method_name,
+        ).inc()
+        yield item

--- a/mlserver/grpc/server.py
+++ b/mlserver/grpc/server.py
@@ -38,14 +38,14 @@ class GRPCServer:
             self._model_repository_handlers
         )
 
-        interceptors = []
+        self._interceptors = []
 
         if self._settings.debug:
             # If debug, enable access logs
-            interceptors = [LoggingInterceptor()]
+            self._interceptors = [LoggingInterceptor()]
 
         if self._settings.metrics_endpoint:
-            interceptors.append(
+            self._interceptors.append(
                 PromServerInterceptor(enable_handling_time_histogram=True)
             )
 
@@ -62,7 +62,7 @@ class GRPCServer:
                 )
             )
 
-            interceptors.append(
+            self._interceptors.append(
                 aio_server_interceptor(
                     tracer_provider=tracer_provider, filter_=excluded_urls
                 )
@@ -70,7 +70,7 @@ class GRPCServer:
 
         self._server = aio.server(
             ThreadPoolExecutor(max_workers=DefaultGrpcWorkers),
-            interceptors=tuple(interceptors),
+            interceptors=tuple(self._interceptors),
             options=self._get_options(),
         )
 

--- a/tests/grpc/test_interceptor.py
+++ b/tests/grpc/test_interceptor.py
@@ -76,7 +76,7 @@ async def test_prometheus_stream_stream(
         yield request
 
     # send 10 requests
-    num_requests = 1
+    num_requests = 10
     for _ in range(num_requests):
         _ = [
             _

--- a/tests/grpc/test_interceptor.py
+++ b/tests/grpc/test_interceptor.py
@@ -1,0 +1,129 @@
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from typing import AsyncGenerator
+
+from grpc import StatusCode
+from mlserver.grpc.interceptors import PromServerInterceptor
+from mlserver.codecs import StringCodec
+from mlserver.grpc import converters
+from mlserver.grpc.server import GRPCServer
+from mlserver.grpc.dataplane_pb2_grpc import GRPCInferenceServiceStub
+from mlserver.grpc import dataplane_pb2 as pb
+
+
+@pytest.mark.parametrize("sum_model", [lazy_fixture("text_model")])
+@pytest.mark.parametrize("sum_model_settings", [lazy_fixture("text_model_settings")])
+async def test_prometheus_unary_unary(
+    grpc_server: GRPCServer,
+    inference_service_stub: AsyncGenerator[GRPCInferenceServiceStub, None],
+    model_generate_request: pb.ModelInferRequest,
+):
+    # send 10 requests
+    num_requests = 10
+    for _ in range(num_requests):
+        _ = await inference_service_stub.ModelInfer(model_generate_request)
+
+    grpc_type = "UNARY"
+    grpc_service_name = "inference.GRPCInferenceService"
+    grpc_method_name = "ModelInfer"
+    prom_interceptor = [
+        interceptor
+        for interceptor in grpc_server._interceptors
+        if isinstance(interceptor, PromServerInterceptor)
+    ][0]
+
+    # get the number of requests intercepted
+    counted_requests = (
+        prom_interceptor._interceptor._metrics["grpc_server_started_counter"]
+        .labels(
+            grpc_type,
+            grpc_service_name,
+            grpc_method_name,
+        )
+        ._value.get()
+    )
+
+    # get the number of ok responses intercepted
+    counted_responses = (
+        prom_interceptor._interceptor._grpc_server_handled_total_counter.labels(
+            grpc_type,
+            grpc_service_name,
+            grpc_method_name,
+            StatusCode.OK.name,
+        )._value.get()
+    )
+
+    assert int(counted_requests) == num_requests
+    assert int(counted_requests) == int(counted_responses)
+
+
+@pytest.mark.parametrize("settings", [lazy_fixture("settings_stream")])
+@pytest.mark.parametrize("sum_model", [lazy_fixture("text_stream_model")])
+@pytest.mark.parametrize("model_name", ["text-stream-model"])
+@pytest.mark.parametrize(
+    "sum_model_settings", [lazy_fixture("text_stream_model_settings")]
+)
+async def test_prometheus_stream_stream(
+    grpc_server: GRPCServer,
+    inference_service_stub: AsyncGenerator[GRPCInferenceServiceStub, None],
+    model_generate_request: pb.ModelInferRequest,
+    model_name: str,
+):
+    model_generate_request.model_name = model_name
+
+    async def get_stream_request(request):
+        yield request
+
+    # send 10 requests
+    num_requests = 1
+    for _ in range(num_requests):
+        _ = [
+            _
+            async for _ in inference_service_stub.ModelStreamInfer(
+                get_stream_request(model_generate_request)
+            )
+        ]
+
+    grpc_type = "BIDI_STREAMING"
+    grpc_service_name = "inference.GRPCInferenceService"
+    grpc_method_name = "ModelStreamInfer"
+    prom_interceptor = [
+        interceptor
+        for interceptor in grpc_server._interceptors
+        if isinstance(interceptor, PromServerInterceptor)
+    ][0]
+
+    # get the number of requests intercepted
+    counted_requests = (
+        prom_interceptor._interceptor._metrics["grpc_server_stream_msg_received"]
+        .labels(
+            grpc_type,
+            grpc_service_name,
+            grpc_method_name,
+        )
+        ._value.get()
+    )
+
+    # get the number of ok responses intercepted
+    counted_responses = (
+        prom_interceptor._interceptor._metrics["grpc_server_stream_msg_sent"]
+        .labels(
+            grpc_type,
+            grpc_service_name,
+            grpc_method_name,
+        )
+        ._value.get()
+    )
+
+    inference_request_g = converters.ModelInferRequestConverter.to_types(
+        model_generate_request
+    )
+
+    # we count the number of words because
+    # each word is gonna be streamed back
+    request_text = StringCodec.decode_input(inference_request_g.inputs[0])[0]
+    num_words = len(request_text.split())
+
+    assert int(counted_requests) == num_requests
+    assert int(counted_requests) * num_words == int(counted_responses)

--- a/tests/testdata/settings-stream.json
+++ b/tests/testdata/settings-stream.json
@@ -3,7 +3,6 @@
   "host": "127.0.0.1",
   "parallel_workers": 0,
   "gzip_enabled": false,
-  "metrics_endpoint": null,
   "cors_settings": {
     "allow_origins": ["*"]
   }

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,17 @@ commands =
     python -m pytest {posargs} -n auto \
         {toxinidir}/tests \
         --ignore={toxinidir}/tests/kafka \
-        --ignore={toxinidir}/tests/parallel
+        --ignore={toxinidir}/tests/parallel \
+        --ignore={toxinidir}/tests/grpc/test_interceptor.py
     # kafka and parallel tests are failing for macos when running in parallel
     # with the entire test suite. So, we run them separately.
+    # Also, we run the grpc interceptor test separately because
+    # other tests will interfere with the metrics counter when
+    # running in parallel.
     python -m pytest {posargs} \
         {toxinidir}/tests/kafka \
-        {toxinidir}/tests/parallel
+        {toxinidir}/tests/parallel \
+        {toxinidir}/tests/grpc/test_interceptor.py
 set_env =
     GITHUB_SERVER_URL = {env:GITHUB_SERVER_URL:https\://github.com}
     GITHUB_REPOSITORY = {env:GITHUB_REPOSITORY:SeldonIO/MLServer}


### PR DESCRIPTION
This PR includes Prometheus interceptor support for gRPC streaming. Currently for gRPC streaming, we have to set `"metrics_endpoint": null`, thus Prometheus logs cannot be scraped.  It also updates docs and test for Prometheus interceptor.