### PR TITLE
Optimize the Default Precision of Model Weights for HuggingFace Runtime

### DIFF
--- a/runtimes/huggingface/mlserver_huggingface/settings.py
+++ b/runtimes/huggingface/mlserver_huggingface/settings.py
@@ -2,6 +2,8 @@ import os
 import orjson
 
 from typing import Optional, Dict, Union, NewType
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from distutils.util import strtobool
 from transformers.pipelines import SUPPORTED_TASKS
@@ -64,6 +66,12 @@ class HuggingFaceSettings(BaseSettings):
     Name of the model that should be loaded in the pipeline.
     """
     model_kwargs: Optional[dict] = None
+
+    @model_validator(mode='after')
+    def set_default_model_kwargs(self) -> 'HuggingFaceSettings':
+        self.model_kwargs = self.model_kwargs if self.model_kwargs is not None else {}
+        self.model_kwargs.setdefault("torch_dtype", "auto")
+        return self
     """
     model kwargs that should be loaded in the pipeline.
     """

--- a/runtimes/huggingface/tests/test_settings.py
+++ b/runtimes/huggingface/tests/test_settings.py
@@ -167,3 +167,42 @@ def test_get_huggingface_settings(
 def test_get_huggingface_settings_raises(model_settings_extra_none):
     with pytest.raises(MissingHuggingFaceSettings):
         get_huggingface_settings(model_settings_extra_none)
+
+
+@pytest.mark.parametrize(
+    "extra, expected_model_kwargs",
+    [
+        (
+            {
+                "task": "text-generation",
+                "task_suffix": "_en",
+                "pretrained_model": "gpt2"
+            },
+            {"torch_dtype": "auto"}
+        ),
+        (
+            {
+                "task": "text-generation",
+                "task_suffix": "_en",
+                "pretrained_model": "gpt2",
+                "model_kwargs": {"some_other_key": "value","torch_dtype": "float32"}
+            },
+            {"some_other_key": "value","torch_dtype": "float32"}
+        ),
+        (
+            {
+                "task": "text-generation",
+                "task_suffix": "_en",
+                "pretrained_model": "gpt2",
+                "model_kwargs": {"some_other_key": "value"}
+            },
+            {"some_other_key": "value","torch_dtype": "auto"}
+        )
+    ]
+)
+def test_huggingface_settings(extra, expected_model_kwargs):
+    hf_settings = HuggingFaceSettings(**extra)
+    assert hf_settings.task == extra.get("task", "")
+    assert hf_settings.task_suffix == extra.get("task_suffix", "")
+    assert hf_settings.pretrained_model == extra.get("pretrained_model", None)
+    assert hf_settings.model_kwargs == expected_model_kwargs


### PR DESCRIPTION
Feat: Add default torch_dtype="auto" to model_kwargs in HF Runtime

close #2046 