### PR TITLE
Fix tensorflow upperbound macos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,13 +67,13 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-        is-pr:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          # MacOS tests take a lot of time, so we will run them only on merge
-          # From https://github.com/orgs/community/discussions/26253
-          - is-pr: true
-            os: macos-13
+        # is-pr:
+        #   - ${{ github.event_name == 'pull_request' }}
+        # exclude:
+        #   # MacOS tests take a lot of time, so we will run them only on merge
+        #   # From https://github.com/orgs/community/discussions/26253
+        #   - is-pr: true
+        #     os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -115,21 +115,21 @@ jobs:
           - "3.9"
           - "3.10"
         tox-environment:
-          - sklearn
-          - xgboost
-          - lightgbm
-          - mlflow
+          # - sklearn
+          # - xgboost
+          # - lightgbm
+          # - mlflow
           - huggingface
-          - alibi-explain
-          - alibi-detect
-          - catboost
-        is-pr:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          # MacOS tests take a lot of time, so we will run them only on merge
-          # From https://github.com/orgs/community/discussions/26253
-          - is-pr: true
-            os: macos-13
+          # - alibi-explain
+          # - alibi-detect
+          # - catboost
+        # is-pr:
+        #   - ${{ github.event_name == 'pull_request' }}
+        # exclude:
+        #   # MacOS tests take a lot of time, so we will run them only on merge
+        #   # From https://github.com/orgs/community/discussions/26253
+        #   - is-pr: true
+        #     os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,13 +67,13 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-        # is-pr:
-        #   - ${{ github.event_name == 'pull_request' }}
-        # exclude:
-        #   # MacOS tests take a lot of time, so we will run them only on merge
-        #   # From https://github.com/orgs/community/discussions/26253
-        #   - is-pr: true
-        #     os: macos-13
+        is-pr:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          # MacOS tests take a lot of time, so we will run them only on merge
+          # From https://github.com/orgs/community/discussions/26253
+          - is-pr: true
+            os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -115,21 +115,21 @@ jobs:
           - "3.9"
           - "3.10"
         tox-environment:
-          # - sklearn
-          # - xgboost
-          # - lightgbm
-          # - mlflow
+          - sklearn
+          - xgboost
+          - lightgbm
+          - mlflow
           - huggingface
-          # - alibi-explain
-          # - alibi-detect
-          # - catboost
-        # is-pr:
-        #   - ${{ github.event_name == 'pull_request' }}
-        # exclude:
-        #   # MacOS tests take a lot of time, so we will run them only on merge
-        #   # From https://github.com/orgs/community/discussions/26253
-        #   - is-pr: true
-        #     os: macos-13
+          - alibi-explain
+          - alibi-detect
+          - catboost
+        is-pr:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          # MacOS tests take a lot of time, so we will run them only on merge
+          # From https://github.com/orgs/community/discussions/26253
+          - is-pr: true
+            os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/runtimes/huggingface/poetry.lock
+++ b/runtimes/huggingface/poetry.lock
@@ -3521,6 +3521,27 @@ files = [
 
 [[package]]
 name = "tensorboard"
+version = "2.16.2"
+description = "TensorBoard lets you watch Tensors Flow"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "tensorboard-2.16.2-py3-none-any.whl", hash = "sha256:9f2b4e7dad86667615c0e5cd072f1ea8403fc032a299f0072d6f74855775cc45"},
+]
+
+[package.dependencies]
+absl-py = ">=0.4"
+grpcio = ">=1.48.2"
+markdown = ">=2.6.8"
+numpy = ">=1.12.0"
+protobuf = ">=3.19.6,<4.24.0 || >4.24.0"
+setuptools = ">=41.0.0"
+six = ">1.9"
+tensorboard-data-server = ">=0.7.0,<0.8.0"
+werkzeug = ">=1.0.1"
+
+[[package]]
+name = "tensorboard"
 version = "2.17.0"
 description = "TensorBoard lets you watch Tensors Flow"
 optional = false
