### PR TITLE
Fix interceptors insert tuple -> list

### DIFF
--- a/mlserver/grpc/server.py
+++ b/mlserver/grpc/server.py
@@ -70,7 +70,7 @@ class GRPCServer:
 
         self._server = aio.server(
             ThreadPoolExecutor(max_workers=DefaultGrpcWorkers),
-            interceptors=tuple(self._interceptors),
+            interceptors=list(self._interceptors),
             options=self._get_options(),
         )
 


### PR DESCRIPTION
Resolves https://github.com/SeldonIO/MLServer/issues/2028
```
   kwargs["interceptors"].insert(
AttributeError: 'tuple' object has no attribute 'insert'
```

---

Wasn't able to run `make test` locally, and install dependencies due to TF 2.18.0 no longer supported on intel x86, and `make test` failing out with a c++ compiler issue :/ 

Tested separately with
```
opentelemetry-instrumentation = "0.48b0"
opentelemetry-exporter-otlp-proto-grpc = "1.27.0"
```
and running
```
poetry run opentelemetry-instrument --metrics_exporter none --traces_exporter otlp mlserver start some-project/
```
which successfully works