### PR TITLE
Fix too loose mlflow dependency constraint in mlserver-mlflow

### DIFF
--- a/runtimes/mlflow/poetry.lock
+++ b/runtimes/mlflow/poetry.lock
@@ -4410,4 +4410,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "06db134e8f1c9af96de58b03f7893be479987055bf9647628cfb8b81e1518689"
+content-hash = "9dab739a569401ce7113e9fb22861e6bf467b3c0a32d08be0ff8c408e5cb57fe"

--- a/runtimes/mlflow/pyproject.toml
+++ b/runtimes/mlflow/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "mlserver_mlflow"}]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 mlserver = "*"
-mlflow = "*"
+mlflow = ">=2.19.0"
 
 [tool.poetry.group.dev.dependencies]
 mlserver = {path = "../..", develop = true}


### PR DESCRIPTION
# Pull Request

## Description
See https://github.com/SeldonIO/MLServer/issues/2113

## Changes Made
Tightened mlflow constraint in mlserver-mlflow to >=2.19.0 as otherwise an import in mlserver-mlflow fails (as it relies on something added in mlflow 2.19.0. See https://github.com/SeldonIO/MLServer/issues/2113 for further detail

## Related Issues
n/a

## Screenshots (if applicable)
n/a

## Checklist
<!-- Make sure to check the items below before submitting your pull request -->

- [x] Code follows the project's style guidelines
- [ ] All tests related to the changes pass successfully
- [x] Documentation is updated (if necessary)
- [ ] Code is reviewed by at least one other team member
- [x] Any breaking changes are communicated and documented

## Additional Notes
n/a