### PR TITLE
Force clean up env (for py 3.12)

### DIFF
--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -262,4 +262,6 @@ class InferencePoolRegistry:
         logger.info(f"Shutdown of {pool.name} complete")
 
         if env_hash:
+            # force calling __del__ on `Environment` to clean up
+            self._pools[env_hash]._env = None  # pylint: disable=protected-access
             del self._pools[env_hash]


### PR DESCRIPTION
This PR adds an explicit cleanup for the custom environment when the pool is discarded. This is because in python 3.12 (for some reason) this is not called by default __del__ as with the previous python versions. 