### PR TITLE
Included separate inference pool

### DIFF
--- a/mlserver/parallel/registry.py
+++ b/mlserver/parallel/registry.py
@@ -38,6 +38,14 @@ def _get_env_tarball(model: MLModel) -> Optional[str]:
     return to_absolute_path(model_settings, env_tarball)
 
 
+def _get_environment_hash_gid(
+    env_hash: str, inference_pool_gid: Optional[str] = None
+) -> str:
+    if inference_pool_gid:
+        return f"{env_hash}-{inference_pool_gid}"
+    return env_hash
+
+
 class InferencePoolRegistry:
     """
     Keeps track of the different inference pools loaded in the server.
@@ -101,9 +109,7 @@ class InferencePoolRegistry:
         )
         logger.info(f"Using environment {expanded_environment_path}")
         env_hash = await compute_hash_of_string(expanded_environment_path)
-
-        if inference_pool_gid is not None:
-            env_hash = f"{env_hash}-{inference_pool_gid}"
+        env_hash = _get_environment_hash_gid(env_hash, inference_pool_gid)
 
         if env_hash in self._pools:
             return self._pools[env_hash]
@@ -142,8 +148,7 @@ class InferencePoolRegistry:
             )
 
         env_hash = await compute_hash_of_file(env_tarball)
-        if inference_pool_gid:
-            env_hash = f"{env_hash}-{inference_pool_gid}"
+        env_hash = _get_environment_hash_gid(env_hash, inference_pool_gid)
 
         if env_hash in self._pools:
             return self._pools[env_hash]

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -15,6 +15,7 @@ from typing import (
     no_type_check,
     TYPE_CHECKING,
 )
+from typing_extensions import Self
 from pydantic import (
     ImportString,
     Field,
@@ -332,10 +333,10 @@ class ModelParameters(BaseSettings):
     implementation."""
 
     @model_validator(mode="after")
-    def set_inference_pool_gid(cls, values: "ModelParameters") -> "ModelParameters":
-        if values.autogenerate_inference_pool_gid and values.inference_pool_gid is None:
-            return values.model_copy(update={"inference_pool_gid": str(uuid.uuid4())})
-        return values
+    def set_inference_pool_gid(self) -> Self:
+        if self.autogenerate_inference_pool_gid and self.inference_pool_gid is None:
+            self.inference_pool_gid = str(uuid.uuid4())
+        return self
 
 
 class ModelSettings(BaseSettings):

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -313,6 +313,9 @@ class ModelParameters(BaseSettings):
     """Path to the environment tarball which should be used to load this
     model."""
 
+    inference_pool_gid: Optional[str] = None
+    """Inference pool group id to be used to serve this model."""
+
     format: Optional[str] = None
     """Format of the model (only available on certain runtimes)."""
 

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -152,26 +152,17 @@ def custom_request_message(sum_model_settings: ModelSettings) -> ModelRequestMes
     )
 
 
-@pytest.fixture(params=[None, "dummy_gid"])
-def inference_pool_gid(request) -> str:
-    return request.param
-
-
 @pytest.fixture
-def env_model_settings(env_tarball: str, inference_pool_gid: str) -> ModelSettings:
+def env_model_settings(env_tarball: str) -> ModelSettings:
     return ModelSettings(
         name="env-model",
         implementation=EnvModel,
-        parameters=ModelParameters(
-            environment_tarball=env_tarball, inference_pool_gid=inference_pool_gid
-        ),
+        parameters=ModelParameters(environment_tarball=env_tarball),
     )
 
 
 @pytest.fixture
-def existing_env_model_settings(
-    env_tarball: str, inference_pool_gid: str, tmp_path
-) -> ModelSettings:
+def existing_env_model_settings(env_tarball: str, tmp_path) -> ModelSettings:
     from mlserver.env import _extract_env
 
     env_path = str(tmp_path)
@@ -180,9 +171,7 @@ def existing_env_model_settings(
     model_settings = ModelSettings(
         name="exising_env_model",
         implementation=EnvModel,
-        parameters=ModelParameters(
-            environment_path=env_path, inference_pool_gid=inference_pool_gid
-        ),
+        parameters=ModelParameters(environment_path=env_path),
     )
     yield model_settings
 

--- a/tests/parallel/conftest.py
+++ b/tests/parallel/conftest.py
@@ -152,17 +152,26 @@ def custom_request_message(sum_model_settings: ModelSettings) -> ModelRequestMes
     )
 
 
+@pytest.fixture(params=[None, "dummy_gid"])
+def inference_pool_gid(request) -> str:
+    return request.param
+
+
 @pytest.fixture
-def env_model_settings(env_tarball: str) -> ModelSettings:
+def env_model_settings(env_tarball: str, inference_pool_gid: str) -> ModelSettings:
     return ModelSettings(
         name="env-model",
         implementation=EnvModel,
-        parameters=ModelParameters(environment_tarball=env_tarball),
+        parameters=ModelParameters(
+            environment_tarball=env_tarball, inference_pool_gid=inference_pool_gid
+        ),
     )
 
 
 @pytest.fixture
-def existing_env_model_settings(env_tarball: str, tmp_path) -> ModelSettings:
+def existing_env_model_settings(
+    env_tarball: str, inference_pool_gid: str, tmp_path
+) -> ModelSettings:
     from mlserver.env import _extract_env
 
     env_path = str(tmp_path)
@@ -171,7 +180,9 @@ def existing_env_model_settings(env_tarball: str, tmp_path) -> ModelSettings:
     model_settings = ModelSettings(
         name="exising_env_model",
         implementation=EnvModel,
-        parameters=ModelParameters(environment_path=env_path),
+        parameters=ModelParameters(
+            environment_path=env_path, inference_pool_gid=inference_pool_gid
+        ),
     )
     yield model_settings
 

--- a/tests/parallel/test_registry.py
+++ b/tests/parallel/test_registry.py
@@ -75,8 +75,11 @@ async def test_load_model(
     inference_pool_registry: InferencePoolRegistry,
     sum_model: MLModel,
     inference_request: InferenceRequest,
+    inference_pool_gid: str,
 ):
     sum_model.settings.name = "foo"
+    sum_model.settings.parameters.inference_pool_gid = inference_pool_gid
+
     model = await inference_pool_registry.load_model(sum_model)
     inference_response = await model.predict(inference_request)
 


### PR DESCRIPTION
Currently MLServer can't deal well with models that are loaded on the same inference pool with other models that are heavy used. In this case there is a risk of starvation and we want to allow the user to be able to create models on separate processes (different inference pool).

MLServer does this but only if the model uses a specific custom environment tarball.

**Proposed solution**:  Introduce `inference_pool_gid` to the `ModelParameters` class. In this way, we give the user the option to add the model to a dedicated inference pool group. Note that this allows to add either a single model or multiple models to the same group. I also included the `autogenerate_inference_pool_gid` boolean flag. When set to `True` and no `inference_pool_gid` is provided, a gid is generated using `uuid4`. This will add the model to a dedicated group - this way the user does not have to specify the gid themself. 