### PR TITLE
Bugfix/Serialize nan and inf as null

### DIFF
--- a/mlserver/types/base.py
+++ b/mlserver/types/base.py
@@ -12,8 +12,7 @@ class BaseModel(pydantic.BaseModel):
     """
 
     model_config = ConfigDict(
-        protected_namespaces=(),
-        use_enum_values=True,
+        protected_namespaces=(), use_enum_values=True, ser_json_inf_nan="null"
     )
 
     def model_dump(self, exclude_unset=True, exclude_none=True, **kwargs):

--- a/tests/batching/test_requests.py
+++ b/tests/batching/test_requests.py
@@ -9,6 +9,7 @@ from mlserver.types import (
     InferenceResponse,
     Parameters,
 )
+import numpy as np
 from mlserver.batching.requests import BatchedRequests
 
 
@@ -187,7 +188,10 @@ def test_merge_request_inputs(
                     parameters=Parameters(content_type="np"),
                     inputs=[
                         RequestInput(
-                            name="foo", datatype="INT32", data=[1, 2, 3], shape=[1, 3]
+                            name="foo",
+                            datatype="INT32",
+                            data=[1, 2, 3, np.nan],
+                            shape=[1, 4],
                         )
                     ],
                 ),
@@ -195,7 +199,10 @@ def test_merge_request_inputs(
                     parameters=Parameters(foo="bar"),
                     inputs=[
                         RequestInput(
-                            name="foo", datatype="INT32", data=[4, 5, 6], shape=[1, 3]
+                            name="foo",
+                            datatype="INT32",
+                            data=[4, 5, 6, np.inf],
+                            shape=[1, 3],
                         )
                     ],
                 ),

--- a/tests/batching/test_requests.py
+++ b/tests/batching/test_requests.py
@@ -202,7 +202,7 @@ def test_merge_request_inputs(
                             name="foo",
                             datatype="INT32",
                             data=[4, 5, 6, np.inf],
-                            shape=[1, 3],
+                            shape=[1, 4],
                         )
                     ],
                 ),
@@ -213,8 +213,8 @@ def test_merge_request_inputs(
                     RequestInput(
                         name="foo",
                         datatype="INT32",
-                        data=[1, 2, 3, 4, 5, 6],
-                        shape=[2, 3],
+                        data=[1, 2, 3, None, 4, 5, 6, None],
+                        shape=[2, 4],
                     )
                 ],
             ),


### PR DESCRIPTION
## Description
This PR aim to fix this issue #1747 by serializing `NaN` and `Inf` values to `null`

## Changes Made
Configure pydantic base model in order to serialize `nan` and `inf` as `null`

## Related Issues

## Checklist
<!-- Make sure to check the items below before submitting your pull request -->

- [x] Code follows the project's style guidelines
- [ ] All tests related to the changes pass successfully
- [x] Documentation is updated (if necessary)
- [ ] Code is reviewed by at least one other team member
- [ ] Any breaking changes are communicated and documented

## Additional Notes
<!-- Add any additional notes or context that may be helpful for reviewers -->

