### PR TITLE
Feature/support existing environments

### DIFF
--- a/docs/user-guide/custom.md
+++ b/docs/user-guide/custom.md
@@ -215,7 +215,8 @@ In these cases, to load your custom runtime, MLServer will need access to these
 dependencies.
 
 It is possible to load this custom set of dependencies by providing them
-through an [environment tarball](../examples/conda/README), whose path can be
+through an [environment tarball](../examples/conda/README) or by giving a
+path to an already exisiting python environment. Both paths can be
 specified within your `model-settings.json` file.
 
 ```{warning}
@@ -276,6 +277,21 @@ Note that, in the folder layout above, we are assuming that:
     }
   }
   ```
+
+If you want to use an already exisiting python environment, you can use the parameter `environment_path` of your `model-settings.json`:
+
+```
+---
+emphasize-lines: 5
+---
+{
+  "model": "sum-model",
+  "implementation": "models.MyCustomRuntime",
+  "parameters": {
+    "environment_path": "~/micromambda/envs/my-conda-environment"
+  }
+}
+```
 
 ## Building a custom MLServer image
 

--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -15,11 +15,8 @@ from .logging import logger
 
 def _extract_env(tarball_path: str, env_path: str) -> None:
     logger.info(f"Extracting environment tarball from {tarball_path}...")
-    try:
-        with tarfile.open(tarball_path, "r") as tarball:
-            tarball.extractall(path=env_path)
-    except Exception:
-        logger.info("Failed to extract environment tarball.")
+    with tarfile.open(tarball_path, "r") as tarball:
+        tarball.extractall(path=env_path)
 
 
 def _compute_hash_of_file(tarball_path: str) -> str:

--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -1,6 +1,7 @@
 import asyncio
 import multiprocessing
 import os
+import shutil
 import sys
 import tarfile
 import glob
@@ -14,11 +15,14 @@ from .logging import logger
 
 def _extract_env(tarball_path: str, env_path: str) -> None:
     logger.info(f"Extracting environment tarball from {tarball_path}...")
-    with tarfile.open(tarball_path, "r") as tarball:
-        tarball.extractall(path=env_path)
+    try:
+        with tarfile.open(tarball_path, "r") as tarball:
+            tarball.extractall(path=env_path)
+    except Exception:
+        logger.info("Failed to extract environment tarball.")
 
 
-def _compute_hash(tarball_path: str) -> str:
+def _compute_hash_of_file(tarball_path: str) -> str:
     """
     From Python 3.11's implementation of `hashlib.file_digest()`:
     https://github.com/python/cpython/blob/3.11/Lib/hashlib.py#L257
@@ -38,10 +42,19 @@ def _compute_hash(tarball_path: str) -> str:
 
     return h.hexdigest()
 
+def _compute_hash_of_string(string: str) -> str:
+    h = hashlib.sha256()
+    h.update(string.encode())
+    return h.hexdigest()
 
-async def compute_hash(tarball_path: str) -> str:
+
+async def compute_hash_of_file(tarball_path: str) -> str:
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _compute_hash, tarball_path)
+    return await loop.run_in_executor(None, _compute_hash_of_file, tarball_path)
+
+async def compute_hash_of_string(string: str) -> str:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _compute_hash_of_string, string)
 
 
 class Environment:
@@ -51,7 +64,8 @@ class Environment:
     environment.
     """
 
-    def __init__(self, env_path: str, env_hash: str):
+    def __init__(self, env_path: str, env_hash: str, delete_env: bool = True):
+        self._delete_env = delete_env
         self._env_path = env_path
         self.env_hash = env_hash
 
@@ -67,7 +81,7 @@ class Environment:
         await loop.run_in_executor(None, _extract_env, tarball_path, env_path)
 
         if not env_hash:
-            env_hash = await compute_hash(tarball_path)
+            env_hash = await compute_hash_of_file(tarball_path)
 
         return cls(env_path, env_hash)
 
