### PR TITLE
Fix MLServer image build

### DIFF
--- a/hack/build-wheels.sh
+++ b/hack/build-wheels.sh
@@ -43,7 +43,7 @@ _main() {
   echo "---> Building MLServer wheel"
   _buildWheel . $_outputPath
 
-  for _runtime in "$ROOT_FOLDER/runtimes/"*; do
+  for _runtime in "$ROOT_FOLDER/runtimes/"*/; do
     echo "---> Building MLServer runtime: '$_runtime'"
     _buildWheel $_runtime $_outputPath
   done


### PR DESCRIPTION
In hack/build-wheels, only consider the directories from
MLServer/runtimes (we've added an __init__.py file for pytest)