@@ -3551,6 +3572,62 @@ files = [
     {file = "tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60"},
     {file = "tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530"},
 ]
+
+[[package]]
+name = "tensorflow"
+version = "2.16.2"
+description = "TensorFlow is an open source machine learning framework for everyone."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "tensorflow-2.16.2-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:546dc68d0740fb4b75593a6bfa308da9526fe31f65c2181d48c8551c4a0ad02f"},
+    {file = "tensorflow-2.16.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:72c84f0e0f8ad0e7cb7b4b3fe9d1c899e6cbebc51c0e64df42a2a32a904aacd7"},
+    {file = "tensorflow-2.16.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a0aee52797cd58870e3bb9c2b4bc0fc2a57eae29a334282bcc08943ca582718"},
+    {file = "tensorflow-2.16.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ed24662a3625b2eaa89a02ea177aadad840d6eb91445091fe1f7ad5fa528db3"},
+    {file = "tensorflow-2.16.2-cp310-cp310-win_amd64.whl", hash = "sha256:e340de5abf4d7dc1d8a5782559aa41757f8a84aeb2d4c490c0fa538a7521fae6"},
+    {file = "tensorflow-2.16.2-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:ec06570d57bfa0e2be804405e3cdc2960e94887e7619ffb6bc053e9775b695aa"},
+    {file = "tensorflow-2.16.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2c8a0e79395639b762e62002db99b2f6cc608f744312c9940899c1128f325331"},
+    {file = "tensorflow-2.16.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8728b12bc86941d90d0a927c40d4b21f8820964a80439a7c45f850eb37d57067"},
+    {file = "tensorflow-2.16.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8798dea8e2281b4a0b569d9c00e7949c0090509be363da271e1ef21828bffae"},
+    {file = "tensorflow-2.16.2-cp311-cp311-win_amd64.whl", hash = "sha256:1da04e39834cdba509b4dd5ac5c71c3a1d1ffe6bc03e6970e65791b9a4071340"},
+    {file = "tensorflow-2.16.2-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:912b8cd1f88fd1ef32b8db54f0193ad0a3f057691324436ba82c5f74a63a17dd"},
+    {file = "tensorflow-2.16.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:917366179b596d0dae13e194a26965229b09fef946e4a5892a47fa9b4f7e4ba1"},
+    {file = "tensorflow-2.16.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7df529f8db271d3def80538aa7fcd6f5abe306f7b01cb5b580138df68afb499"},
+    {file = "tensorflow-2.16.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5badc6744672a3181c012b6ab2815975be34d0573db3b561383634acc0d46a55"},
+    {file = "tensorflow-2.16.2-cp312-cp312-win_amd64.whl", hash = "sha256:505df82fde3b9c6a2a78bf679efb4d0a2e84f4f925202130477ca519ae1514e4"},
+    {file = "tensorflow-2.16.2-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:2528a162e879b40d81db3568c08256718cec4a0356580badbd362cd8af02a41b"},
+    {file = "tensorflow-2.16.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:4c94106b73ecd044b7772e4338f8aa65a43ef2e290fe3fc27cc094138f50a341"},
+    {file = "tensorflow-2.16.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec5c57e6828b074ddb460aa69fbaa2cd502c6080a4e200e0163f2a2c9e20acfc"},
+    {file = "tensorflow-2.16.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b085fc4b296e0daf2e8a8b71bf433acba0ba30d6c30f3d07ad05f10477c7762c"},
+    {file = "tensorflow-2.16.2-cp39-cp39-win_amd64.whl", hash = "sha256:5d5951e91435909d6023f8c5afcfde9cee946a65ed03020fc8b87e627c04c6d1"},
+]
+
+[package.dependencies]
+absl-py = ">=1.0.0"
+astunparse = ">=1.6.0"
+flatbuffers = ">=23.5.26"
+gast = ">=0.2.1,<0.5.0 || >0.5.0,<0.5.1 || >0.5.1,<0.5.2 || >0.5.2"
+google-pasta = ">=0.1.1"
+grpcio = ">=1.24.3,<2.0"
+h5py = ">=3.10.0"
+keras = ">=3.0.0"
+libclang = ">=13.0.0"
+ml-dtypes = ">=0.3.1,<0.4.0"
+numpy = {version = ">=1.23.5,<2.0.0", markers = "python_version <= \"3.11\""}
+opt-einsum = ">=2.3.2"
+packaging = "*"
+protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
+requests = ">=2.21.0,<3"
+setuptools = "*"
+six = ">=1.12.0"
+tensorboard = ">=2.16,<2.17"
+tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "python_version < \"3.12\""}
+termcolor = ">=1.1.0"
+typing-extensions = ">=3.6.6"
+wrapt = ">=1.11.0"
+
+[package.extras]
+and-cuda = ["nvidia-cublas-cu12 (==12.3.4.1)", "nvidia-cuda-cupti-cu12 (==12.3.101)", "nvidia-cuda-nvcc-cu12 (==12.3.107)", "nvidia-cuda-nvrtc-cu12 (==12.3.107)", "nvidia-cuda-runtime-cu12 (==12.3.101)", "nvidia-cudnn-cu12 (==8.9.7.29)", "nvidia-cufft-cu12 (==11.0.12.1)", "nvidia-curand-cu12 (==10.3.4.107)", "nvidia-cusolver-cu12 (==11.5.4.101)", "nvidia-cusparse-cu12 (==12.2.0.103)", "nvidia-nccl-cu12 (==2.19.3)", "nvidia-nvjitlink-cu12 (==12.3.101)"]
 
 [[package]]
 name = "tensorflow"
