### PR TITLE
Stop showing accesslog entries by default

### DIFF
--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -165,7 +165,7 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    debug: bool = True
+    debug: bool = False
 
     parallel_workers: int = DEFAULT_PARALLEL_WORKERS
     """When parallel inference is enabled, number of workers to run inference


### PR DESCRIPTION
By default, stop writing the uvicorn accesslog to the log (stdout).

It makes sense to move to the new default, as production settings will not want the verbosity that comes with "debug: True". End users may still configure this via the server settings file (settings.json) or via an environment variable (`MLSERVER_DEBUG`)