### PR TITLE
fix: XGBoost model loading issue with modelcar in KServe deployments

### DIFF
--- a/runtimes/xgboost/mlserver_xgboost/xgboost.py
+++ b/runtimes/xgboost/mlserver_xgboost/xgboost.py
@@ -22,15 +22,18 @@ WELLKNOWN_MODEL_FILENAMES = ["model.bst", "model.json", "model.ubj"]
 
 
 def _load_sklearn_interface(model_uri: str) -> XGBModel:
+    with open(model_uri, "rb") as f:
+        model_bytes = bytearray(f.read())
+
     try:
         regressor = xgb.XGBRegressor()
-        regressor.load_model(model_uri)
+        regressor.load_model(model_bytes)
         return regressor
     except TypeError:
         # If there was an error, it's likely due to the model being a
         # classifier
         classifier = xgb.XGBClassifier()
-        classifier.load_model(model_uri)
+        classifier.load_model(model_bytes)
         return classifier
 
 


### PR DESCRIPTION
fix: XGBoost model loading issue with modelcar in KServe deployments

Signed-off-by: Snomaan6846 [syedali@redhat.com](mailto:syedali@redhat.com)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Description : 
The XGBoost library is not prepared to load model files from virtual filesystems (like /proc/$pid/root/... in case of modelcars). If we pass models as bytearrays to the XGBoost library (instead of file paths), the lib itself doesn't have to read the file. See https://github.com/dmlc/xgboost/issues/11736#issuecomment-3390860940 for the lib maintainers' insights.
