### PR TITLE
Fix Uvicorn/Asyncio untime error in worker.py 

### DIFF
--- a/mlserver/parallel/worker.py
+++ b/mlserver/parallel/worker.py
@@ -78,12 +78,16 @@ class Worker(Process):
         To avoid this, and be able to properly shut them down, we forcefully
         ignore the signals coming from the main parent process.
         """
-        loop = asyncio.get_event_loop()
-
-        for sign in IGNORED_SIGNALS:
-            # Ensure that signal handlers are a no-op, to let the main process
-            # take care of cleaning up workers
-            loop.add_signal_handler(sign, _noop)
+        try:
+            loop = asyncio.get_event_loop()
+            
+            for sign in IGNORED_SIGNALS:
+                # Ensure that signal handlers are a no-op, to let the main process
+                # take care of cleaning up workers
+                loop.add_signal_handler(sign, _noop)
+        except RuntimeError:
+            # Ignore if the loop is already closed
+            pass
 
     def __inner_init__(self):
         """


### PR DESCRIPTION
Below error occurred, the ignore_signals() handler in worker.py ran into an error caused by a recent [uvicorn update](https://github.com/Kludex/uvicorn/commit/9b3f17a549ec96f57bf4d975145fc58feefdd4e8) when it tries to call asyncio.get_event_loop() where none exists. 
```
Traceback (most recent call last):
  File "/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/python3.10/site-packages/mlserver/parallel/worker.py", line 70, in run
    self._ignore_signals()
  File "/python3.10/site-packages/mlserver/parallel/worker.py", line 81, in _ignore_signals
    loop = asyncio.get_event_loop()
  File "/python3.10/site-packages/uvloop/__init__.py", line 206, in get_event_loop
    raise RuntimeError(
RuntimeError: There is no current event loop in thread 'MainThread'.
```