@@ -136,3 +150,8 @@ class Environment:
         multiprocessing.set_executable(sys.executable)
         sys.path = self._prev_sys_path
         os.environ["PATH"] = self._prev_bin_path
+
+    def __del__(self) -> None:
+        logger.info("Cleaning up environment")
+        if self._delete_env:
+            shutil.rmtree(self._env_path)

--- a/mlserver/env.py
+++ b/mlserver/env.py
@@ -42,6 +42,7 @@ def _compute_hash_of_file(tarball_path: str) -> str:
 
     return h.hexdigest()
 
+
 def _compute_hash_of_string(string: str) -> str:
     h = hashlib.sha256()
     h.update(string.encode())
@@ -51,6 +52,7 @@ def _compute_hash_of_string(string: str) -> str:
 async def compute_hash_of_file(tarball_path: str) -> str:
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, _compute_hash_of_file, tarball_path)
+
 
 async def compute_hash_of_string(string: str) -> str:
     loop = asyncio.get_running_loop()

--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -81,8 +81,14 @@ class InferencePoolRegistry:
             env_hash = await compute_hash_of_string(environment_path)
             if env_hash in self._pools:
                 return self._pools[env_hash]
-            env = Environment(env_path=model.settings.parameters.environment_path, env_hash=env_hash, delete_env=False)
-            pool = InferencePool(self._settings, env=env, on_worker_stop=self._on_worker_stop)
+            env = Environment(
+                env_path=model.settings.parameters.environment_path,
+                env_hash=env_hash,
+                delete_env=False,
+            )
+            pool = InferencePool(
+                self._settings, env=env, on_worker_stop=self._on_worker_stop
+            )
         else:
             env_tarball = _get_env_tarball(model)
             if not env_tarball:

--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -76,13 +76,17 @@ class InferencePoolRegistry:
 
     async def _get_or_create(self, model: MLModel) -> InferencePool:
         if model.settings.parameters and model.settings.parameters.environment_path:
-            environment_path = model.settings.parameters.environment_path
+            environment_path = os.path.abspath(
+                os.path.expanduser(
+                    os.path.expandvars(model.settings.parameters.environment_path)
+                )
+            )
             logger.info(f"Using environment {environment_path}")
             env_hash = await compute_hash_of_string(environment_path)
             if env_hash in self._pools:
                 return self._pools[env_hash]
             env = Environment(
-                env_path=model.settings.parameters.environment_path,
+                env_path=environment_path,
                 env_hash=env_hash,
                 delete_env=False,
             )

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -305,6 +305,9 @@ class ModelParameters(BaseSettings):
     version: Optional[str] = None
     """Version of the model."""
 
+    environment_path: Optional[str] = None
+    """Path to a directory that contains the python environment to be used to load this model."""
+
     environment_tarball: Optional[str] = None
     """Path to the environment tarball which should be used to load this
     model."""

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -306,7 +306,8 @@ class ModelParameters(BaseSettings):
     """Version of the model."""
 
     environment_path: Optional[str] = None