@@ -4559,4 +4636,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "387768fda1c449abaa4b1e0bc334f856ee9ba22196cb54499f1c3f8da22b3fba"
+content-hash = "ef16814dbd96c26ca4d5366fc75249221db896fd39015b9496d97c92a277e405"

--- a/runtimes/huggingface/pyproject.toml
+++ b/runtimes/huggingface/pyproject.toml
@@ -23,8 +23,11 @@ torch = [
     {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = "<2.3.0"},
     {markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'", version = "<2.4.0"}
 ]
+tensorflow = [
+    {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = ">=2.12,<2.17"},
+    {markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'", version = ">=2.12,<2.18"}
+]
 transformers = ">=4.30,<5.0"
-tensorflow = ">=2.12,<2.18"
 
 [build-system]
 requires = ["poetry-core"]

--- a/runtimes/huggingface/pyproject.toml
+++ b/runtimes/huggingface/pyproject.toml
@@ -23,6 +23,8 @@ torch = [
     {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = "<2.3.0"},
     {markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'", version = "<2.4.0"}
 ]
+# tensorflow 2.17.0 not compiled for MacOS
+# see: https://www.tensorflow.org/install/pip#package_location
 tensorflow = [
     {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = ">=2.12,<2.17"},
     {markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'", version = ">=2.12,<2.18"}

--- a/runtimes/huggingface/pyproject.toml
+++ b/runtimes/huggingface/pyproject.toml
@@ -23,7 +23,7 @@ torch = [
     {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = "<2.3.0"},
     {markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'", version = "<2.4.0"}
 ]
-# tensorflow 2.17.0 not compiled for MacOS
+# tensorflow 2.17.0 not compiled for MacOS for x86 architectures
 # see: https://www.tensorflow.org/install/pip#package_location
 tensorflow = [
     {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", version = ">=2.12,<2.17"},


### PR DESCRIPTION
Limited `tensorflow`  upperbound to `2.17` for macos.
It seems that `2.17` is not compiled for `macos` (see package location [here](https://www.tensorflow.org/install/pip#package_location)) 