-    """Path to a directory that contains the python environment to be used to load this model."""
+    """Path to a directory that contains the python environment to be used
+    to load this model."""
 
     environment_tarball: Optional[str] = None
     """Path to the environment tarball which should be used to load this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,10 +97,6 @@ async def env(env_tarball: str, tmp_path: str) -> Environment:
     env = await Environment.from_tarball(env_tarball, str(tmp_path))
     yield env
 
-    # Envs can be quite heavy, so let's make sure we're clearing them up once
-    # the test finishes
-    shutil.rmtree(tmp_path)
-
 
 @pytest.fixture(autouse=True)
 def logger(settings: Settings):

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -160,9 +160,11 @@ def env_model_settings(env_tarball: str) -> ModelSettings:
         parameters=ModelParameters(environment_tarball=env_tarball),
     )
 
+
 @pytest.fixture
 def existing_env_model_settings(env_tarball: str, tmp_path) -> ModelSettings:
     from mlserver.env import _extract_env
+
     env_path = str(tmp_path)
 
     _extract_env(env_tarball, env_path)

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -160,6 +160,19 @@ def env_model_settings(env_tarball: str) -> ModelSettings:
         parameters=ModelParameters(environment_tarball=env_tarball),
     )
 
+@pytest.fixture
+def existing_env_model_settings(env_tarball: str, tmp_path) -> ModelSettings:
+    from mlserver.env import _extract_env
+    env_path = str(tmp_path)
+
+    _extract_env(env_tarball, env_path)
+    model_settings = ModelSettings(
+        name="exising_env_model",
+        implementation=EnvModel,
+        parameters=ModelParameters(environment_path=env_path),
+    )
+    yield model_settings
+
 
 @pytest.fixture
 async def worker_with_env(

--- a/tests/parallel/test_registry.py
+++ b/tests/parallel/test_registry.py
@@ -32,7 +32,8 @@ async def env_model(
 
 @pytest.fixture
 async def existing_env_model(
-    inference_pool_registry: InferencePoolRegistry, existing_env_model_settings: ModelSettings
+    inference_pool_registry: InferencePoolRegistry,
+    existing_env_model_settings: ModelSettings,
 ) -> MLModel:
     env_model = EnvModel(existing_env_model_settings)
     model = await inference_pool_registry.load_model(env_model)
@@ -40,6 +41,7 @@ async def existing_env_model(
     yield model
 
     await inference_pool_registry.unload_model(model)
+
 
 def test_set_environment_hash(sum_model: MLModel):
     env_hash = "0e46fce1decb7a89a8b91c71d8b6975630a17224d4f00094e02e1a732f8e95f3"

--- a/tests/parallel/test_registry.py
+++ b/tests/parallel/test_registry.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import asyncio
 
-from mlserver.env import Environment, compute_hash
+from mlserver.env import Environment, compute_hash_of_file
 from mlserver.model import MLModel
 from mlserver.settings import Settings, ModelSettings
 from mlserver.types import InferenceRequest
@@ -124,7 +124,7 @@ async def test_load_reuses_env_folder(
     new_model = EnvModel(env_model_settings)
 
     # Make sure there's already existing env
-    env_hash = await compute_hash(env_tarball)
+    env_hash = await compute_hash_of_file(env_tarball)
     env_path = inference_pool_registry._get_env_path(env_hash)
     await Environment.from_tarball(env_tarball, env_path, env_hash)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,7 +5,7 @@ import shutil
 
 from typing import Tuple
 
-from mlserver.env import Environment, compute_hash
+from mlserver.env import Environment, compute_hash_of_file
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def expected_python_folder(env_python_version: Tuple[int, int]) -> str:
 
 
 async def test_compute_hash(env_tarball: str):
-    env_hash = await compute_hash(env_tarball)
+    env_hash = await compute_hash_of_file(env_tarball)
     assert len(env_hash) == 64
 
 


### PR DESCRIPTION
# Using Pre-existing Python Environments

## Description
The current implementation of mlserver only supports specifying a Python environment through a tarball, which is then unpacked before the workers are activated. Our configuration, however, already includes pre-defined environments we aim to utilize. The current pull request offers an option to select a path to an already set up Python environment.

## Changes Made
* Added the `environment_path` model parameter to specify the path to the existing environment.
* Relocated the code responsible for removing an unpacked environment from `PoolRegistry` to `Environment` – the component where it’s unpacked
* Integrated a `delete_env` attribute within Environment, determining whether the environment should be deleted from the disk upon the application's termination.
* Added documentation how to use it

## Related Issues
-

## Screenshots (if applicable)
-

## Checklist
<!-- Make sure to check the items below before submitting your pull request -->

- [x] Code follows the project's style guidelines
- [x] All tests related to the changes pass successfully
- [x] Documentation is updated (if necessary)
- [ ] Code is reviewed by at least one other team member
- [x] Any breaking changes are communicated and documented

## Additional Notes
-